### PR TITLE
fix type mismatch in Windows-specific mapping code

### DIFF
--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -310,7 +310,7 @@ impl PathMappings {
 
         #[cfg(windows)]
         let file_str = if file_str.starts_with(r"\\?\") {
-            file_str[r"\\?\".len()..]
+            &file_str[r"\\?\".len()..]
         } else {
             file_str
         };


### PR DESCRIPTION
The current form of the code triggers:

```
error[E0308]: `if` and `else` have incompatible types
   --> src/mapping.rs:314:13
    |
311 |           let file_str = if file_str.starts_with(r"\\?\") {
    |  ________________________-
312 | |             file_str[r"\\?\".len()..]
    | |             ------------------------- expected because of this
313 | |         } else {
314 | |             file_str
    | |             ^^^^^^^^ expected `str`, found `&str`
315 | |         };
    | |_________- `if` and `else` have incompatible types
```