### PR TITLE
Add an option to get pdb from cache/symbol server using its debug id

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -16,6 +16,7 @@ pub(crate) struct Dumper<'a> {
     pub output: &'a str,
     pub symbol_server: Option<&'a str>,
     pub store: Option<&'a str>,
+    pub debug_id: Option<&'a str>,
 }
 
 impl Dumper<'_> {
@@ -50,12 +51,12 @@ pub(crate) enum Action<'a> {
 impl Action<'_> {
     pub(super) fn action(&self, filename: &str) -> common::Result<()> {
         let path = PathBuf::from(filename);
-        let buf = utils::read_file(&path);
         let filename = path.file_name().unwrap().to_str().unwrap().to_string();
 
         match self {
             Self::Dump(dumper) => match path.extension().unwrap().to_str().unwrap() {
                 "dll" | "exe" => {
+                    let buf = utils::read_file(&path);
                     let symbol_server = cache::get_sym_servers(dumper.symbol_server);
                     let res = windows::utils::get_pe_pdb_buf(path, &buf, symbol_server.as_ref());
                     if let Some((pe, pdb_buf, pdb_name)) = res {
@@ -74,6 +75,23 @@ impl Action<'_> {
                     }
                 }
                 "pdb" | "pd_" => {
+                    let (buf, filename) = if let Some(debug_id) = dumper.debug_id {
+                        let symbol_server = cache::get_sym_servers(dumper.symbol_server);
+                        let (buf, filename) =
+                            cache::search_symbol_file(filename, debug_id, symbol_server.as_ref());
+                        if let Some(buf) = buf {
+                            (buf, filename)
+                        } else {
+                            return Err(format!(
+                                "Impossible to get file {} with debug id {}",
+                                filename, debug_id
+                            )
+                            .into());
+                        }
+                    } else {
+                        (utils::read_file(&path), filename)
+                    };
+
                     match windows::pdb::PDBInfo::new(&buf, filename, "".to_string(), None, true) {
                         Ok(pdb) => dumper.store_pdb(&pdb),
                         Err(e) => Err(e.into()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,12 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("debug_id")
+                .help("Get the pdb file passed as argument from the cache or from symbol server using the debug id")
+                .long("debug-id")
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("symbol-server")
                 .help("Symbol Server configuration\n(e.g. \"SRV*c:\\symcache\\*https://symbols.mozilla.org/\")\nIt can be in file $HOME/.dump_syms/config too.")
                 .long("symbol-server")
@@ -55,11 +61,13 @@ fn main() {
     let filename = matches.value_of("filename").unwrap();
     let symbol_server = matches.value_of("symbol-server");
     let store = matches.value_of("store");
+    let debug_id = matches.value_of("debug_id");
 
     let action = Action::Dump(Dumper {
         output,
         symbol_server,
         store,
+        debug_id,
     });
 
     if let Err(e) = action.action(&filename) {


### PR DESCRIPTION
For example
```sh
 dump_syms ntdll.pdb --debug-id 00C54168286C479D81823570A9C442462 --symbol-server 'SRV*https://msdl.microsoft.com/download/symbols'
```
The goal is to be able to get pdbs where they are.