### PR TITLE
Improve support for executable section symbols in ELF files

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -199,7 +199,7 @@ mod tests {
         let data = read(tmp_out).unwrap();
         let new: Vec<_> = data.split(|c| *c == b'\n').skip(1).collect();
 
-        let basic = PathBuf::from("./test_data/linux/basic.full_no_multiple.sym");
+        let basic = PathBuf::from("./test_data/linux/basic.full.sym");
         let data = read(basic).unwrap();
         let basic: Vec<_> = data.split(|c| *c == b'\n').skip(1).collect();
 
@@ -239,7 +239,7 @@ mod tests {
         let data = re.replace_all(&data, "<procedure linkage table>");
         let new: Vec<_> = data.split(|c: char| c == '\n').skip(1).collect();
 
-        let basic = PathBuf::from("./test_data/linux/basic.full.sym");
+        let basic = PathBuf::from("./test_data/linux/basic.dbg.sym");
         let data = read(basic).unwrap();
         let data = String::from_utf8(data).unwrap();
         let data = re.replace_all(&data, "<procedure linkage table>");
@@ -279,7 +279,7 @@ mod tests {
         let data = String::from_utf8(data).unwrap();
         let new: Vec<_> = data.split(|c: char| c == '\n').skip(1).collect();
 
-        let basic = PathBuf::from("./test_data/linux/basic.full.sym");
+        let basic = PathBuf::from("./test_data/linux/basic.dbg.sym");
         let data = read(basic).unwrap();
         let data = String::from_utf8(data).unwrap();
         let basic: Vec<_> = data.split(|c: char| c == '\n').skip(1).collect();

--- a/test_data/linux/basic.dbg.sym
+++ b/test_data/linux/basic.dbg.sym
@@ -2,8 +2,8 @@ MODULE Linux x86_64 20AD60B0B4C68177552708AA192E77390 basic.full
 INFO CODE_ID B060AD20C6B47781552708AA192E7739FAC7C84A
 FILE 0 /home/calixte/dev/mozilla/dump_syms.calixteman/test_data/linux/basic.cpp
 PUBLIC 1000 0 _init
-PUBLIC 1020 0 <.plt ELF section>
-PUBLIC 1030 0 <.plt.got ELF section>
+PUBLIC 1020 0 <.plt ELF section in basic.dbg>
+PUBLIC 1030 0 <.plt.got ELF section in basic.dbg>
 PUBLIC 1040 0 _start
 PUBLIC 1070 0 deregister_tm_clones
 PUBLIC 10a0 0 register_tm_clones

--- a/test_data/linux/basic.full.sym
+++ b/test_data/linux/basic.full.sym
@@ -1,10 +1,10 @@
 MODULE Linux x86_64 20AD60B0B4C68177552708AA192E77390 basic.full
 INFO CODE_ID B060AD20C6B47781552708AA192E7739FAC7C84A
 FILE 0 /home/calixte/dev/mozilla/dump_syms.calixteman/test_data/linux/basic.cpp
-PUBLIC m 1000 0 _init
-PUBLIC m 1020 0 <.plt ELF section>
-PUBLIC m 1030 0 <.plt.got ELF section>
-PUBLIC m 1040 0 _start
+PUBLIC 1000 0 _init
+PUBLIC 1020 0 <.plt ELF section in basic.full>
+PUBLIC 1030 0 <.plt.got ELF section in basic.full>
+PUBLIC 1040 0 _start
 PUBLIC 1070 0 deregister_tm_clones
 PUBLIC 10a0 0 register_tm_clones
 PUBLIC 10e0 0 __do_global_dtors_aux
@@ -42,7 +42,7 @@ FUNC 12bd 1c 0 main
 12d7 2 37 0
 PUBLIC 12e0 0 __libc_csu_init
 PUBLIC 1340 0 __libc_csu_fini
-PUBLIC m 1344 0 _fini
+PUBLIC 1344 0 _fini
 STACK CFI INIT 1040 2b .cfa: $rsp 8 +
 STACK CFI INIT 1020 10 .cfa: $rsp 16 + .ra: .cfa -8 + ^
 STACK CFI 1026 .cfa: $rsp 24 +


### PR DESCRIPTION
This changes how synthetic symbols for executable ELF sections are emitted:
* If a symbol is already present for a given address we won't emit a
  synthetic symbol and we won't mark the existing symbol as multiple
* More generally a symbol is only marked as multiple if multiple
  **different** versions of it are present
* The synthetic symbols now contain the name of the object they're from

This also enable us to improve the tests (and I removed the hack I had
introduced in the previous patch to work around the multiple markers
that had popped up due to the changes)