### PR TITLE
Libify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,21 +65,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide 0.4.4",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base64"
@@ -197,22 +179,6 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpp_demangle"
@@ -358,12 +324,12 @@ checksum = "d4699f5cb7678f099b747ffdc1e6ce6cdc42579e29d28315aa715b9fd10324fc"
 name = "dump_syms"
 version = "0.0.7"
 dependencies = [
+ "anyhow",
  "bitflags",
  "cab",
  "clap",
  "crossbeam",
  "dirs",
- "failure",
  "futures",
  "fxhash",
  "goblin",
@@ -371,7 +337,6 @@ dependencies = [
  "lazy_static",
  "log",
  "num_cpus",
- "openssl",
  "pdb",
  "regex",
  "reqwest",
@@ -406,28 +371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,7 +394,7 @@ dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
- "miniz_oxide 0.5.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -459,21 +402,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -728,16 +656,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
- "bytes",
+ "http",
  "hyper",
- "native-tls",
+ "rustls",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -893,16 +821,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
@@ -940,24 +858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb67c6dd0fa9b00619c41c5700b6f92d5f418be49b45ddb9970fbd4569df3c8"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1028,15 +928,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,49 +938,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-src"
-version = "111.18.0+1.1.1n"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1151,12 +999,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plain"
@@ -1255,25 +1097,42 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1283,20 +1142,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustls"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi",
-]
 
 [[package]]
 name = "scopeguard"
@@ -1331,26 +1201,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework"
-version = "2.6.1"
+name = "sct"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1447,6 +1304,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1567,18 +1430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,13 +1529,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
+name = "tokio-rustls"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -1779,6 +1631,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,12 +1653,6 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -1916,6 +1768,25 @@ checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ required-features = ["cli"]
 [features]
 default = ["cli", "http"]
 # Feature needed when building the dump_syms executable
-cli = ["clap"]
+cli = ["clap", "simplelog"]
 # Feature for allowing retrieval of symbols via HTTP
 http = ["reqwest", "futures", "tokio"]
 
@@ -41,7 +41,7 @@ reqwest = { version = "0.11", optional = true, default-features = false, feature
 serde = "1.0"
 serde_json = "1.0"
 sha2 = "0.9"
-simplelog = "0.10"
+simplelog = { version = "0.10", optional = true }
 symbolic = { version = "8", features = ["demangle", "minidump"] }
 tokio = { version = "1.8", optional = true }
 url = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
+anyhow = "1.0"
 bitflags = "1.3"
 cab = "0.2"
 clap = "2.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,25 @@ description = "Dump debug symbols into Breakpad ones"
 edition = "2018"
 license = "MIT/Apache-2.0"
 
+[[bin]]
+name = "dump_syms"
+required-features = ["cli"]
+
+[features]
+default = ["cli", "http"]
+# Feature needed when building the dump_syms executable
+cli = ["clap"]
+# Feature for allowing retrieval of symbols via HTTP
+http = ["reqwest", "futures", "tokio"]
+
 [dependencies]
 anyhow = "1.0"
 bitflags = "1.3"
 cab = "0.2"
-clap = "2.33"
+clap = { version = "2.33", optional = true }
 crossbeam = "0.8.1"
 dirs = "3.0"
-failure = "0.1"
-futures = "0.3"
+futures = { version = "0.3", optional = true }
 goblin = "0.5.1" # Keep in sync with symbolic-debuginfo
 hashbrown = { version = "0.11", features = ["serde"] }
 lazy_static = "1.4"
@@ -24,23 +34,23 @@ log = "0.4"
 num_cpus = "1.13"
 pdb = "0.7"
 regex = "1.4"
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.11", optional = true, default-features = false, features = [
+    "blocking",
+    "rustls-tls",
+] }
 serde = "1.0"
 serde_json = "1.0"
 sha2 = "0.9"
 simplelog = "0.10"
 symbolic = { version = "8", features = ["demangle", "minidump"] }
-tokio = "1.8"
+tokio = { version = "1.8", optional = true }
 url = "2.2"
 uuid = "0.8"
 
 [dev-dependencies]
+reqwest = { version = "0.11", default-features = false, features = [
+    "blocking",
+    "rustls-tls",
+] }
 fxhash = "0.2"
 tempfile = "3"
