### PR TITLE
Allow to build against a vendored openssl to avoid libssl dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "hashbrown",
  "is_sorted",
  "log",
+ "openssl",
  "pdb 0.5.0 (git+https://github.com/calixteman/pdb?rev=6a1b75e1d0de86ef827feaca42fc459c4d9cc020)",
  "reqwest",
  "simplelog",
@@ -1083,6 +1084,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.6.1+1.1.1d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91b04cb43c1a8a90e934e0cd612e2a5715d976d2d6cff4490278a0cddf35005"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1101,7 @@ dependencies = [
  "autocfg 1.0.0",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,10 @@ uuid = "0.8"
 [dev-dependencies]
 fxhash = "0.2"
 tempdir = "0.3"
+
+[features]
+vendored-openssl = ["openssl/vendored"]
+
+[dependencies.openssl]
+version = "0.10"
+optional = true


### PR DESCRIPTION
A binary that links against libssl on linux is hard to keep working on multiple distros, and dump_syms pulls openssl indirectly via reqwest.