### PR TITLE
Add an option to store the sym file in a path useful for stackwalker

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use crate::action::{Action, Dumper};
 
 fn main() {
     // Init the logger
-    let _ = TermLogger::init(LevelFilter::Warn, Config::default(), TerminalMode::Stderr);
+    let _ = TermLogger::init(LevelFilter::Info, Config::default(), TerminalMode::Stderr);
 
     let matches = App::new("dump_syms")
         .version(crate_version!())
@@ -37,6 +37,13 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("store")
+                .help("Store output file as FILENAME.pdb/DEBUG_ID/FILENAME.sym in the given directory")
+                .short("s")
+                .long("store")
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("symbol-server")
                 .help("Symbol Server configuration\n(e.g. \"SRV*c:\\symcache\\*https://symbols.mozilla.org/\")\nIt can be in file $HOME/.dump_syms/config too.")
                 .long("symbol-server")
@@ -47,10 +54,12 @@ fn main() {
     let output = matches.value_of("output").unwrap();
     let filename = matches.value_of("filename").unwrap();
     let symbol_server = matches.value_of("symbol-server");
+    let store = matches.value_of("store");
 
     let action = Action::Dump(Dumper {
         output,
         symbol_server,
+        store,
     });
 
     if let Err(e) = action.action(&filename) {

--- a/src/windows/pdb.rs
+++ b/src/windows/pdb.rs
@@ -424,6 +424,14 @@ impl PDBInfo {
         write!(writer, "{}", self)?;
         Ok(())
     }
+
+    pub fn debug_id(&self) -> &str {
+        &self.debug_id
+    }
+
+    pub fn pdb_name(&self) -> &str {
+        &self.pdb_name
+    }
 }
 
 #[cfg(test)]

--- a/src/windows/utils.rs
+++ b/src/windows/utils.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use symbolic_debuginfo::pe::PeObject;
 use uuid::Uuid;
 
-use crate::cache;
+use crate::cache::{self, SymbolServer};
 use crate::utils;
 
 #[cfg(unix)]
@@ -65,7 +65,7 @@ fn os_specific_try_to_find_pdb(path: PathBuf, pdb_filename: String) -> (Option<V
 pub fn get_pe_pdb_buf<'a>(
     path: PathBuf,
     buf: &'a [u8],
-    symbol_server: Option<&str>,
+    symbol_server: Option<&Vec<SymbolServer>>,
 ) -> Option<(PeObject<'a>, Vec<u8>, String)> {
     let pe = PeObject::parse(&buf)
         .unwrap_or_else(|_| panic!("Unable to parse the PE file {}", path.to_str().unwrap()));


### PR DESCRIPTION
For example
```bash
dump_syms foo.pdb --store ~/bar
```
will write foo.sym in directory "~/bar/foo.pdb/123456789ABCDEF/"