-
-[features]
-vendored-openssl = ["openssl/vendored"]
-
-[dependencies.openssl]
-version = "0.10"
-optional = true

--- a/src/action.rs
+++ b/src/action.rs
@@ -5,14 +5,15 @@
 
 use std::path::PathBuf;
 
-use crate::common::{self, FileType};
-use crate::linux::elf::ElfInfo;
-use crate::mac::macho::MachoInfo;
-use crate::utils;
-use crate::windows::pdb::PDBInfo;
+use dump_syms::common::{self, FileType};
+use dump_syms::linux::elf::ElfInfo;
+use dump_syms::mac::macho::MachoInfo;
+use dump_syms::utils;
+use dump_syms::windows::pdb::PDBInfo;
 
-use super::dumper::{self, Config};
+use dump_syms::dumper::{self, Config};
 
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum Action<'a> {
     Dump(Config<'a>),
     ListArch,
@@ -82,9 +83,8 @@ mod tests {
         copy(basic64, &tmp_file).unwrap();
 
         let action = Action::Dump(Config {
-            output: tmp_out.to_str().unwrap(),
+            output: tmp_out.clone().into(),
             symbol_server: None,
-            store: None,
             debug_id: None,
             code_id: None,
             arch: common::get_compile_time_arch(),
@@ -116,9 +116,8 @@ mod tests {
         copy(basic64, &tmp_file).unwrap();
 
         let action = Action::Dump(Config {
-            output: tmp_out.to_str().unwrap(),
+            output: tmp_out.into(),
             symbol_server: None,
-            store: None,
             debug_id: None,
             code_id: None,
             arch: common::get_compile_time_arch(),
@@ -148,9 +147,8 @@ mod tests {
         copy(basic64_dll, &tmp_dll).unwrap();
 
         let action = Action::Dump(Config {
-            output: tmp_out.to_str().unwrap(),
+            output: tmp_out.clone().into(),
             symbol_server: None,
-            store: None,
             debug_id: None,
             code_id: None,
             arch: common::get_compile_time_arch(),
@@ -179,9 +177,8 @@ mod tests {
         let tmp_out = tmp_dir.path().join("output.sym");
 
         let action = Action::Dump(Config {
-            output: tmp_out.to_str().unwrap(),
+            output: tmp_out.clone().into(),
             symbol_server: None,
-            store: None,
             debug_id: None,
             code_id: None,
             arch: common::get_compile_time_arch(),
@@ -214,9 +211,8 @@ mod tests {
         let tmp_out = tmp_dir.path().join("output.sym");
 
         let action = Action::Dump(Config {
-            output: tmp_out.to_str().unwrap(),
+            output: tmp_out.clone().into(),
             symbol_server: None,
-            store: None,
             debug_id: None,
             code_id: None,
             arch: common::get_compile_time_arch(),
@@ -256,9 +252,8 @@ mod tests {
         let tmp_out = tmp_dir.path().join("output.sym");
 
         let action = Action::Dump(Config {
-            output: tmp_out.to_str().unwrap(),
+            output: tmp_out.clone().into(),
             symbol_server: None,
-            store: None,
             debug_id: None,
             code_id: None,
             arch: common::get_compile_time_arch(),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -148,30 +148,6 @@ fn copy_in_cache(path: Option<PathBuf>, data: &[u8]) -> bool {
     true
 }
 
-fn get_base(file_name: &str) -> PathBuf {
-    // The file is stored at cache/xul.pdb/DEBUG_ID/xul.pd_
-    // the xul.pdb represents the base
-    let path = PathBuf::from(file_name);
-    if let Some(e) = path.extension() {
-        let e = e.to_str().unwrap().to_lowercase();
-        match e.as_str() {
-            "pd_" => path.with_extension("pdb"),
-            "ex_" => path.with_extension("exe"),
-            "dl_" => path.with_extension("dll"),
-            _ => path.clone(),
-        }
-    } else {
-        path.clone()
-    }
-}
-
-pub fn get_path_for_sym(file_name: &str, id: &str) -> PathBuf {
-    let base = get_base(file_name);
-    let file_name = PathBuf::from(file_name);
-    let file_name = file_name.with_extension("sym");
-    base.join(id).join(file_name)
-}
-
 fn search_in_cache(
     servers: &[SymbolServer],
     id: &str,
@@ -293,7 +269,7 @@ pub fn search_file(
         _ => return (None, file_name),
     };
 
-    let base = get_base(&file_name);
+    let base = utils::get_base(&file_name);
 
     // Start with the caches
     if let Some(path) = search_in_cache(servers, id, &base, &file_name) {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -33,9 +33,7 @@ struct Job {
 
 impl Job {
     fn new(cache: Option<PathBuf>, url: String) -> common::Result<Self> {
-        if Url::parse(&url).is_err() {
-            return Err(From::from(format!("Invalid url: {}", url)));
-        }
+        anyhow::ensure!(Url::parse(&url).is_ok(), "Invalid url: {}", url);
         Ok(Self { cache, url })
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,7 +12,7 @@ use symbolic::debuginfo::{peek, FileFormat};
 
 pub type Result<T> = result::Result<T, anyhow::Error>;
 
-pub(crate) enum FileType {
+pub enum FileType {
     Pdb,
     Pe,
     Elf,
@@ -21,7 +21,7 @@ pub(crate) enum FileType {
 }
 
 impl FileType {
-    pub(crate) fn from_buf(buf: &[u8]) -> Self {
+    pub fn from_buf(buf: &[u8]) -> Self {
         match peek(buf, true /* check for fat binary */) {
             FileFormat::Pdb => Self::Pdb,
             FileFormat::Pe => Self::Pe,
@@ -30,26 +30,30 @@ impl FileType {
             _ => Self::Unknown,
         }
     }
+}
 
-    pub(crate) fn from_str(s: &str) -> Self {
+impl std::str::FromStr for FileType {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let s = s.to_lowercase();
-        match s.as_str() {
+        Ok(match s.as_str() {
             "pdb" => Self::Pdb,
             "elf" => Self::Elf,
             "macho" => Self::Macho,
             _ => Self::Unknown,
-        }
+        })
     }
 }
 
-pub(crate) trait Dumpable {
+pub trait Dumpable {
     fn dump<W: Write>(&self, writer: W) -> Result<()>;
     fn get_name(&self) -> &str;
     fn get_debug_id(&self) -> &str;
     fn has_stack(&self) -> bool;
 }
 
-pub(crate) trait Mergeable {
+pub trait Mergeable {
     fn merge(left: Self, right: Self) -> Result<Self>
     where
         Self: Sized;
@@ -59,7 +63,7 @@ pub(crate) trait LineFinalizer<M> {
     fn finalize(&mut self, sym_rva: u32, sym_len: u32, map: &M);
 }
 
-pub(crate) fn get_compile_time_arch() -> &'static str {
+pub fn get_compile_time_arch() -> &'static str {
     use Arch::*;
 
     match ARCH {
@@ -82,7 +86,7 @@ pub(crate) fn normalize_anonymous_namespace(text: &str) -> String {
 }
 
 pub(crate) fn fix_symbol_name<'a>(name: &'a Name<'a>) -> Name<'a> {
-    lazy_static! {
+    lazy_static::lazy_static! {
         static ref LLVM_NNN: Regex = Regex::new(r"\.llvm\.[0-9]+$").unwrap();
     }
     let fixed = LLVM_NNN.replace(name.as_str(), "");

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,14 +5,12 @@
 
 use regex::Regex;
 use std::env::consts::ARCH;
-use std::error;
 use std::io::Write;
 use std::result;
 use symbolic::common::{Arch, Name};
 use symbolic::debuginfo::{peek, FileFormat};
 
-type Error = Box<dyn error::Error + std::marker::Send + std::marker::Sync>;
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T> = result::Result<T, anyhow::Error>;
 
 pub(crate) enum FileType {
     Pdb,

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -4,7 +4,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use crossbeam::channel::{bounded, Receiver, Sender};
-use failure::Fail;
 use hashbrown::HashMap;
 use log::{error, info};
 use std::fs;
@@ -56,7 +55,7 @@ pub(crate) trait Creator: Mergeable + Dumpable + Sized {
         _filename: &str,
         _mapping: Option<Arc<PathMappings>>,
     ) -> common::Result<Self> {
-        Err("Not implemented".into())
+        anyhow::bail!("Not implemented")
     }
 }
 
@@ -124,7 +123,7 @@ impl Creator for PEInfo {
         _filename: &str,
         _mapping: Option<Arc<PathMappings>>,
     ) -> common::Result<Self> {
-        Err("Not implemented".into())
+        anyhow::bail!("Not implemented")
     }
 
     fn get_pe<'a>(
@@ -188,7 +187,7 @@ fn get_from_id(
         return if let Some(buf) = buf {
             Ok((buf, filename))
         } else {
-            Err(format!("Impossible to get file {} with id {}", filename, id).into())
+            anyhow::bail!("Impossible to get file {} with id {}", filename, id)
         };
     }
 
@@ -240,7 +239,7 @@ pub(crate) fn single_file(config: &Config, filename: &str) -> common::Result<()>
             config.check_cfi,
             MachoInfo::get_dbg(arch, &buf, path, &filename, file_mapping)?,
         ),
-        FileType::Unknown => Err("Unknown file format".into()),
+        FileType::Unknown => anyhow::bail!("Unknown file format"),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,15 @@
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[cfg(feature = "http")]
+pub mod cache;
+pub mod common;
+pub mod dumper;
+mod line;
+pub mod linux;
+pub mod mac;
+pub mod mapping;
+pub mod utils;
+pub mod windows;

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -112,7 +112,7 @@ impl PathMappingGenerator {
                 } else if let Ok(group) = action.parse::<usize>() {
                     ActionKind::Group(group)
                 } else {
-                    return Err(format!("Invalid action {} in mapping string", action).into());
+                    anyhow::bail!("Invalid action {} in mapping string", action);
                 };
                 actions.push(Action {
                     kind: action,
@@ -211,9 +211,7 @@ impl PathMappings {
         if let Some(vars) = vars {
             for var in vars {
                 let pair = var.splitn(2, '=').collect::<Vec<_>>();
-                if pair.len() != 2 {
-                    return Err(format!("Invalid pair {}: must be var=value", var).into());
-                }
+                anyhow::ensure!(pair.len() == 2, "Invalid pair {}: must be var=value", var);
                 variables.insert(pair[0].to_string(), pair[1].to_string());
             }
         }
@@ -230,11 +228,10 @@ impl PathMappings {
             return Ok(());
         }
 
-        if sources.as_ref().map_or(0, |v| v.len()) != destinations.as_ref().map_or(0, |v| v.len()) {
-            return Err(
-                "mapping-src and mapping-dest must have the same number of elements".into(),
-            );
-        }
+        anyhow::ensure!(
+            sources.as_ref().map_or(0, |v| v.len()) == destinations.as_ref().map_or(0, |v| v.len()),
+            "mapping-src and mapping-dest must have the same number of elements"
+        );
 
         let sources = sources.as_ref().unwrap();
         let destinations = destinations.as_ref().unwrap();

--- a/src/windows/pdb.rs
+++ b/src/windows/pdb.rs
@@ -3,7 +3,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use failure::Fail;
 use hashbrown::HashSet;
 use pdb::{
     AddressMap, BlockSymbol, DebugInformation, FallibleIterator, MachineType, ModuleInfo,
@@ -259,10 +258,7 @@ fn get_stack_info(pdb_buf: Option<&[u8]>, pe: Option<PeObject>) -> String {
     let mut cfi_writer = AsciiCfiWriter::new(writer);
     if let Some(pe) = pe {
         if pe.has_unwind_info() {
-            cfi_writer
-                .process(&Object::Pe(pe))
-                .map_err(|e| e.compat())
-                .unwrap();
+            cfi_writer.process(&Object::Pe(pe)).unwrap();
             found_unwind_info = true;
         }
     }
@@ -271,10 +267,7 @@ fn get_stack_info(pdb_buf: Option<&[u8]>, pe: Option<PeObject>) -> String {
         if let Some(pdb_buf) = pdb_buf {
             if let Ok(pdb) = PdbObject::parse(pdb_buf) {
                 if pdb.has_unwind_info() {
-                    cfi_writer
-                        .process(&Object::Pdb(pdb))
-                        .map_err(|e| e.compat())
-                        .unwrap();
+                    cfi_writer.process(&Object::Pdb(pdb)).unwrap();
                 }
             }
         }
@@ -585,7 +578,7 @@ impl Dumpable for PDBInfo {
 
 impl Mergeable for PDBInfo {
     fn merge(_left: PDBInfo, _right: PDBInfo) -> common::Result<PDBInfo> {
-        Err("PDB merge not implemented".into())
+        anyhow::bail!("PDB merge not implemented")
     }
 }
 
@@ -686,7 +679,7 @@ impl Dumpable for PEInfo {
 
 impl Mergeable for PEInfo {
     fn merge(_left: PEInfo, _right: PEInfo) -> common::Result<PEInfo> {
-        Err("PE merge not implemented".into())
+        anyhow::bail!("PE merge not implemented")
     }
 }
 

--- a/src/windows/pdb.rs
+++ b/src/windows/pdb.rs
@@ -190,7 +190,7 @@ impl Collector {
     }
 }
 
-pub(crate) struct PDBInfo {
+pub struct PDBInfo {
     symbols: PDBSymbols,
     files: Vec<String>,
     cpu: Cpu,

--- a/src/windows/utils.rs
+++ b/src/windows/utils.rs
@@ -3,15 +3,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use log::warn;
 use std::path::Path;
 use symbolic::debuginfo::pe::PeObject;
 use uuid::Uuid;
 
+#[cfg(feature = "http")]
 use crate::cache::{self, SymbolServer};
 use crate::utils;
 use crate::windows::pdb::PDBInfo;
 
+#[cfg(feature = "http")]
 fn try_to_find_pdb(path: &Path, pdb_filename: &str) -> Option<Vec<u8>> {
     // Just check that the file is in the same directory as the PE one
     let pdb = path.with_file_name(pdb_filename);
@@ -34,6 +35,7 @@ fn try_to_find_pdb(path: &Path, pdb_filename: &str) -> Option<Vec<u8>> {
     None
 }
 
+#[cfg(feature = "http")]
 fn os_specific_try_to_find_pdb(path: &Path, pdb_filename: &str) -> (Option<Vec<u8>>, String) {
     // We may have gotten either an OS native path, or a Windows path.
     // On Windows, they're both the same. On Unix, they are different, and in that case,
@@ -54,6 +56,7 @@ fn os_specific_try_to_find_pdb(path: &Path, pdb_filename: &str) -> (Option<Vec<u
     }
 }
 
+#[cfg(feature = "http")]
 pub fn get_pe_pdb_buf<'a>(
     path: &Path,
     buf: &'a [u8],
@@ -65,7 +68,7 @@ pub fn get_pe_pdb_buf<'a>(
         let pdb_filename = pdb_filename.into_owned();
         let (pdb, pdb_name) = os_specific_try_to_find_pdb(path, &pdb_filename);
         if pdb_name.is_empty() {
-            warn!("Invalid pdb filename in PE file: \"{}\"", pdb_filename);
+            log::warn!("Invalid pdb filename in PE file: \"{}\"", pdb_filename);
             None
         } else if let Some(pdb_buf) = pdb {
             Some((pe, pdb_buf, pdb_name))


### PR DESCRIPTION
This PR makes changes so that this crate it can be used as a library (eg https://github.com/rust-minidump/minidump-writer/pull/21#discussion_r861912364).

- Replaced `failure` with `anyhow`. `failure` has been [unmaintained](https://rustsec.org/advisories/RUSTSEC-2020-0036.html) for several years, `anyhow` is one of the maintained alternatives. This change is intended as temporary, as IMO the errors in this crate should use `thiserror`, or just manually defined errors, as it makes library usage easier by not using string errors for everything, but made sense for a binary application.
- Places `clap` and `simplelog` behind a `cli` feature flag, these dependencies are only used when used as a binary, crates that depend on this as a library don't need them and thus should not compile them. To preserve backwards compatibility for `cargo install` this feature is made default, so library users will need to explicitly opt-out.
- Places HTTP symbol retrieval behind the `http` feature. This removes several heavy dependencies only used for retrieving symbols from remote symbol stores, in the use case that motivated this PR linked above, this functionality is not needed and only adds compile time for no benefit. Again, this feature is enabled by default for backwards compatibility.
- Replaces `reqwest`'s use of native-tls with `rustls`, simplifying the build when `http` is enabled. I frankly despise OpenSSL and all of the aggravating problems that come with it, `rustls` is a drop-in replacement that completely avoids all of those aggravations. This change is obviously due to my personal bias, I can back it out if requested.

Resolves: #253