### PR TITLE
Update pdb-addr2line and pdb with it.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
- "uuid 1.1.2",
+ "uuid",
 ]
 
 [[package]]
@@ -350,7 +350,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "url",
- "uuid 1.1.2",
+ "uuid",
 ]
 
 [[package]]
@@ -567,7 +567,7 @@ checksum = "c955ab4e0ad8c843ea653a3d143048b87490d9be56bd7132a435c2407846ac8f"
 dependencies = [
  "log",
  "plain",
- "scroll 0.11.0",
+ "scroll",
 ]
 
 [[package]]
@@ -951,36 +951,25 @@ dependencies = [
 
 [[package]]
 name = "pdb"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f4d162ecaaa1467de5afbe62d597757b674b51da8bb4e587430c5fdb2af7aa"
-dependencies = [
- "fallible-iterator",
- "scroll 0.10.2",
- "uuid 0.8.2",
-]
-
-[[package]]
-name = "pdb"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82040a392923abe6279c00ab4aff62d5250d1c8555dc780e4b02783a7aa74863"
 dependencies = [
  "fallible-iterator",
- "scroll 0.11.0",
- "uuid 1.1.2",
+ "scroll",
+ "uuid",
 ]
 
 [[package]]
 name = "pdb-addr2line"
-version = "0.7.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add993687a36870ce51d6f0a21f4fb820881a450315f815e31ad257553a9707c"
+checksum = "a2c82a6b034a2783f14c46a113bdbe71832ffc64735484f5ee5cf5bd826efb4c"
 dependencies = [
  "bitflags",
  "elsa",
  "maybe-owned",
- "pdb 0.7.0",
+ "pdb",
  "range-collections",
  "thiserror",
 ]
@@ -1199,12 +1188,6 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
-
-[[package]]
-name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
@@ -1390,7 +1373,7 @@ dependencies = [
  "debugid",
  "memmap2",
  "stable_deref_trait",
- "uuid 1.1.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1411,9 +1394,9 @@ dependencies = [
  "nom",
  "nom-supreme",
  "parking_lot",
- "pdb 0.8.0",
+ "pdb",
  "regex",
- "scroll 0.11.0",
+ "scroll",
  "serde",
  "serde_json",
  "smallvec",
@@ -1674,12 +1657,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ hashbrown = { version = "0.11", features = ["serde"] }
 lazy_static = "1.4"
 log = "0.4"
 num_cpus = "1.13"
-pdb-addr2line = "0.7"
+pdb-addr2line = "0.9"
 regex = "1.4"
 reqwest = { version = "0.11", optional = true, default-features = false, features = [
     "blocking",

--- a/src/windows/symbol.rs
+++ b/src/windows/symbol.rs
@@ -177,7 +177,7 @@ impl SelectedSymbol {
         } else {
             match formatter.format_function(
                 &self.name,
-                self.module_index.unwrap_or(0) as u16,
+                self.module_index.unwrap_or(0),
                 self.type_index,
             ) {
                 Ok(function) => FuncName::Undecorated(function),
@@ -210,12 +210,12 @@ impl SelectedSymbol {
             return self.parameter_size;
         }
 
-        let module_index = self.module_index.unwrap_or(0) as u16;
+        let module_index = self.module_index.unwrap_or(0);
         let (min_start, max_end) = self.ebp.drain(..).fold((std::u32::MAX, 0), |acc, i| {
             (
                 acc.0.min(i.offset),
                 acc.1
-                    .max(i.offset + formatter.get_type_size(module_index, i.type_index)),
+                    .max(i.offset + formatter.get_type_size(module_index, i.type_index) as u32),
             )
         });
 


### PR DESCRIPTION
The only change in pdb-addr2line 0.9 compared to 0.7 was the update of the pdb crate from 0.7 to 0.8. Now module index is a usize, and type sizes are u64.

This update de-duplicates our uuid and pdb dependencies.