### PR TITLE
Multithread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
+dependencies = [
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,12 +429,14 @@ dependencies = [
  "bitflags",
  "cab",
  "clap",
+ "crossbeam",
  "dirs",
  "failure",
  "futures",
  "fxhash",
  "hashbrown",
  "log",
+ "num_cpus",
  "openssl",
  "pdb",
  "regex",
@@ -859,6 +922,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +941,15 @@ checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
  "libc",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ license = "MIT/Apache-2.0"
 bitflags = "1.2"
 cab = "0.2"
 clap = "2.33"
+crossbeam = "0.7"
 dirs = "2.0"
 failure = "0.1"
 futures = "0.3"
 hashbrown = { version = "0.7", features = ["serde"] }
 log = "0.4"
+num_cpus = "1.13"
 pdb = "0.6"
 regex = "1.3"
 reqwest = { version = "0.10", features = ["blocking"] }

--- a/src/action.rs
+++ b/src/action.rs
@@ -3,294 +3,61 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use failure::Fail;
-use log::info;
-use std::fs;
 use std::path::PathBuf;
-use std::str::FromStr;
-use std::sync::Arc;
-use std::thread;
-use symbolic_common::Arch;
 
-use crate::cache;
-use crate::common::{self, Dumpable, FileType, Mergeable};
-use crate::linux::elf::{ElfInfo, Platform};
+use crate::common::{self, FileType};
+use crate::linux::elf::ElfInfo;
 use crate::mac::macho::MachoInfo;
-use crate::mapping::PathMappings;
 use crate::utils;
-use crate::windows;
+use crate::windows::pdb::PDBInfo;
 
-pub(crate) struct Dumper<'a> {
-    pub output: &'a str,
-    pub symbol_server: Option<&'a str>,
-    pub store: Option<&'a str>,
-    pub debug_id: Option<&'a str>,
-    pub code_id: Option<&'a str>,
-    pub arch: &'a str,
-    pub mapping_var: Option<Vec<&'a str>>,
-    pub mapping_src: Option<Vec<&'a str>>,
-    pub mapping_dest: Option<Vec<&'a str>>,
-    pub mapping_file: Option<&'a str>,
-}
-
-impl Dumper<'_> {
-    fn store<D: Dumpable>(&self, dumpable: &D) -> common::Result<()> {
-        let store = self.store.filter(|p| !p.is_empty()).map(|p| {
-            PathBuf::from(p).join(cache::get_path_for_sym(
-                &dumpable.get_name(),
-                dumpable.get_debug_id(),
-            ))
-        });
-
-        if let Some(store) = store.as_ref() {
-            fs::create_dir_all(store.parent().unwrap())?;
-            let store = store.to_str().unwrap();
-            let output = utils::get_writer_for_sym(store);
-            if let Err(e) = dumpable.dump(output) {
-                return Err(e);
-            }
-            info!("Write symbols at {}", store);
-        }
-
-        if self.output != "-" || store.is_none() {
-            let output = utils::get_writer_for_sym(self.output);
-            dumpable.dump(output)?;
-            info!("Write symbols at {}", self.output);
-        }
-        Ok(())
-    }
-
-    fn has_id(&self) -> bool {
-        self.debug_id.is_some() || self.code_id.is_some()
-    }
-
-    fn get_from_id(&self, path: &PathBuf, filename: String) -> common::Result<(Vec<u8>, String)> {
-        for id in &[self.debug_id, self.code_id] {
-            if let Some(id) = id {
-                let symbol_server = cache::get_sym_servers(self.symbol_server);
-                let (buf, filename) = cache::search_file(filename, id, symbol_server.as_ref());
-                return if let Some(buf) = buf {
-                    Ok((buf, filename))
-                } else {
-                    Err(format!("Impossible to get file {} with id {}", filename, id).into())
-                };
-            }
-        }
-
-        Ok((utils::read_file(&path), filename))
-    }
-
-    fn pdb(
-        &self,
-        buf: &[u8],
-        path: PathBuf,
-        filename: String,
-        mapping: Option<Arc<PathMappings>>,
-    ) -> common::Result<()> {
-        let mut pdb = windows::pdb::PDBInfo::new(&buf, filename, "".to_string(), None, mapping)?;
-        windows::utils::try_to_set_pe(&path, &mut pdb, &buf);
-        self.store(&pdb)
-    }
-
-    fn pdb_pe(
-        &self,
-        pdb_buf: &[u8],
-        pdb_filename: String,
-        pe_buf: &[u8],
-        pe_path: PathBuf,
-        pe_filename: String,
-        mapping: Option<Arc<PathMappings>>,
-    ) -> common::Result<()> {
-        let pe = windows::utils::get_pe(pe_path, pe_buf);
-        let pdb =
-            windows::pdb::PDBInfo::new(&pdb_buf, pdb_filename, pe_filename, Some(pe), mapping)?;
-        self.store(&pdb)
-    }
-
-    fn elf(
-        &self,
-        buf: &[u8],
-        filename: String,
-        mapping: Option<Arc<PathMappings>>,
-    ) -> common::Result<()> {
-        let elf = ElfInfo::new(&buf, filename, Platform::Linux, mapping)?;
-        self.store(&elf)
-    }
-
-    fn macho(
-        &self,
-        buf: &[u8],
-        filename: String,
-        mapping: Option<Arc<PathMappings>>,
-    ) -> common::Result<()> {
-        let arch = Arch::from_str(self.arch).map_err(|e| e.compat())?;
-        let macho = MachoInfo::new(&buf, filename, arch, mapping)?;
-        self.store(&macho)
-    }
-
-    fn two_elfs<T, F, G>(&self, f1: F, f2: G) -> common::Result<()>
-    where
-        T: Mergeable + Dumpable + Send + 'static,
-        F: FnOnce() -> common::Result<T>,
-        F: Send + 'static,
-        G: FnOnce() -> common::Result<T>,
-        G: Send + 'static,
-    {
-        // Normally we should have a debug file and a stripped executable (or lib)
-        // So the thread getting data for the debug file should be a way longer that the oter
-        let t_1 = thread::Builder::new()
-            .name("Dump_syms 1".to_string())
-            .spawn(f1)
-            .unwrap();
-        let t_2 = thread::Builder::new()
-            .name("Dump_syms 2".to_string())
-            .spawn(f2)
-            .unwrap();
-
-        let elf_1 = t_1
-            .join()
-            .expect("Couldn't join on the associated thread")?;
-        let elf_2 = t_2
-            .join()
-            .expect("Couldn't join on the associated thread")?;
-
-        let elf = T::merge(elf_1, elf_2)?;
-        self.store(&elf)
-    }
-
-    fn pe(
-        &self,
-        buf: &[u8],
-        path: PathBuf,
-        filename: String,
-        mapping: Option<Arc<PathMappings>>,
-    ) -> common::Result<()> {
-        let symbol_server = cache::get_sym_servers(self.symbol_server);
-        let res = windows::utils::get_pe_pdb_buf(path, &buf, symbol_server.as_ref());
-
-        if let Some((pe, pdb_buf, pdb_name)) = res {
-            let pdb = windows::pdb::PDBInfo::new(&pdb_buf, pdb_name, filename, Some(pe), mapping)?;
-            self.store(&pdb)
-        } else {
-            Err("No pdb file found".into())
-        }
-    }
-}
+use super::dumper::{self, Config};
 
 pub(crate) enum Action<'a> {
