### PR TITLE
Detect if a public symbol is code in checking if the section containi…

### DIFF
--- a/src/windows/source.rs
+++ b/src/windows/source.rs
@@ -50,10 +50,6 @@ impl<'a, 's> SourceLineCollector<'a, 's> {
         })
     }
 
-    pub(super) fn has_lines(&self) -> bool {
-        !self.lines.is_empty()
-    }
-
     pub(super) fn collect_source_lines(
         &self,
         offset: PdbInternalSectionOffset,

--- a/src/windows/symbol.rs
+++ b/src/windows/symbol.rs
@@ -11,7 +11,7 @@ use std::collections::{btree_map, BTreeMap};
 use std::io::Write;
 
 use super::line::Lines;
-use super::pdb::RvaLabels;
+use super::pdb::PDBSections;
 use super::source::SourceLineCollector;
 use super::types::{FuncName, TypeDumper};
 
@@ -243,7 +243,7 @@ impl RvaSymbols {
     pub(super) fn add_public_symbol(
         &mut self,
         symbol: PublicSymbol,
-        rva_labels: &RvaLabels,
+        pdb_sections: &PDBSections,
         address_map: &AddressMap,
     ) {
         let rva = match symbol.offset.to_rva(address_map) {
@@ -251,7 +251,7 @@ impl RvaSymbols {
             _ => return,
         };
 
-        if symbol.code || symbol.function || rva_labels.contains(&rva.0) {
+        if symbol.code || symbol.function || pdb_sections.is_code(symbol.offset.section) {
             match self.map.entry(rva.0) {
                 btree_map::Entry::Occupied(selected) => {
                     let selected = selected.into_mut();


### PR DESCRIPTION
…ng it have IMAGE_SCN_CNT_CODE or IMAGE_SCN_MEM_EXECUTE flags.

In writing tests for https://github.com/mozilla/dump_syms/pull/13, I discovered some uncovered public symbols.
So it seems that the fact the symbol belongs to an executable section is enough.
So an additional test will be added in the PR #13 (but need this PR before).