### PR TITLE
Fix filenames in store

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,8 +63,7 @@ pub fn get_path_for_sym(file_name: &str, id: &str) -> PathBuf {
     let mut pb = get_base(file_name);
 
     pb.push(id);
-    pb.push(file_name);
-    pb.set_extension("sym");
+    pb.push(format!("{file_name}.sym"));
 
     pb
 }


### PR DESCRIPTION
`PathBuf::set_extension` replaces the path's current extension if it already has one, so dump_syms would previously end up writing to e.g. `libc.so.sym` rather than `libc.so.6.sym`.