-    Dump(Dumper<'a>),
+    Dump(Config<'a>),
     ListArch,
 }
 
 impl Action<'_> {
     pub(super) fn action(&self, filenames: &[&str]) -> common::Result<()> {
         if filenames.len() == 1 {
-            self.one_file(filenames[0])
+            // no need to spawn a thread for one file
+            self.single_file(filenames[0])
         } else {
-            self.two_files(filenames)
+            self.several_files(filenames)
         }
     }
 
-    fn one_file(&self, filename: &str) -> common::Result<()> {
-        let path = PathBuf::from(filename);
-        let filename = utils::get_filename(&path);
-
+    fn single_file(&self, filename: &str) -> common::Result<()> {
         match self {
-            Self::Dump(dumper) => {
-                let (buf, filename) = dumper.get_from_id(&path, filename)?;
-                let file_mapping = PathMappings::new(
-                    &dumper.mapping_var,
-                    &dumper.mapping_src,
-                    &dumper.mapping_dest,
-                    &dumper.mapping_file,
-                )?
-                .map(Arc::new);
-                match FileType::from_buf(&buf) {
-                    FileType::Elf => {
-                        dumper.elf(&buf, filename, file_mapping.as_ref().map(Arc::clone))
-                    }
-                    FileType::Pdb => {
-                        dumper.pdb(&buf, path, filename, file_mapping.as_ref().map(Arc::clone))
-                    }
-                    FileType::Pe => {
-                        dumper.pe(&buf, path, filename, file_mapping.as_ref().map(Arc::clone))
-                    }
-                    FileType::Macho => {
-                        dumper.macho(&buf, filename, file_mapping.as_ref().map(Arc::clone))
-                    }
-                    FileType::Unknown => Err("Unknown file format".into()),
-                }
-            }
+            Self::Dump(config) => dumper::single_file(&config, filename),
             Self::ListArch => {
+                let path = PathBuf::from(filename);
+                let filename = utils::get_filename(&path);
+
                 let buf = utils::read_file(&path);
                 MachoInfo::print_architectures(&buf, filename)
             }
         }
     }
 
-    fn two_files(&self, filenames: &[&str]) -> common::Result<()> {
-        let path_1 = PathBuf::from(filenames[0]);
-        let filename_1 = utils::get_filename(&path_1);
-
-        let path_2 = PathBuf::from(filenames[1]);
-        let filename_2 = utils::get_filename(&path_2);
-
+    fn several_files(&self, filenames: &[&str]) -> common::Result<()> {
         match self {
-            Self::Dump(dumper) => {
-                if dumper.has_id() {
-                    return Err("One filename must be given with --code-id or --debug-id".into());
-                }
-                let file_mapping = PathMappings::new(
-                    &dumper.mapping_var,
-                    &dumper.mapping_src,
-                    &dumper.mapping_dest,
-                    &dumper.mapping_file,
-                )?
-                .map(Arc::new);
-
-                let (buf_1, filename_1) = dumper.get_from_id(&path_1, filename_1)?;
-                let (buf_2, filename_2) = dumper.get_from_id(&path_2, filename_2)?;
-
-                match (FileType::from_buf(&buf_1), FileType::from_buf(&buf_2)) {
-                    (FileType::Elf, FileType::Elf) => {
-                        let arch = Platform::Linux;
-                        dumper.two_elfs(
-                            move || ElfInfo::new(&buf_1, filename_1, arch, None),
-                            move || ElfInfo::new(&buf_2, filename_2, arch, None),
-                        )
-                    }
-                    (FileType::Pdb, FileType::Pe) => dumper.pdb_pe(
-                        &buf_1,
-                        filename_1,
-                        &buf_2,
-                        path_2,
-                        filename_2,
-                        file_mapping.as_ref().map(Arc::clone),
-                    ),
-                    (FileType::Pe, FileType::Pdb) => dumper.pdb_pe(
-                        &buf_2,
-                        filename_2,
-                        &buf_1,
-                        path_1,
-                        filename_1,
-                        file_mapping.as_ref().map(Arc::clone),
-                    ),
-                    (FileType::Macho, FileType::Macho) => {
-                        let arch = Arch::from_str(dumper.arch).map_err(|e| e.compat())?;
-                        dumper.two_elfs(
-                            move || MachoInfo::new(&buf_1, filename_1, arch, None),
-                            move || MachoInfo::new(&buf_2, filename_2, arch, None),
-                        )
-                    }
-                    _ => Err("Invalid files: must be two elf or a pdb and a pe".into()),
-                }
-            }
+            Self::Dump(config) => match config.file_type {
+                FileType::Elf => dumper::several_files::<ElfInfo>(&config, filenames),
+                FileType::Macho => dumper::several_files::<MachoInfo>(&config, filenames),
+                FileType::Pdb => dumper::several_files::<PDBInfo>(&config, filenames),
+                _ => Ok(()),
+            },
             Self::ListArch => {
-                let buf = utils::read_file(&path_1);
-                MachoInfo::print_architectures(&buf, filename_1)?;
+                for f in filenames {
+                    let path = PathBuf::from(f);
+                    let filename = utils::get_filename(&path);
 
-                let buf = utils::read_file(&path_2);
-                MachoInfo::print_architectures(&buf, filename_2)
+                    let buf = utils::read_file(&path);
+                    MachoInfo::print_architectures(&buf, filename)?;
+                }
+                Ok(())
             }
         }
     }
@@ -313,13 +80,15 @@ mod tests {
 
         copy(basic64, &tmp_file).unwrap();
 
-        let action = Action::Dump(Dumper {
+        let action = Action::Dump(Config {
             output: tmp_out.to_str().unwrap(),
             symbol_server: None,
             store: None,
             debug_id: None,
             code_id: None,
-            arch: "",
+            arch: common::get_compile_time_arch(),
+            file_type: FileType::Pdb,
+            num_jobs: 1,
             mapping_var: None,
             mapping_src: None,
             mapping_dest: None,
@@ -347,13 +116,15 @@ mod tests {
         copy(basic64_pdb, &tmp_pdb).unwrap();
         copy(basic64_dll, &tmp_dll).unwrap();
 
-        let action = Action::Dump(Dumper {
+        let action = Action::Dump(Config {
             output: tmp_out.to_str().unwrap(),
             symbol_server: None,
             store: None,
             debug_id: None,
             code_id: None,
-            arch: "",
+            arch: common::get_compile_time_arch(),
+            file_type: FileType::Pdb,
+            num_jobs: 1,
             mapping_var: None,
             mapping_src: None,
             mapping_dest: None,
@@ -370,80 +141,20 @@ mod tests {
     }
 
     #[test]
-    fn test_pe_and_pdb() {
-        let tmp_dir = Builder::new().prefix("pe_pdb").tempdir().unwrap();
-        let basic64_pdb = PathBuf::from("./test_data/windows/basic64.pdb");
-        let basic64_dll = PathBuf::from("./test_data/windows/basic64.dll");
-        let tmp_out = tmp_dir.path().join("output.sym");
-
-        let action = Action::Dump(Dumper {
-            output: tmp_out.to_str().unwrap(),
-            symbol_server: None,
-            store: None,
-            debug_id: None,
-            code_id: None,
-            arch: "",
-            mapping_var: None,
-            mapping_src: None,
-            mapping_dest: None,
-            mapping_file: None,
-        });
-
-        action
-            .action(&[basic64_dll.to_str().unwrap(), basic64_pdb.to_str().unwrap()])
-            .unwrap();
-
-        let data = read(tmp_out).unwrap();
-        let data = String::from_utf8(data).unwrap();
-
-        assert!(data.contains("CODE_ID"));
-        assert!(data.contains("STACK CFI"));
-    }
-
-    #[test]
-    fn test_pdb_and_pe() {
-        let tmp_dir = Builder::new().prefix("pdb_pe").tempdir().unwrap();
-        let basic64_pdb = PathBuf::from("./test_data/windows/basic64.pdb");
-        let basic64_dll = PathBuf::from("./test_data/windows/basic64.dll");
-        let tmp_out = tmp_dir.path().join("output.sym");
-
-        let action = Action::Dump(Dumper {
-            output: tmp_out.to_str().unwrap(),
-            symbol_server: None,
-            store: None,
-            debug_id: None,
-            code_id: None,
-            arch: "",
-            mapping_var: None,
-            mapping_src: None,
-            mapping_dest: None,
-            mapping_file: None,
-        });
-
-        action
-            .action(&[basic64_pdb.to_str().unwrap(), basic64_dll.to_str().unwrap()])
-            .unwrap();
-
-        let data = read(tmp_out).unwrap();
-        let data = String::from_utf8(data).unwrap();
-
-        assert!(data.contains("CODE_ID"));
-        assert!(data.contains("STACK CFI"));
-    }
-
-    #[test]
     fn test_elf_full() {
         let tmp_dir = Builder::new().prefix("full").tempdir().unwrap();
         let full = PathBuf::from("./test_data/linux/basic.full");
         let tmp_out = tmp_dir.path().join("output.sym");
 
-        let action = Action::Dump(Dumper {
+        let action = Action::Dump(Config {
             output: tmp_out.to_str().unwrap(),
             symbol_server: None,
             store: None,
             debug_id: None,
             code_id: None,
-            arch: "",
+            arch: common::get_compile_time_arch(),
+            file_type: FileType::Elf,
+            num_jobs: 1,
             mapping_var: None,
             mapping_src: None,
             mapping_dest: None,
@@ -469,13 +180,15 @@ mod tests {
         let dbg = PathBuf::from("./test_data/linux/basic.dbg");
         let tmp_out = tmp_dir.path().join("output.sym");
 
-        let action = Action::Dump(Dumper {
+        let action = Action::Dump(Config {
             output: tmp_out.to_str().unwrap(),
             symbol_server: None,
             store: None,
             debug_id: None,
             code_id: None,
-            arch: "",
+            arch: common::get_compile_time_arch(),
+            file_type: FileType::Elf,
+            num_jobs: 2,
             mapping_var: None,
             mapping_src: None,
             mapping_dest: None,
@@ -503,13 +216,15 @@ mod tests {
         let dbg = PathBuf::from("./test_data/linux/basic.dbg");
         let tmp_out = tmp_dir.path().join("output.sym");
 
-        let action = Action::Dump(Dumper {
+        let action = Action::Dump(Config {
             output: tmp_out.to_str().unwrap(),
             symbol_server: None,
             store: None,
             debug_id: None,
             code_id: None,
-            arch: "",
+            arch: common::get_compile_time_arch(),
+            file_type: FileType::Elf,
+            num_jobs: 2,
             mapping_var: None,
             mapping_src: None,
             mapping_dest: None,

--- a/src/common.rs
+++ b/src/common.rs
@@ -31,6 +31,16 @@ impl FileType {
             _ => Self::Unknown,
         }
     }
+
+    pub(crate) fn from_str(s: &str) -> Self {
+        let s = s.to_lowercase();
+        match s.as_str() {
+            "pdb" => Self::Pdb,
+            "elf" => Self::Elf,
+            "macho" => Self::Macho,
+            _ => Self::Unknown,
+        }
+    }
 }
 
 pub(crate) trait Dumpable {

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -1,0 +1,361 @@
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crossbeam::channel::{Receiver, Sender};
+use crossbeam::crossbeam_channel::bounded;
+use failure::Fail;
+use hashbrown::HashMap;
+use log::info;
+use std::fs;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use symbolic_common::Arch;
+
+use crate::cache;
+use crate::common::{self, Dumpable, FileType, Mergeable};
+use crate::linux::elf::{ElfInfo, Platform};
+use crate::mac::macho::MachoInfo;
+use crate::mapping::PathMappings;
+use crate::utils;
+use crate::windows::{self, pdb::PDBInfo};
+
+pub(crate) struct Config<'a> {
+    pub output: &'a str,
+    pub symbol_server: Option<&'a str>,
+    pub store: Option<&'a str>,
+    pub debug_id: Option<&'a str>,
+    pub code_id: Option<&'a str>,
+    pub arch: &'a str,
+    pub file_type: FileType,
+    pub num_jobs: usize,
+    pub mapping_var: Option<Vec<&'a str>>,
+    pub mapping_src: Option<Vec<&'a str>>,
+    pub mapping_dest: Option<Vec<&'a str>>,
+    pub mapping_file: Option<&'a str>,
+}
+
+pub(crate) trait Creator: Mergeable + Dumpable + Sized {
+    fn get_dbg(
+        arch: Arch,
+        buf: &[u8],
+        path: PathBuf,
+        filename: String,
+        mapping: Option<Arc<PathMappings>>,
+    ) -> common::Result<Self>;
+
+    fn get_pe<'a>(
+        _conf: &Config<'a>,
+        _buf: &[u8],
+        _path: PathBuf,
+        _filename: String,
+        _mapping: Option<Arc<PathMappings>>,
+    ) -> common::Result<Self> {
+        Err("Not implemented".into())
+    }
+}
+
+impl Creator for ElfInfo {
+    fn get_dbg(
+        _arch: Arch,
+        buf: &[u8],
+        _path: PathBuf,
+        filename: String,
+        mapping: Option<Arc<PathMappings>>,
+    ) -> common::Result<Self> {
+        Self::new(&buf, filename, Platform::Linux, mapping)
+    }
+}
+
+impl Creator for MachoInfo {
+    fn get_dbg(
+        arch: Arch,
+        buf: &[u8],
+        _path: PathBuf,
+        filename: String,
+        mapping: Option<Arc<PathMappings>>,
+    ) -> common::Result<Self> {
+        Self::new(&buf, filename, arch, mapping)
+    }
+}
+
+impl Creator for PDBInfo {
+    fn get_dbg(
+        _arch: Arch,
+        buf: &[u8],
+        path: PathBuf,
+        filename: String,
+        mapping: Option<Arc<PathMappings>>,
+    ) -> common::Result<Self> {
+        let mut pdb = Self::new(&buf, filename, "".to_string(), None, mapping)?;
+        windows::utils::try_to_set_pe(&path, &mut pdb, &buf);
+        Ok(pdb)
+    }
+
+    fn get_pe<'a>(
+        conf: &Config<'a>,
+        buf: &[u8],
+        path: PathBuf,
+        filename: String,
+        mapping: Option<Arc<PathMappings>>,
+    ) -> common::Result<Self> {
+        let symbol_server = cache::get_sym_servers(conf.symbol_server);
+        let res = windows::utils::get_pe_pdb_buf(path, &buf, symbol_server.as_ref());
+
+        if let Some((pe, pdb_buf, pdb_name)) = res {
+            let pdb = Self::new(&pdb_buf, pdb_name, filename, Some(pe), mapping)?;
+            Ok(pdb)
+        } else {
+            Err("No pdb file found".into())
+        }
+    }
+}
+
+fn store<D: Dumpable, S1: AsRef<str>, S2: AsRef<str>>(
+    output: S1,
+    store: Option<S2>,
+    dumpable: D,
+) -> common::Result<()> {
+    let output = output.as_ref();
+    let store = store.filter(|p| !p.as_ref().is_empty()).map(|p| {
+        PathBuf::from(p.as_ref()).join(cache::get_path_for_sym(
+            &dumpable.get_name(),
+            dumpable.get_debug_id(),
+        ))
+    });
+
+    if let Some(store) = store.as_ref() {
+        fs::create_dir_all(store.parent().unwrap())?;
+        let store = store.to_str().unwrap();
+        let output = utils::get_writer_for_sym(store);
+        if let Err(e) = dumpable.dump(output) {
+            return Err(e);
+        }
+        info!("Write symbols at {}", store);
+    }
+
+    if output != "-" || store.is_none() {
+        let output_stream = utils::get_writer_for_sym(output);
+        dumpable.dump(output_stream)?;
+        info!("Write symbols at {}", output);
+    }
+    Ok(())
+}
+
+fn get_from_id(
+    config: &Config,
+    path: &PathBuf,
+    filename: String,
+) -> common::Result<(Vec<u8>, String)> {
+    for id in &[config.debug_id, config.code_id] {
+        if let Some(id) = id {
+            let symbol_server = cache::get_sym_servers(config.symbol_server);
+            let (buf, filename) = cache::search_file(filename, id, symbol_server.as_ref());
+            return if let Some(buf) = buf {
+                Ok((buf, filename))
+            } else {
+                Err(format!("Impossible to get file {} with id {}", filename, id).into())
+            };
+        }
+    }
+
+    Ok((utils::read_file(&path), filename))
+}
+
+pub(crate) fn single_file(config: &Config, filename: &str) -> common::Result<()> {
+    let path = PathBuf::from(filename);
+    let filename = utils::get_filename(&path);
+
+    let (buf, filename) = get_from_id(config, &path, filename)?;
+    let file_mapping = PathMappings::new(
+        &config.mapping_var,
+        &config.mapping_src,
+        &config.mapping_dest,
+        &config.mapping_file,
+    )?
+    .map(Arc::new);
+    let arch = Arch::from_str(config.arch).map_err(|e| e.compat())?;
+
+    match FileType::from_buf(&buf) {
+        FileType::Elf => store(
+            config.output,
+            config.store,
+            ElfInfo::get_dbg(arch, &buf, path, filename, file_mapping)?,
+        ),
+        FileType::Pdb => store(
+            config.output,
+            config.store,
+            PDBInfo::get_dbg(arch, &buf, path, filename, file_mapping)?,
+        ),
+        FileType::Pe => store(
+            config.output,
+            config.store,
+            PDBInfo::get_pe(config, &buf, path, filename, file_mapping)?,
+        ),
+        FileType::Macho => store(
+            config.output,
+            config.store,
+            MachoInfo::get_dbg(arch, &buf, path, filename, file_mapping)?,
+        ),
+        FileType::Unknown => Err("Unknown file format".into()),
+    }
+}
+
+enum JobType<D: Dumpable> {
+    Get,
+    Dump(D),
+}
+
+struct JobItem<D: Dumpable> {
+    file: String,
+    typ: JobType<D>,
+    mapping: Option<Arc<PathMappings>>,
+}
+
+fn send_store_jobs<T: Creator>(
+    sender: &Sender<Option<JobItem<T>>>,
+    results: &mut HashMap<String, T>,
+    num_threads: usize,
+    output: &str,
+    store: &Option<String>,
+) -> common::Result<()> {
+    if results.len() == 1 {
+        let (_, d) = results.drain().take(1).next().unwrap();
+        self::store(&output, store.as_ref(), d)?;
+    } else {
+        for (_, d) in results.drain() {
+            sender
+                .send(Some(JobItem {
+                    file: "".to_string(),
+                    typ: JobType::Dump(d),
+                    mapping: None,
+                }))
+                .unwrap();
+        }
+    }
+
+    // Poison the receiver.
+    for _ in 0..num_threads {
+        sender.send(None).unwrap();
+    }
+
+    Ok(())
+}
+
+fn consumer<T: Creator>(
+    arch: Arch,
+    sender: Sender<Option<JobItem<T>>>,
+    receiver: Receiver<Option<JobItem<T>>>,
+    results: Arc<Mutex<HashMap<String, T>>>,
+    counter: Arc<AtomicUsize>,
+    num_threads: usize,
+    output: String,
+    store: Option<String>,
+) -> common::Result<()> {
+    while let Ok(job) = receiver.recv() {
+        if job.is_none() {
+            return Ok(());
+        }
+
+        let JobItem { file, typ, mapping } = job.unwrap();
+
+        match typ {
+            JobType::Get => {
+                let path = PathBuf::from(file);
+                let filename = utils::get_filename(&path);
+                let buf = utils::read_file(&path);
+
+                let info = T::get_dbg(arch, &buf, path, filename, mapping)?;
+
+                let mut results = results.lock().unwrap();
+                let info = if let Some(prev) = results.remove(info.get_debug_id()) {
+                    T::merge(info, prev)?
+                } else {
+                    info
+                };
+                results.insert(info.get_debug_id().to_string(), info);
+            }
+            JobType::Dump(d) => {
+                let cwd = ".".to_string();
+                let store = Some(store.as_ref().unwrap_or(&cwd));
+                self::store(&output, store.as_ref(), d)?;
+                continue;
+            }
+        }
+
+        if counter.load(Ordering::SeqCst) == 1 {
+            // it was the last file: so we just have to add jobs to dump & store
+            // and then poison the queue
+            let mut results = results.lock().unwrap();
+            send_store_jobs(&sender, &mut results, num_threads, &output, &store)?;
+        } else {
+            counter.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn several_files<T: 'static + Creator + std::marker::Send>(
+    config: &Config,
+    filenames: &[&str],
+) -> common::Result<()> {
+    let file_mapping = PathMappings::new(
+        &config.mapping_var,
+        &config.mapping_src,
+        &config.mapping_dest,
+        &config.mapping_file,
+    )?
+    .map(Arc::new);
+    let arch = Arch::from_str(config.arch).map_err(|e| e.compat())?;
+    let results = Arc::new(Mutex::new(HashMap::default()));
+    let num_jobs = config.num_jobs.min(filenames.len());
+    let counter = Arc::new(AtomicUsize::new(filenames.len()));
+
+    let (sender, receiver) = bounded(num_jobs + 1);
+
+    let mut receivers = Vec::with_capacity(num_jobs);
+    for i in 0..num_jobs {
+        let sender = sender.clone();
+        let receiver = receiver.clone();
+        let arch = arch.clone();
+        let results = Arc::clone(&results);
+        let counter = Arc::clone(&counter);
+        let output = config.output.to_string();
+        let store = config.store.map(|s| s.to_string());
+
+        let t = thread::Builder::new()
+            .name(format!("dump-syms {}", i))
+            .spawn(move || {
+                consumer::<T>(
+                    arch, sender, receiver, results, counter, num_jobs, output, store,
+                )
+            })
+            .unwrap();
+
+        receivers.push(t);
+    }
+
+    for f in filenames {
+        sender
+            .send(Some(JobItem {
+                file: f.to_string(),
+                typ: JobType::Get,
+                mapping: file_mapping.as_ref().map(Arc::clone),
+            }))
+            .unwrap();
+    }
+
+    for receiver in receivers {
+        if let Err(e) = receiver.join() {
+            eprintln!("Error: {:?}", e);
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -246,6 +246,7 @@ fn send_store_jobs<T: Creator>(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn consumer<T: Creator>(
     arch: Arch,
     sender: Sender<Option<JobItem<T>>>,
@@ -322,7 +323,6 @@ pub(crate) fn several_files<T: 'static + Creator + std::marker::Send>(
     for i in 0..num_jobs {
         let sender = sender.clone();
         let receiver = receiver.clone();
-        let arch = arch.clone();
         let results = Arc::clone(&results);
         let counter = Arc::clone(&counter);
         let output = config.output.to_string();

--- a/src/linux/elf.rs
+++ b/src/linux/elf.rs
@@ -9,6 +9,7 @@ use log::{error, warn};
 use std::collections::btree_map;
 use std::fmt::{Display, Formatter};
 use std::io::{Cursor, Write};
+use std::sync::Arc;
 use symbolic_common::{Language, Name};
 use symbolic_debuginfo::{Function, Object, ObjectDebugSession};
 use symbolic_demangle::{Demangle, DemangleFormat, DemangleOptions};
@@ -358,7 +359,7 @@ impl ElfInfo {
         buf: &[u8],
         file_name: String,
         platform: Platform,
-        mapping: Option<PathMappings>,
+        mapping: Option<Arc<PathMappings>>,
     ) -> common::Result<Self> {
         let o = Object::parse(&buf).map_err(|e| e.compat())?;
         Self::from_object(&o, file_name, platform, mapping)
@@ -368,7 +369,7 @@ impl ElfInfo {
         o: &Object,
         file_name: String,
         platform: Platform,
-        mapping: Option<PathMappings>,
+        mapping: Option<Arc<PathMappings>>,
     ) -> common::Result<Self> {
         let mut collector = Collector::default();
         let mut source = SourceFiles::new(mapping);

--- a/src/linux/elf.rs
+++ b/src/linux/elf.rs
@@ -310,7 +310,7 @@ impl Collector {
                     self.collect_function(&fun, source);
                 }
                 Err(e) => {
-                    error!("{:?}", e);
+                    error!("Function collection: {:?}", e);
                 }
             }
         }
@@ -347,7 +347,7 @@ impl Collector {
 
         let mut cfi_writer = AsciiCfiWriter::new(writer);
         if let Err(e) = cfi_writer.process(o) {
-            error!("{}", e);
+            error!("CFI: {:?}", e);
         }
 
         String::from_utf8(buf).unwrap()

--- a/src/linux/source.rs
+++ b/src/linux/source.rs
@@ -7,6 +7,7 @@ use hashbrown::{hash_map, HashMap};
 use log::error;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
 use symbolic_debuginfo::FileInfo;
 
 use crate::mapping::PathMappings;
@@ -20,7 +21,7 @@ pub struct SourceFiles {
     fake_id_to_ref: Vec<(Option<u32>, String)>,
     id_to_ref: Vec<String>,
     cache: HashMap<(SliceRef, SliceRef, SliceRef), u32>,
-    mapping: Option<PathMappings>,
+    mapping: Option<Arc<PathMappings>>,
 }
 
 #[derive(Debug, Default)]
@@ -30,7 +31,7 @@ pub struct SourceMap {
 }
 
 impl SourceFiles {
-    pub(super) fn new(mapping: Option<PathMappings>) -> Self {
+    pub(super) fn new(mapping: Option<Arc<PathMappings>>) -> Self {
         SourceFiles {
             mapping,
             ..Default::default()

--- a/src/mac/macho.rs
+++ b/src/mac/macho.rs
@@ -6,6 +6,7 @@
 use failure::Fail;
 use std::fmt::{Display, Formatter};
 use std::io::Write;
+use std::sync::Arc;
 use symbolic_common::Arch;
 use symbolic_debuginfo::Archive;
 
@@ -29,7 +30,7 @@ impl MachoInfo {
         buf: &[u8],
         file_name: String,
         arch: Arch,
-        mapping: Option<PathMappings>,
+        mapping: Option<Arc<PathMappings>>,
     ) -> common::Result<Self> {
         // Fat files may contain several objects for different architectures
         // So if there is only one object, then we don't care about the arch (as argument)

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,18 +189,24 @@ For example with --mapping-var="rev=123abc" --mapping-src="/foo/bar/(.*)" --mapp
         num_cpus::get()
     };
     let typ = matches.value_of("type").unwrap();
-    let file_type = if filenames.len() >= 2 && typ == "" {
-        eprintln!("Since there are several files to dump, the type must be specified with --type");
-        std::process::exit(1);
-    } else {
-        let t = common::FileType::from_str(typ);
-        match t {
-            FileType::Elf | FileType::Macho | FileType::Pdb => t,
-            _ => {
-                eprintln!("Type must be one of the values: elf, macho or pdb");
-                std::process::exit(1);
+    let file_type = if filenames.len() >= 2 {
+        if typ == "" {
+            eprintln!(
+                "Since there are several files to dump, the type must be specified with --type"
+            );
+            std::process::exit(1);
+        } else {
+            let t = common::FileType::from_str(typ);
+            match t {
+                FileType::Elf | FileType::Macho | FileType::Pdb => t,
+                _ => {
+                    eprintln!("Type must be one of the values: elf, macho or pdb");
+                    std::process::exit(1);
+                }
             }
         }
+    } else {
+        FileType::Unknown
     };
 
     let action = if matches.is_present("list_arch") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,6 @@ fn main() {
                 .help("Files to dump (.dll, .exe, .pdb, .pd_, .so, .dbg)")
                 .required(true)
                 .takes_value(true)
-                .max_values(2),
         )
         .arg(
             Arg::with_name("output")

--- a/src/windows/pdb.rs
+++ b/src/windows/pdb.rs
@@ -21,7 +21,7 @@ use super::source::{SourceFiles, SourceLineCollector};
 use super::symbol::{BlockInfo, PDBSymbols, RvaSymbols, SelectedSymbol};
 use super::types::{DumperFlags, TypeDumper};
 use super::utils::get_pe_debug_id;
-use crate::common::{self, Dumpable};
+use crate::common::{self, Dumpable, Mergeable};
 use crate::mapping::PathMappings;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -567,6 +567,12 @@ impl Dumpable for PDBInfo {
 
     fn get_name(&self) -> &str {
         &self.pdb_name
+    }
+}
+
+impl Mergeable for PDBInfo {
+    fn merge(_left: PDBInfo, _right: PDBInfo) -> common::Result<PDBInfo> {
+        Err("PDB merge not implemented".into())
     }
 }
 

--- a/src/windows/pdb.rs
+++ b/src/windows/pdb.rs
@@ -12,6 +12,7 @@ use pdb::{
 };
 use std::fmt::{Display, Formatter};
 use std::io::{Cursor, Write};
+use std::sync::Arc;
 use symbolic_debuginfo::{pdb::PdbObject, pe::PeObject, Object};
 use symbolic_minidump::cfi::AsciiCfiWriter;
 use uuid::Uuid;
@@ -483,7 +484,7 @@ impl PDBInfo {
         pdb_name: String,
         pe_name: String,
         pe: Option<PeObject>,
-        mapping: Option<PathMappings>,
+        mapping: Option<Arc<PathMappings>>,
     ) -> Result<Self> {
         let cursor = Cursor::new(buf);
         let mut pdb = PDB::open(cursor)?;
@@ -637,7 +638,7 @@ mod tests {
         (output, toks[1])
     }
 
-    fn get_new_bp(file_name: &str, mapping: Option<PathMappings>) -> Vec<u8> {
+    fn get_new_bp(file_name: &str, mapping: Option<Arc<PathMappings>>) -> Vec<u8> {
         let path = PathBuf::from("./test_data/windows");
         let mut path = path.join(file_name);
 
@@ -1000,7 +1001,7 @@ mod tests {
         )
         .unwrap();
         let dll = "basic32.dll";
-        let output = get_new_bp(dll, mapping);
+        let output = get_new_bp(dll, mapping.map(Arc::new));
         let bp = BreakpadObject::parse(&output).unwrap();
 
         let map = bp.file_map();

--- a/src/windows/source.rs
+++ b/src/windows/source.rs
@@ -13,6 +13,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::ops::Bound::{Excluded, Included};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::line::Lines;
 use crate::mapping::PathMappings;
@@ -88,13 +89,13 @@ pub(super) struct SourceFiles<'a> {
     string_table: Option<StringTable<'a>>,
     ref_to_id: RefToIds,
     id_to_ref: Vec<StringRef>,
-    mapping: Option<PathMappings>,
+    mapping: Option<Arc<PathMappings>>,
 }
 
 impl<'a> SourceFiles<'a> {
     pub(super) fn new<S: 'a + Source<'a>>(
         pdb: &mut PDB<'a, S>,
-        mapping: Option<PathMappings>,
+        mapping: Option<Arc<PathMappings>>,
     ) -> Result<Self> {
         // The string table may be empty: not a problem
         let string_table = match pdb.string_table() {

--- a/src/windows/symbol.rs
+++ b/src/windows/symbol.rs
@@ -59,6 +59,9 @@ pub(super) struct PDBSymbol {
     pub id: usize,
 }
 
+// it's safe because source (with Rc) isn't shared: it's just an internal thing
+unsafe impl Send for PDBSymbol {}
+
 impl PDBSymbol {
     fn get_from(&self, rva: u32, len: u32) -> PDBSymbol {
         PDBSymbol {

--- a/src/windows/utils.rs
+++ b/src/windows/utils.rs
@@ -78,11 +78,6 @@ pub fn get_pe_pdb_buf<'a>(
     }
 }
 
-pub fn get_pe(path: PathBuf, buf: &[u8]) -> PeObject {
-    PeObject::parse(&buf)
-        .unwrap_or_else(|_| panic!("Unable to parse the PE file {}", path.to_str().unwrap()))
-}
-
 pub fn get_pe_debug_id(pe: Option<&PeObject>) -> Option<String> {
     if let Some(pe) = pe {
         let mut buf = Uuid::encode_buffer();


### PR DESCRIPTION
Using `dump_syms foo.so bar.so toto.so --type elf̀` the 3 dumps will run in parallel (the number of threads can be specified using `-j`).
The type (`--type`) of debug files is needed to avoid to have to guess it out of threads and when there is only 1 file no threads are used.
To avoid naming issues the `--store` option is recommended else by default it will be `--store "."` and then the outputed files will be in `store_dir/xul.so/DEBUG_ID/xul.sym`. 
And the path remapping stuff is shared between the threads.