### PR TITLE
Add support for --inlines for mach-O and ELF

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -95,6 +95,7 @@ mod tests {
             mapping_dest: None,
             mapping_file: None,
             check_cfi: false,
+            emit_inlines: false,
         });
 
         action.action(&[tmp_file.to_str().unwrap()]).unwrap();
@@ -128,6 +129,7 @@ mod tests {
             mapping_dest: None,
             mapping_file: None,
             check_cfi: true,
+            emit_inlines: false,
         });
 
         let res = action.action(&[tmp_file.to_str().unwrap()]);
@@ -159,6 +161,7 @@ mod tests {
             mapping_dest: None,
             mapping_file: None,
             check_cfi: false,
+            emit_inlines: false,
         });
 
         action.action(&[tmp_pdb.to_str().unwrap()]).unwrap();
@@ -189,6 +192,7 @@ mod tests {
             mapping_dest: None,
             mapping_file: None,
             check_cfi: false,
+            emit_inlines: false,
         });
 
         action.action(&[full.to_str().unwrap()]).unwrap();
@@ -223,6 +227,7 @@ mod tests {
             mapping_dest: None,
             mapping_file: None,
             check_cfi: false,
+            emit_inlines: false,
         });
 
         action
@@ -264,6 +269,7 @@ mod tests {
             mapping_dest: None,
             mapping_file: None,
             check_cfi: false,
+            emit_inlines: false,
         });
 
         action

--- a/src/action.rs
+++ b/src/action.rs
@@ -208,6 +208,40 @@ mod tests {
     }
 
     #[test]
+    fn test_elf_full_with_inlines() {
+        let tmp_dir = Builder::new().prefix("full").tempdir().unwrap();
+        let full = PathBuf::from("./test_data/linux/basic.full");
+        let tmp_out = tmp_dir.path().join("output.sym");
+
+        let action = Action::Dump(Config {
+            output: tmp_out.clone().into(),
+            symbol_server: None,
+            debug_id: None,
+            code_id: None,
+            arch: common::get_compile_time_arch(),
+            file_type: FileType::Elf,
+            num_jobs: 1,
+            mapping_var: None,
+            mapping_src: None,
+            mapping_dest: None,
+            mapping_file: None,
+            check_cfi: false,
+            emit_inlines: true,
+        });
+
+        action.action(&[full.to_str().unwrap()]).unwrap();
+
+        let data = read(tmp_out).unwrap();
+        let new: Vec<_> = data.split(|c| *c == b'\n').skip(1).collect();
+
+        let basic = PathBuf::from("./test_data/linux/basic.full.inlines.sym");
+        let data = read(basic).unwrap();
+        let basic: Vec<_> = data.split(|c| *c == b'\n').skip(1).collect();
+
+        assert_eq!(basic, new);
+    }
+
+    #[test]
     fn test_elf_stripped_dbg() {
         let tmp_dir = Builder::new().prefix("stripped_dbg").tempdir().unwrap();
         let stripped = PathBuf::from("./test_data/linux/basic.stripped");

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -81,6 +81,7 @@ pub struct Config<'a> {
     pub file_type: FileType,
     pub num_jobs: usize,
     pub check_cfi: bool,
+    pub emit_inlines: bool,
     pub mapping_var: Option<Vec<&'a str>>,
     pub mapping_src: Option<Vec<&'a str>>,
     pub mapping_dest: Option<Vec<&'a str>>,

--- a/src/inline_origins.rs
+++ b/src/inline_origins.rs
@@ -1,0 +1,71 @@
+use log::warn;
+use symbolic::common::{Language, Name};
+use symbolic::demangle::{Demangle, DemangleOptions};
+
+use std::collections::HashMap;
+
+use crate::common;
+
+#[derive(Debug, Default)]
+pub struct InlineOrigins<'a> {
+    demangled_names: Vec<String>,
+    index_for_mangled_name: HashMap<Name<'a>, u32>,
+}
+
+impl<'a> InlineOrigins<'a> {
+    pub fn get_id(&mut self, name: &Name<'a>) -> u32 {
+        if let Some(index) = self.index_for_mangled_name.get(name) {
+            return *index;
+        }
+
+        let s = Self::demangle(name);
+        let index = self.demangled_names.len() as u32;
+        self.demangled_names.push(s);
+        self.index_for_mangled_name.insert(name.clone(), index);
+        index
+    }
+
+    pub fn get_list(self) -> Vec<String> {
+        self.demangled_names
+    }
+
+    fn demangle(name: &Name) -> String {
+        let name = common::fix_symbol_name(name);
+        if let Language::C = name.language() {
+            return name.as_str().to_string();
+        }
+
+        match name.demangle(DemangleOptions::complete()) {
+            Some(demangled) => demangled,
+            None => {
+                let aname = name.as_str();
+                warn!("Didn't manage to demangle {:?}", name);
+                aname.to_string()
+            }
+        }
+    }
+}
+
+/// Adds all inline origins from `right` into `left`, and returns
+/// a Vec which maps the IDs from right into the IDs in left.
+pub fn merge_inline_origins(left: &mut Vec<String>, right: Vec<String>) -> Vec<u32> {
+    // Merging is a bit of a silly business. This is used when we feed both a binary
+    // and a debug file into dump_syms. In this case, the debug file has all the
+    // information about inlines, and the binary file has none of the information about
+    // inlines.
+    // So we only need to care about the case where either `right` or `left` is empty.
+    // The other case is a theoretical possibility but doesn't need to be good or fast.
+    if right.is_empty() {
+        return Vec::new();
+    }
+    if left.is_empty() {
+        let count = right.len() as u32;
+        *left = right;
+        return (0..count).collect();
+    }
+    // Just append the two vecs to each other. We don't bother with deduplication.
+    let count = right.len() as u32;
+    let offset = left.len() as u32;
+    left.extend(right.into_iter());
+    (offset..(offset + count)).collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod cache;
 pub mod common;
 pub mod dumper;
+pub mod inline_origins;
 mod line;
 pub mod linux;
 pub mod mac;

--- a/src/line.rs
+++ b/src/line.rs
@@ -3,7 +3,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::fmt::{self, Debug, Display, Formatter};
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Debug, Display, Formatter},
+};
 
 #[derive(Clone, Default)]
 pub(crate) struct Line {
@@ -28,25 +31,117 @@ impl Debug for Line {
     }
 }
 
