### PR TITLE
Add an option (--check-cfi) to fail in case of no stack data

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -94,6 +94,7 @@ mod tests {
             mapping_src: None,
             mapping_dest: None,
             mapping_file: None,
+            check_cfi: false,
         });
 
         action.action(&[tmp_file.to_str().unwrap()]).unwrap();
@@ -103,6 +104,35 @@ mod tests {
 
         assert!(!data.contains("CODE_ID"));
         assert!(!data.contains("STACK CFI"));
+    }
+
+    #[test]
+    fn test_missing_cfi() {
+        let tmp_dir = Builder::new().prefix("missing_cfi").tempdir().unwrap();
+        let basic64 = PathBuf::from("./test_data/windows/basic64.pdb");
+        let tmp_file = tmp_dir.path().join("basic64.pdb");
+        let tmp_out = tmp_dir.path().join("output.sym");
+
+        copy(basic64, &tmp_file).unwrap();
+
+        let action = Action::Dump(Config {
+            output: tmp_out.to_str().unwrap(),
+            symbol_server: None,
+            store: None,
+            debug_id: None,
+            code_id: None,
+            arch: common::get_compile_time_arch(),
+            file_type: FileType::Pdb,
+            num_jobs: 1,
+            mapping_var: None,
+            mapping_src: None,
+            mapping_dest: None,
+            mapping_file: None,
+            check_cfi: true,
+        });
+
+        let res = action.action(&[tmp_file.to_str().unwrap()]);
+        assert!(res.is_err());
     }
 
     #[test]
@@ -130,6 +160,7 @@ mod tests {
             mapping_src: None,
             mapping_dest: None,
             mapping_file: None,
+            check_cfi: false,
         });
 
         action.action(&[tmp_pdb.to_str().unwrap()]).unwrap();
@@ -160,6 +191,7 @@ mod tests {
             mapping_src: None,
             mapping_dest: None,
             mapping_file: None,
+            check_cfi: false,
         });
 
         action.action(&[full.to_str().unwrap()]).unwrap();
@@ -194,6 +226,7 @@ mod tests {
             mapping_src: None,
             mapping_dest: None,
             mapping_file: None,
+            check_cfi: false,
         });
 
         action
@@ -235,6 +268,7 @@ mod tests {
             mapping_src: None,
             mapping_dest: None,
             mapping_file: None,
+            check_cfi: false,
         });
 
         action

--- a/src/common.rs
+++ b/src/common.rs
@@ -48,6 +48,7 @@ pub(crate) trait Dumpable {
     fn dump<W: Write>(&self, writer: W) -> Result<()>;
     fn get_name(&self) -> &str;
     fn get_debug_id(&self) -> &str;
+    fn has_stack(&self) -> bool;
 }
 
 pub(crate) trait Mergeable {

--- a/src/linux/elf.rs
+++ b/src/linux/elf.rs
@@ -497,4 +497,8 @@ impl Dumpable for ElfInfo {
     fn get_name(&self) -> &str {
         &self.file_name
     }
+
+    fn has_stack(&self) -> bool {
+        !self.stack.is_empty()
+    }
 }

--- a/src/mac/macho.rs
+++ b/src/mac/macho.rs
@@ -98,4 +98,8 @@ impl Dumpable for MachoInfo {
     fn get_name(&self) -> &str {
         self.elf.get_name()
     }
+
+    fn has_stack(&self) -> bool {
+        self.elf.has_stack()
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,11 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("check_cfi")
+                .help("Fail if there are no CFI data")
+                .long("check-cfi")
+        )
+        .arg(
             Arg::with_name("verbose")
                 .help("Set the level of verbosity (off, error (default), warn, info, debug, trace)")
                 .long("verbose")
@@ -178,6 +183,7 @@ For example with --mapping-var="rev=123abc" --mapping-src="/foo/bar/(.*)" --mapp
     let debug_id = matches.value_of("debug_id");
     let code_id = matches.value_of("code_id");
     let arch = matches.value_of("arch").unwrap();
+    let check_cfi = matches.is_present("check_cfi");
     let mapping_var = matches
         .values_of("mapping_var")
         .map(|v| v.collect::<Vec<_>>());
@@ -226,6 +232,7 @@ For example with --mapping-var="rev=123abc" --mapping-src="/foo/bar/(.*)" --mapp
             arch,
             file_type,
             num_jobs,
+            check_cfi,
             mapping_var,
             mapping_src,
             mapping_dest,

--- a/src/windows/pdb.rs
+++ b/src/windows/pdb.rs
@@ -577,6 +577,10 @@ impl Dumpable for PDBInfo {
     fn get_name(&self) -> &str {
         &self.pdb_name
     }
+
+    fn has_stack(&self) -> bool {
+        !self.stack.is_empty()
+    }
 }
 
 impl Mergeable for PDBInfo {
@@ -673,6 +677,10 @@ impl Dumpable for PEInfo {
         }
 
         &self.pdb_name
+    }
+
+    fn has_stack(&self) -> bool {
+        !self.stack.is_empty()
     }
 }
 


### PR DESCRIPTION
  - it aims to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1717909
  - the main goal of sym files is to be able to unwind crash stack so having empty CFI data is pretty useless.
  - so --check-cfi must be explictly set to not dump dbg files without cfi.