+/// Represents an inlined function call.
+#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct InlineSite {
+    /// The identifier of the function name, as an index into InlineOrigins.
+    pub(crate) inline_origin_id: u32,
+    /// The call depth of this call. Calls from the outer function have
+    /// depth 0, calls inside an inline function of depth N have depth N + 1.
+    pub(crate) call_depth: u32,
+    /// The line number of the call in the parent function.
+    pub(crate) call_line_number: u32,
+    /// The filename of the call in the parent function.
+    pub(crate) call_file_id: u32,
+}
+
+impl Debug for InlineSite {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "InlineSite {{ inline_origin_id: {}, call_depth: {}, call_line_number: {}, call_file_id: {} }}",
+            self.inline_origin_id, self.call_depth, self.call_line_number, self.call_file_id
+        )
+    }
+}
+
+/// Represents a contiguous slice of instructions (i.e. an rva range)
+/// for an inlined function call.
+#[derive(Clone, Default)]
+pub(crate) struct InlineAddressRange {
+    /// rva stands for relative virtual address
+    pub(crate) rva: u32,
+    /// Length in bytes
+    pub(crate) len: u32,
+}
+
+impl Debug for InlineAddressRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "InlineAddressRange {{ rva: {:x}, len: {:x} }}",
+            self.rva, self.len
+        )
+    }
+}
+
+/// Information about the instructions of a single function in the binary.
+///
+/// This information allows mapping an instruction address to information about the
+/// source code which generated this instruction, specifically to the source
+/// file and line number, and to the inline stack at each address (with file + line
+/// at each level of inlining).
+// TODO: Consider renaming this struct to FunctionDebugInfo
 #[derive(Clone, Debug, Default)]
 pub struct Lines {
-    // The lines
+    /// The line records.
+    ///
+    /// If inline information is available, then the line records carry the file/line
+    /// at the inline "leaf", i.e. at the deepest level of the inline stack at that
+    /// location.
+    ///
+    /// If no inline information is available, then the line records are about the
+    /// outermost level (i.e. they describe locations in the outer function).
     pub(crate) lines: Vec<Line>,
+    /// The inline records, if available.
+    pub(crate) inlines: BTreeMap<InlineSite, Vec<InlineAddressRange>>,
     // Each time we insert a new line we check
     // that its rva is greater than the previous one.
-    // If is_sorted is false before finalizing data, we'll sort them.
-    pub(crate) is_sorted: bool,
-    pub(crate) last_rva: u32,
+    // If are_lines_sorted is false before finalizing data, we'll sort them.
+    pub(crate) are_lines_sorted: bool,
+    /// The rva of the most-recently-added line record, for sortedness detection.
+    pub(crate) last_line_rva: u32,
+}
+
+fn write_inline_record(
+    site: &InlineSite,
+    ranges: &[InlineAddressRange],
+    f: &mut Formatter<'_>,
+) -> fmt::Result {
+    // INLINE <inline_nest_level> <call_site_line> <call_site_file_id> <origin_id> [<address> <size>]+
+    write!(
+        f,
+        "INLINE {} {} {} {}",
+        site.call_depth, site.call_line_number, site.call_file_id, site.inline_origin_id,
+    )?;
+    for range in ranges {
+        write!(f, " {:x} {:x}", range.rva, range.len)?;
+    }
+    writeln!(f)
+}
+
+fn write_line_record(line: &Line, f: &mut Formatter<'_>) -> fmt::Result {
+    writeln!(
+        f,
+        "{:x} {:x} {} {}",
+        line.rva, line.len, line.num, line.file_id
+    )
 }
 
 impl Display for Lines {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        for line in self.lines.iter() {
-            writeln!(
-                f,
-                "{:x} {:x} {} {}",
-                line.rva, line.len, line.num, line.file_id
-            )?;
+        // Write out all inline records first, and then all line records.
+
+        // Sort the inlines by the first range's rva and by call depth.
+        let mut inlines: Vec<(&_, &_)> = self.inlines.iter().collect();
+        inlines.sort_by_key(|(site, ranges)| (ranges.first().unwrap().rva, site.call_depth));
+        for (site, ranges) in inlines {
+            write_inline_record(site, ranges, f)?;
+        }
+
+        // Write out the line records.
+        for line in &self.lines {
+            write_line_record(line, f)?;
         }
         Ok(())
     }
@@ -56,8 +151,9 @@ impl Lines {
     pub(crate) fn new() -> Self {
         Self {
             lines: Vec::new(),
-            is_sorted: true,
-            last_rva: 0,
+            inlines: BTreeMap::new(),
+            are_lines_sorted: true,
+            last_line_rva: 0,
         }
     }
 
@@ -71,8 +167,15 @@ impl Lines {
 
         // There are no guarantee that the rva are sorted
         // So we check each time we push an element and we'll sort if it's required
-        self.is_sorted = self.is_sorted && self.last_rva <= rva;
-        self.last_rva = rva;
+        self.are_lines_sorted = self.are_lines_sorted && self.last_line_rva <= rva;
+        self.last_line_rva = rva;
+    }
+
+    pub(crate) fn add_inline(&mut self, site: InlineSite, address_range: InlineAddressRange) {
+        self.inlines
+            .entry(site)
+            .or_insert_with(|| Vec::with_capacity(1))
+            .push(address_range);
     }
 
     pub(crate) fn compute_len(&mut self, sym_rva: u32, sym_len: u32) {
@@ -87,10 +190,10 @@ impl Lines {
             return;
         }
 
-        // If the rva aren't ordered we need to sort the lines
-        if !self.is_sorted {
-            self.lines.sort_by_key(|x| x.rva);
-        }
+        assert!(
+            self.are_lines_sorted,
+            "Call ensure_order() before calling compute_len()"
+        );
 
         let lens: Vec<u32> = self.lines.windows(2).map(|w| w[1].rva - w[0].rva).collect();
 
@@ -103,6 +206,31 @@ impl Lines {
             .for_each(|(line, len)| line.len = *len);
 
         last.len = sym_len - (last.rva - sym_rva);
+    }
+
+    /// Makes sure that `self.lines` and `self.inlines` are sorted.
+    ///
+    /// Must be called before invoking the `Display` implementation and
+    /// before calling `compute_len`.
+    pub(crate) fn ensure_order(&mut self) {
+        if !self.are_lines_sorted {
+            // Sort the lines.
+            self.lines.sort_by_key(|x| x.rva);
+            self.are_lines_sorted = true;
+        }
+
+        // Sort the address ranges of each inline site and merge adjacent ranges.
+        for ranges in self.inlines.values_mut() {
+            ranges.sort_by_key(|range| range.rva);
+            ranges.dedup_by(|next, current| {
+                if current.rva.checked_add(current.len) == Some(next.rva) {
+                    current.len += next.len;
+                    true
+                } else {
+                    false
+                }
+            })
+        }
     }
 
     fn find_lines_for_range(&self, rva: u32, len: u32) -> Lines {
@@ -118,8 +246,24 @@ impl Lines {
                     }
                 })
                 .collect(),
-            is_sorted: true,
-            last_rva: 0,
+            inlines: self
+                .inlines
+                .iter()
+                .filter_map(|(site, ranges)| {
+                    let filtered_ranges: Vec<InlineAddressRange> = ranges
+                        .iter()
+                        .filter(|range| rva <= range.rva && range.rva + range.len <= rva + len)
+                        .cloned()
+                        .collect();
+                    if !filtered_ranges.is_empty() {
+                        Some((site.clone(), filtered_ranges))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            are_lines_sorted: true,
+            last_line_rva: 0,
         }
     }
 

--- a/src/linux/elf.rs
+++ b/src/linux/elf.rs
@@ -87,8 +87,9 @@ impl Display for ElfInfo {
 // - lines: each range is mapped to a set of lines, for any reason a range can be mapped with a line which is out of range
 //   when the line address is an inlinee address, line info gives us the "calling" location
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Collector {
+    collect_inlines: bool,
     syms: ElfSymbols,
 }
 
@@ -272,9 +273,10 @@ impl ElfInfo {
         file_name: &str,
         platform: Platform,
         mapping: Option<Arc<PathMappings>>,
+        collect_inlines: bool,
     ) -> common::Result<Self> {
         let o = Object::parse(buf)?;
-        Self::from_object(&o, file_name, platform, mapping)
+        Self::from_object(&o, file_name, platform, mapping, collect_inlines)
     }
 
     pub fn from_object(
@@ -282,8 +284,12 @@ impl ElfInfo {
         file_name: &str,
         platform: Platform,
         mapping: Option<Arc<PathMappings>>,
+        collect_inlines: bool,
     ) -> common::Result<Self> {
-        let mut collector = Collector::default();
+        let mut collector = Collector {
+            collect_inlines,
+            syms: ElfSymbols::default(),
+        };
         let mut source = SourceFiles::new(mapping);
         let debug_id = format!("{}", o.debug_id().breakpad());
         let code_id = o.code_id().map(|c| c.as_str().to_string().to_uppercase());

--- a/src/linux/lines.rs
+++ b/src/linux/lines.rs
@@ -8,6 +8,7 @@ use crate::line::Lines;
 
 impl LineFinalizer<()> for Lines {
     fn finalize(&mut self, sym_rva: u32, sym_len: u32, _map: &()) {
+        self.ensure_order();
         self.compute_len(sym_rva, sym_len);
     }
 }

--- a/src/mac/macho.rs
+++ b/src/mac/macho.rs
@@ -30,6 +30,7 @@ impl MachoInfo {
         file_name: &str,
         arch: Arch,
         mapping: Option<Arc<PathMappings>>,
+        collect_inlines: bool,
     ) -> common::Result<Self> {
         // Fat files may contain several objects for different architectures
         // So if there is only one object, then we don't care about the arch (as argument)
@@ -46,7 +47,13 @@ impl MachoInfo {
 
         if let Some(object) = object {
             Ok(Self {
-                elf: ElfInfo::from_object(&object, file_name, Platform::Mac, mapping)?,
+                elf: ElfInfo::from_object(
+                    &object,
+                    file_name,
+                    Platform::Mac,
+                    mapping,
+                    collect_inlines,
+                )?,
             })
         } else {
             anyhow::bail!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,11 @@ For example with --mapping-var="rev=123abc" --mapping-src="/foo/bar/(.*)" --mapp
                 .long("mapping-file")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("inlines")
+                .help("Whether to emit INLINE and INLINE_ORIGIN directives")
+                .long("inlines"),
+        )
         .get_matches();
 
     let verbosity = match matches.value_of("verbose").unwrap() {
@@ -179,6 +184,7 @@ For example with --mapping-var="rev=123abc" --mapping-src="/foo/bar/(.*)" --mapp
     let code_id = matches.value_of("code_id");
     let arch = matches.value_of("arch").unwrap();
     let check_cfi = matches.is_present("check_cfi");
+    let emit_inlines = matches.is_present("inlines");
     let mapping_var = matches
         .values_of("mapping_var")
         .map(|v| v.collect::<Vec<_>>());
@@ -237,6 +243,7 @@ For example with --mapping-var="rev=123abc" --mapping-src="/foo/bar/(.*)" --mapp
             file_type,
             num_jobs,
             check_cfi,
+            emit_inlines,
             mapping_var,
             mapping_src,
             mapping_dest,

--- a/src/windows/lines.rs
+++ b/src/windows/lines.rs
@@ -10,6 +10,7 @@ use pdb_addr2line::pdb;
 
 impl LineFinalizer<AddressMap<'_>> for Lines {
     fn finalize(&mut self, sym_rva: u32, sym_len: u32, address_map: &AddressMap) {
+        self.ensure_order();
         self.compute_len(sym_rva, sym_len);
 
         // the rva is the internal rva (needed to compute the length)

--- a/test_data/linux/basic.full.inlines.sym
+++ b/test_data/linux/basic.full.inlines.sym
@@ -1,0 +1,134 @@
+MODULE Linux x86_64 20AD60B0B4C68177552708AA192E77390 basic.full
+INFO CODE_ID B060AD20C6B47781552708AA192E7739FAC7C84A
+FILE 0 /home/calixte/dev/mozilla/dump_syms.calixteman/test_data/linux/basic.cpp
+INLINE_ORIGIN 0 inline_4(int)
+INLINE_ORIGIN 1 inline_3(int)
+INLINE_ORIGIN 2 inline_2(int)
+INLINE_ORIGIN 3 inline_1(int)
+PUBLIC 1000 0 _init
+PUBLIC 1020 0 <.plt ELF section in basic.full>
+PUBLIC 1030 0 <.plt.got ELF section in basic.full>
+PUBLIC 1040 0 _start
+PUBLIC 1070 0 deregister_tm_clones
+PUBLIC 10a0 0 register_tm_clones
+PUBLIC 10e0 0 __do_global_dtors_aux
+PUBLIC 1120 0 frame_dummy
+FUNC 1125 26 0 inline_1(int)
+1125 7 2 0
+112c 9 3 0
+1135 11 4 0
+1146 3 5 0
+1149 2 6 0
+FUNC 114b 2c 0 inline_2(int)
+INLINE 0 10 0 3 1158 1d
+114b d 9 0
+1158 9 3 0
+1161 11 4 0
+1172 3 5 0
+1175 2 11 0
+FUNC 1177 33 0 inline_3(int)
+INLINE 0 15 0 2 118a 1e
+INLINE 1 10 0 3 118a 1d
+1177 13 14 0
+118a 9 3 0
+1193 11 4 0
+11a4 3 5 0
+11a7 1 10 0
+11a8 2 16 0
+FUNC 11aa 3a 0 inline_4(int)
+INLINE 0 20 0 1 11c3 1f
+INLINE 1 15 0 2 11c3 1e
+INLINE 2 10 0 3 11c3 1d
+11aa 19 19 0
+11c3 9 3 0
+11cc 11 4 0
+11dd 3 5 0
+11e0 1 10 0
+11e1 1 15 0
+11e2 2 21 0
+FUNC 11e4 d9 0 foo(int)
+INLINE 0 26 0 0 120e 20
+INLINE 1 20 0 1 120e 1f 1265 1f
+INLINE 2 15 0 2 120e 1e 1265 1e
+INLINE 3 10 0 3 120e 1d 1265 1d
+INLINE 0 29 0 0 1265 20
+INLINE 0 29 0 2 1292 1e
+INLINE 1 10 0 3 1292 1d
+11e4 7 24 0
+11eb 9 25 0
+11f4 1a 26 0
+120e 9 3 0
+1217 11 4 0
+1228 3 5 0
+122b 1 10 0
+122c 1 15 0
+122d 1 20 0
+122e 3 26 0
+1231 d 27 0
+123e c 28 0
+124a 1b 29 0
+1265 9 3 0
+126e 11 4 0
+127f 3 5 0
+1282 1 10 0
+1283 1 15 0
+1284 1 20 0
+1285 d 29 0
+1292 9 3 0
+129b 11 4 0
+12ac 3 5 0
+12af 1 10 0
+12b0 3 29 0
+12b3 8 31 0
+12bb 2 32 0
+FUNC 12bd 1c 0 main
+12bd f 35 0
+12cc b 36 0
+12d7 2 37 0
+PUBLIC 12e0 0 __libc_csu_init
+PUBLIC 1340 0 __libc_csu_fini
+PUBLIC 1344 0 _fini
+STACK CFI INIT 1040 2b .cfa: $rsp 8 +
+STACK CFI INIT 1020 10 .cfa: $rsp 16 + .ra: .cfa -8 + ^
+STACK CFI 1026 .cfa: $rsp 24 +
+STACK CFI INIT 1030 8 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI INIT 1125 26 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI 1126 .cfa: $rsp 16 + $rbp: .cfa -16 + ^
+STACK CFI 1129 .cfa: $rbp 16 +
+STACK CFI 114a .cfa: $rsp 8 +
+STACK CFI INIT 114b 2c .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI 114c .cfa: $rsp 16 + $rbp: .cfa -16 + ^
+STACK CFI 114f .cfa: $rbp 16 +
+STACK CFI 1176 .cfa: $rsp 8 +
+STACK CFI INIT 1177 33 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI 1178 .cfa: $rsp 16 + $rbp: .cfa -16 + ^
+STACK CFI 117b .cfa: $rbp 16 +
+STACK CFI 11a9 .cfa: $rsp 8 +
+STACK CFI INIT 11aa 3a .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI 11ab .cfa: $rsp 16 + $rbp: .cfa -16 + ^
+STACK CFI 11ae .cfa: $rbp 16 +
+STACK CFI 11e3 .cfa: $rsp 8 +
+STACK CFI INIT 11e4 d9 .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI 11e5 .cfa: $rsp 16 + $rbp: .cfa -16 + ^
+STACK CFI 11e8 .cfa: $rbp 16 +
+STACK CFI 12bc .cfa: $rsp 8 +
+STACK CFI INIT 12bd 1c .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI 12be .cfa: $rsp 16 + $rbp: .cfa -16 + ^
+STACK CFI 12c1 .cfa: $rbp 16 +
+STACK CFI 12d8 .cfa: $rsp 8 +
+STACK CFI INIT 12e0 5d .cfa: $rsp 8 + .ra: .cfa -8 + ^
+STACK CFI 12e2 .cfa: $rsp 16 + $r15: .cfa -16 + ^
+STACK CFI 12eb .cfa: $rsp 24 + $r14: .cfa -24 + ^
+STACK CFI 12f0 .cfa: $rsp 32 + $r13: .cfa -32 + ^
+STACK CFI 12f5 .cfa: $rsp 40 + $r12: .cfa -40 + ^
+STACK CFI 12f9 .cfa: $rsp 48 + $rbp: .cfa -48 + ^
+STACK CFI 1301 .cfa: $rsp 56 + $rbx: .cfa -56 + ^
+STACK CFI 1308 .cfa: $rsp 64 +
+STACK CFI 1332 .cfa: $rsp 56 +
+STACK CFI 1333 .cfa: $rsp 48 +
+STACK CFI 1334 .cfa: $rsp 40 +
+STACK CFI 1336 .cfa: $rsp 32 +
+STACK CFI 1338 .cfa: $rsp 24 +
+STACK CFI 133a .cfa: $rsp 16 +
+STACK CFI 133c .cfa: $rsp 8 +
+STACK CFI INIT 1340 1 .cfa: $rsp 8 + .ra: .cfa -8 + ^


### PR DESCRIPTION
Partially implements #280.

This PR adds a command line argument called `--inlines`. When specified, if dump_syms is run on an ELF or a mach-O file with DWARF information, it now includes "INLINE_ORIGIN" and "INLINE" directives.

I am grouping all INLINE_ORIGIN lines at the start of the file, because that's the most straightforward thing to do with the current setup, because dump_syms currently reads everything into memory first, sorts it, and then emits it. In the future it may make sense to switch to a streaming architecture, for better performance.

There are cases where we're producing slightly incorrect inline information, this is due to https://github.com/getsentry/symbolic/issues/603.

For PDBs, the best plan forward is probably to switch to [`ObjectDebugSession`](https://docs.rs/symbolic-debuginfo/latest/symbolic_debuginfo/enum.ObjectDebugSession.html) for PDBs as well, and just use the same code as for ELF / mach-O. This might require some work in symbolic-debuginfo.