### PR TITLE
Stop emitting "static" in front of method names.

### DIFF
--- a/src/windows/pdb.rs
+++ b/src/windows/pdb.rs
@@ -10,7 +10,7 @@ use pdb::{
     SeparatedCodeSymbol, Source, SymbolData, SymbolTable, PDB,
 };
 use pdb_addr2line::pdb;
-use pdb_addr2line::{Error, TypeFormatterFlags};
+use pdb_addr2line::Error;
 use std::fmt::{Display, Formatter};
 use std::io::{Cursor, Write};
 use std::sync::Arc;
@@ -519,10 +519,7 @@ impl PDBInfo {
         pdb_data.collect_public_symbols(globals, &mut collector)?;
 
         let context_data = pdb_addr2line::ContextPdbData::try_from_pdb(pdb)?;
-        let flags = TypeFormatterFlags::NO_FUNCTION_RETURN
-            | TypeFormatterFlags::SPACE_AFTER_COMMA
-            | TypeFormatterFlags::NAME_ONLY;
-        let formatter = context_data.make_type_formatter_with_flags(flags)?;
+        let formatter = context_data.make_type_formatter()?;
 
         let code_id = pe
             .as_ref()

--- a/test_data/windows/basic-opt32.sym
+++ b/test_data/windows/basic-opt32.sym
@@ -613,7 +613,7 @@ FUNC 6c90 3 0 A::meth2(int)
 6c90 3 72 0
 FUNC 6ca0 5 0 A::meth2(double)
 6ca0 5 75 0
-FUNC 6cb0 1 0 static A::meth2(short, signed char)
+FUNC 6cb0 1 0 A::meth2(short, signed char)
 6cb0 1 78 0
 FUNC 6cc0 7 0 A::meth4(A*, A::B&&)
 6cc0 7 89 0
@@ -773,7 +773,7 @@ FUNC 996f d 0 __crt_rotate_pointer_value(const unsigned int, const int)
 996f 3 491 23
 9972 8 492 23
 997a 2 493 23
-FUNC 997f d 0 static __scrt_narrow_argv_policy::configure_argv()
+FUNC 997f d 0 __scrt_narrow_argv_policy::configure_argv()
 997f d 400 24
 FUNC 998f 44 0 find_pe_section(unsigned char* const, const unsigned int)
 998f 3 61 37
@@ -786,7 +786,7 @@ FUNC 998f 44 0 find_pe_section(unsigned char* const, const unsigned int)
 99ca 3 79 37
 99cd 2 80 37
 99cf 4 75 37
-FUNC 99e4 5 0 static __scrt_narrow_environment_policy::initialize_environment()
+FUNC 99e4 5 0 __scrt_narrow_environment_policy::initialize_environment()
 99e4 5 421 24
 FUNC 99e9 34 0 is_potentially_valid_image_base(void* const)
 99e9 3 28 37
@@ -1282,9 +1282,9 @@ a960 8 472 48
 a968 12 474 48
 a97a c 500 48
 a986 11 515 48
-FUNC a9ec 5 0 static <lambda_02a71323d951a238fa4826e9f186893b>::<lambda_invoker_cdecl>(void* const)
+FUNC a9ec 5 0 <lambda_02a71323d951a238fa4826e9f186893b>::<lambda_invoker_cdecl>(void* const)
 a9ec 5 84 49
-FUNC a9f1 9 0 static <lambda_cea3005bd909f0fdd45a57e92f4e3309>::<lambda_invoker_cdecl>(const unsigned int)
+FUNC a9f1 9 0 <lambda_cea3005bd909f0fdd45a57e92f4e3309>::<lambda_invoker_cdecl>(const unsigned int)
 a9f1 9 83 49
 FUNC a9fc 10 0 __crt_internal_free_policy::operator()<char>(char const* const) const
 a9fc 3 334 23
@@ -2018,7 +2018,7 @@ bbad 3 134 57
 bbb0 11 136 57
 bbc1 f 136 57
 bbd0 1 139 57
-FUNC bbdf 1f 0 static UnDecorator::UScore(Tokens)
+FUNC bbdf 1f 0 UnDecorator::UScore(Tokens)
 bbdf 3 4979 57
 bbe2 17 4984 57
 bbf9 3 4987 57
@@ -2029,7 +2029,7 @@ bc0a 9 613 58
 bc13 2a 615 58
 bc3d 4 616 58
 bc41 a 621 58
-FUNC bc5c cdd 0 static UnDecorator::composeDeclaration(DName const&)
+FUNC bc5c cdd 0 UnDecorator::composeDeclaration(DName const&)
 bc5c 9 2394 57
 bc65 e 2396 57
 bc73 2 2395 57
@@ -2170,25 +2170,25 @@ c8f6 8 2701 57
 c8fe 28 2703 57
 c926 b 2706 57
 c931 8 2708 57
-FUNC cc70 e 0 static UnDecorator::doAccessSpecifiers()
+FUNC cc70 e 0 UnDecorator::doAccessSpecifiers()
 cc70 e 4960 57
-FUNC cc81 e 0 static UnDecorator::doAllocationLanguage()
+FUNC cc81 e 0 UnDecorator::doAllocationLanguage()
 cc81 e 4952 57
-FUNC cc92 e 0 static UnDecorator::doAllocationModel()
+FUNC cc92 e 0 UnDecorator::doAllocationModel()
 cc92 e 4951 57
-FUNC cca3 e 0 static UnDecorator::doEcsu()
+FUNC cca3 e 0 UnDecorator::doEcsu()
 cca3 e 4970 57
-FUNC ccb4 e 0 static UnDecorator::doEllipsis()
+FUNC ccb4 e 0 UnDecorator::doEllipsis()
 ccb4 e 4972 57
-FUNC ccc5 e 0 static UnDecorator::doFunctionReturns()
+FUNC ccc5 e 0 UnDecorator::doFunctionReturns()
 ccc5 e 4950 57
-FUNC ccd6 d 0 static UnDecorator::doMSKeywords()
+FUNC ccd6 d 0 UnDecorator::doMSKeywords()
 ccd6 d 4948 57
-FUNC cce6 e 0 static UnDecorator::doMemberTypes()
+FUNC cce6 e 0 UnDecorator::doMemberTypes()
 cce6 e 4962 57
-FUNC ccf7 b 0 static UnDecorator::doNameOnly()
+FUNC ccf7 b 0 UnDecorator::doNameOnly()
 ccf7 b 4967 57
-FUNC cd04 b 0 static UnDecorator::doNoIdentCharCheck()
+FUNC cd04 b 0 UnDecorator::doNoIdentCharCheck()
 cd04 b 4971 57
 FUNC cd11 86 0 DName::doPchar(char const*, int)
 cd11 7 828 58
@@ -2204,19 +2204,19 @@ cd84 6 838 58
 cd8a 2 857 58
 cd8c 6 858 58
 cd92 5 860 58
-FUNC cdb8 e 0 static UnDecorator::doPtr64()
+FUNC cdb8 e 0 UnDecorator::doPtr64()
 cdb8 e 4949 57
-FUNC cdc9 e 0 static UnDecorator::doRestrictionSpec()
+FUNC cdc9 e 0 UnDecorator::doRestrictionSpec()
 cdc9 e 4975 57
-FUNC cdda 12 0 static UnDecorator::doThisTypes()
+FUNC cdda 12 0 UnDecorator::doThisTypes()
 cdda 12 4959 57
-FUNC cdf0 e 0 static UnDecorator::doThrowTypes()
+FUNC cdf0 e 0 UnDecorator::doThrowTypes()
 cdf0 e 4961 57
-FUNC ce01 b 0 static UnDecorator::doTypeOnly()
+FUNC ce01 b 0 UnDecorator::doTypeOnly()
 ce01 b 4968 57
-FUNC ce0e b 0 static UnDecorator::doUnderScore()
+FUNC ce0e b 0 UnDecorator::doUnderScore()
 ce0e b 4947 57
-FUNC ce1b f6 0 static UnDecorator::getArgumentList()
+FUNC ce1b f6 0 UnDecorator::getArgumentList()
 ce1b 8 3544 57
 ce23 3 3546 57
 ce26 4 3545 57
@@ -2244,7 +2244,7 @@ ceef 12 3549 57
 cf01 9 3605 57
 cf0a 5 3614 57
 cf0f 2 3616 57
-FUNC cf4e ca 0 static UnDecorator::getArgumentTypes()
+FUNC cf4e ca 0 UnDecorator::getArgumentTypes()
 cf4e 5 3503 57
 cf53 17 3504 57
 cf6a 9 3514 57
@@ -2258,7 +2258,7 @@ cfd2 d 3540 57
 cfdf 21 3507 57
 d000 b 3510 57
 d00b d 3540 57
-FUNC d04a 1b1 0 static UnDecorator::getArrayType(DName const&)
+FUNC d04a 1b1 0 UnDecorator::getArrayType(DName const&)
 d04a 3 4647 57
 d04d 13 4648 57
 d060 7 4650 57
@@ -2290,7 +2290,7 @@ d187 b 4685 57
 d192 36 4686 57
 d1c8 17 4688 57
 d1df 1c 4690 57
-FUNC d267 98 0 static UnDecorator::getBasedType()
+FUNC d267 98 0 UnDecorator::getBasedType()
 d267 6 3057 57
 d26d 11 3058 57
 d27e c 3063 57
@@ -2305,7 +2305,7 @@ d2d8 a 3116 57
 d2e2 d 3120 57
 d2ef e 3124 57
 d2fd 2 3126 57
-FUNC d325 3df 0 static UnDecorator::getBasicDataType(DName const&)
+FUNC d325 3df 0 UnDecorator::getBasicDataType(DName const&)
 d325 3 3725 57
 d328 14 3726 57
 d33c 3 3728 57
@@ -2416,9 +2416,9 @@ d892 12 973 57
 d8a4 12 974 57
 d8b6 20 975 57
 d8d6 4 979 57
-FUNC d911 14 0 static UnDecorator::getCallIndex()
+FUNC d911 14 0 UnDecorator::getCallIndex()
 d911 14 4734 57
-FUNC d92a d3 0 static UnDecorator::getCallingConvention()
+FUNC d92a d3 0 UnDecorator::getCallingConvention()
 d92a 5 3229 57
 d92f f 3230 57
 d93e c 3232 57
@@ -2456,7 +2456,7 @@ d9de e 3311 57
 d9ec 2 3317 57
 d9ee d 3315 57
 d9fb 2 3317 57
-FUNC da31 5ea 0 static UnDecorator::getDataIndirectType(DName const&, char const*, DName const&, int)
+FUNC da31 5ea 0 UnDecorator::getDataIndirectType(DName const&, char const*, DName const&, int)
 da31 6 4321 57
 da37 16 4327 57
 da4d 7 4329 57
@@ -2572,11 +2572,11 @@ dffe 8 4570 57
 e006 3 4571 57
 e009 a 4573 57
 e013 8 4575 57
-FUNC e195 32 0 static UnDecorator::getDataIndirectType()
+FUNC e195 32 0 UnDecorator::getDataIndirectType()
 e195 6 4698 57
 e19b 2a 4701 57
 e1c5 2 4702 57
-FUNC e1d3 c5 0 static UnDecorator::getDataType(DName*)
+FUNC e1d3 c5 0 UnDecorator::getDataType(DName*)
 e1d3 6 3338 57
 e1d9 b 3339 57
 e1e4 19 3344 57
@@ -2592,7 +2592,7 @@ e240 2a 3364 57
 e26a 11 3365 57
 e27b a 3347 57
 e285 13 3375 57
-FUNC e2c9 242 0 static UnDecorator::getDecoratedName()
+FUNC e2c9 242 0 UnDecorator::getDecoratedName()
 e2c9 c 992 57
 e2d5 6 1003 57
 e2db 5 1007 57
@@ -2655,7 +2655,7 @@ e4e0 4 1129 57
 e4e4 e 1130 57
 e4f2 a 1132 57
 e4fc f 1134 57
-FUNC e59b 11f 0 static UnDecorator::getDimension(bool)
+FUNC e59b 11f 0 UnDecorator::getDimension(bool)
 e59b 3 1871 57
 e59e 13 1873 57
 e5b1 c 1876 57
@@ -2678,7 +2678,7 @@ e676 1e 1910 57
 e694 14 1914 57
 e6a8 d 1893 57
 e6b5 5 1918 57
-FUNC e701 54 0 static UnDecorator::getDispatchTarget()
+FUNC e701 54 0 UnDecorator::getDispatchTarget()
 e701 3 3702 57
 e704 1c 3703 57
 e720 8 3707 57
@@ -2688,9 +2688,9 @@ e739 e 3713 57
 e747 2 3721 57
 e749 a 3720 57
 e753 2 3721 57
-FUNC e76a 14 0 static UnDecorator::getDisplacement()
+FUNC e76a 14 0 UnDecorator::getDisplacement()
 e76a 14 4733 57
-FUNC e783 118 0 static UnDecorator::getECSUDataType()
+FUNC e783 118 0 UnDecorator::getECSUDataType()
 e783 3 3967 57
 e786 5 3970 57
 e78b 3 3967 57
@@ -2717,9 +2717,9 @@ e85b 16 4021 57
 e871 10 4025 57
 e881 16 3979 57
 e897 4 4027 57
-FUNC e8e1 11 0 static UnDecorator::getECSUName()
+FUNC e8e1 11 0 UnDecorator::getECSUName()
 e8e1 11 3162 57
-FUNC e8f6 f0 0 static UnDecorator::getEnumType()
+FUNC e8f6 f0 0 UnDecorator::getEnumType()
 e8f6 6 3166 57
 e8fc 5 3170 57
 e901 8 3167 57
@@ -2740,7 +2740,7 @@ e9a8 c 3199 57
 e9b4 2 3224 57
 e9b6 d 3222 57
 e9c3 23 3224 57
-FUNC ea22 1b7 0 static UnDecorator::getExtendedDataIndirectType(char const*&, bool&, int)
+FUNC ea22 1b7 0 UnDecorator::getExtendedDataIndirectType(char const*&, bool&, int)
 ea22 6 4236 57
 ea28 11 4243 57
 ea39 2 4239 57
@@ -2784,7 +2784,7 @@ ebb4 10 4252 57
 ebc4 3 4254 57
 ebc7 b 4317 57
 ebd2 7 4318 57
-FUNC ec46 67 0 static UnDecorator::getExternalDataType(DName const&)
+FUNC ec46 67 0 UnDecorator::getExternalDataType(DName const&)
 ec46 6 4932 57
 ec4c 5 4935 57
 ec51 1 4932 57
@@ -2795,7 +2795,7 @@ eca4 3 4943 57
 eca7 3 4941 57
 ecaa 1 4943 57
 ecab 2 4945 57
-FUNC ecc6 3d8 0 static UnDecorator::getFunctionIndirectType(DName const&)
+FUNC ecc6 3d8 0 UnDecorator::getFunctionIndirectType(DName const&)
 ecc6 3 4036 57
 ecc9 16 4037 57
 ecdf 10 4040 57
@@ -2858,7 +2858,7 @@ f06b b 4174 57
 f076 10 4097 57
 f086 10 4057 57
 f096 8 4179 57
-FUNC f194 14 0 static UnDecorator::getGuardNumber()
+FUNC f194 14 0 UnDecorator::getGuardNumber()
 f194 14 4735 57
 FUNC f1ad 20 0 DName::getLastChar() const
 f1ad 1 511 58
@@ -2891,7 +2891,7 @@ f23b e 932 58
 f249 1 933 58
 f24a 2 932 58
 f24c 1 933 58
-FUNC f251 3f 0 static UnDecorator::getLexicalFrame()
+FUNC f251 3f 0 UnDecorator::getLexicalFrame()
 f251 3f 4693 57
 FUNC f29f 87 0 _HeapManager::getMemory(unsigned int, int)
 f29f 6 151 58
@@ -2913,14 +2913,14 @@ f30b 3 190 58
 f30e d 202 58
 f31b 7 205 58
 f322 4 194 58
-FUNC f347 45 0 static UnDecorator::getNoexcept()
+FUNC f347 45 0 UnDecorator::getNoexcept()
 f347 3 3636 57
 f34a 1c 3637 57
 f366 18 3640 57
 f37e 2 3644 57
 f380 a 3643 57
 f38a 2 3644 57
-FUNC f39d 61 0 static UnDecorator::getNumberOfDimensions()
+FUNC f39d 61 0 UnDecorator::getNumberOfDimensions()
 f39d c 1923 57
 f3a9 8 1925 57
 f3b1 d 1926 57
@@ -2938,7 +2938,7 @@ f3f8 2 1952 57
 f3fa 1 1955 57
 f3fb 2 1937 57
 f3fd 1 1955 57
-FUNC f416 658 0 static UnDecorator::getOperatorName(bool, bool*)
+FUNC f416 658 0 UnDecorator::getOperatorName(bool, bool*)
 f416 6 1267 57
 f41c d 1276 57
 f429 2 1268 57
@@ -3046,15 +3046,15 @@ fa22 13 1394 57
 fa35 8 1645 57
 fa3d 11 1646 57
 fa4e 20 1647 57
-FUNC fc04 1e 0 static UnDecorator::getPointerType(DName const&, DName const&)
+FUNC fc04 1e 0 UnDecorator::getPointerType(DName const&, DName const&)
 fc04 3 4712 57
 fc07 19 4715 57
 fc20 2 4716 57
-FUNC fc29 1e 0 static UnDecorator::getPointerTypeArray(DName const&, DName const&)
+FUNC fc29 1e 0 UnDecorator::getPointerTypeArray(DName const&, DName const&)
 fc29 3 4719 57
 fc2c 19 4722 57
 fc45 2 4723 57
-FUNC fc4e 1e4 0 static UnDecorator::getPrimaryDataType(DName const&)
+FUNC fc4e 1e4 0 UnDecorator::getPrimaryDataType(DName const&)
 fc4e 6 3380 57
 fc54 8 3384 57
 fc5c 2 3381 57
@@ -3093,7 +3093,7 @@ fe14 4 3447 57
 fe18 a 3449 57
 fe22 6 3455 57
 fe28 a 3461 57
-FUNC feab 129 0 static UnDecorator::getPtrRefDataType(DName const&, int)
+FUNC feab 129 0 UnDecorator::getPtrRefDataType(DName const&, int)
 feab 3 4579 57
 feae 12 4581 57
 fec0 6 4584 57
@@ -3124,7 +3124,7 @@ ffb4 9 4637 57
 ffbd 2 4643 57
 ffbf d 4641 57
 ffcc 8 4643 57
-FUNC 1001e fa 0 static UnDecorator::getPtrRefType(DName const&, DName const&, char const*)
+FUNC 1001e fa 0 UnDecorator::getPtrRefType(DName const&, DName const&, char const*)
 1001e 5 4183 57
 10023 11 4188 57
 10034 c 4189 57
@@ -3147,11 +3147,11 @@ FUNC 1001e fa 0 static UnDecorator::getPtrRefType(DName const&, DName const&, ch
 100fc 9 4225 57
 10105 10 4229 57
 10115 3 4232 57
-FUNC 10156 1c 0 static UnDecorator::getReferenceType(DName const&, DName const&, char const*)
+FUNC 10156 1c 0 UnDecorator::getReferenceType(DName const&, DName const&, char const*)
 10156 3 4726 57
 10159 17 4727 57
 10170 2 4728 57
-FUNC 10179 f9 0 static UnDecorator::getRestrictionSpec()
+FUNC 10179 f9 0 UnDecorator::getRestrictionSpec()
 10179 5 3648 57
 1017e 31 3649 57
 101af 5 3652 57
@@ -3177,13 +3177,13 @@ FUNC 10179 f9 0 static UnDecorator::getRestrictionSpec()
 10257 c 3693 57
 10263 9 3697 57
 1026c 6 3699 57
-FUNC 102b0 2f 0 static UnDecorator::getReturnType(DName*)
+FUNC 102b0 2f 0 UnDecorator::getReturnType(DName*)
 102b0 3 3322 57
 102b3 d 3323 57
 102c0 10 3327 57
 102d0 a 3331 57
 102da 5 3333 57
-FUNC 102ea 394 0 static UnDecorator::getScope()
+FUNC 102ea 394 0 UnDecorator::getScope()
 102ea c 1693 57
 102f6 a 1694 57
 10300 2 1695 57
@@ -3242,7 +3242,7 @@ FUNC 102ea 394 0 static UnDecorator::getScope()
 10649 2e 1837 57
 10677 5 1851 57
 1067c 2 1853 57
-FUNC 10763 d4 0 static UnDecorator::getScopedName()
+FUNC 10763 d4 0 UnDecorator::getScopedName()
 10763 6 3131 57
 10769 5 3137 57
 1076e 3 3132 57
@@ -3268,7 +3268,7 @@ FUNC 10763 d4 0 static UnDecorator::getScopedName()
 10806 2a 3153 57
 10830 5 3157 57
 10835 2 3159 57
-FUNC 1086c 51 0 static UnDecorator::getSignedDimension()
+FUNC 1086c 51 0 UnDecorator::getSignedDimension()
 1086c 5 1857 57
 10871 b 1858 57
 1087c c 1859 57
@@ -3277,7 +3277,7 @@ FUNC 1086c 51 0 static UnDecorator::getSignedDimension()
 10895 19 1863 57
 108ae a 1866 57
 108b8 5 1867 57
-FUNC 108d1 11 0 static UnDecorator::getStorageConvention()
+FUNC 108d1 11 0 UnDecorator::getStorageConvention()
 108d1 11 4694 57
 FUNC 108e6 2d 0 DName::getString(char*, char*) const
 108e6 4 554 58
@@ -3332,7 +3332,7 @@ FUNC 10a46 1b 0 pcharNode::getString(char*, char*) const
 10a46 3 971 58
 10a49 14 972 58
 10a5d 4 973 58
-FUNC 10a67 b0 0 static UnDecorator::getStringEncoding(char const*, int)
+FUNC 10a67 b0 0 UnDecorator::getStringEncoding(char const*, int)
 10a67 6 1655 57
 10a6d b 1656 57
 10a78 22 1659 57
@@ -3358,7 +3358,7 @@ FUNC 10b43 37 0 getStringHelper(char*, char const*, char const*, int)
 10b57 1e 212 58
 10b75 3 213 58
 10b78 2 214 58
-FUNC 10b87 48 0 static UnDecorator::getSymbolName()
+FUNC 10b87 48 0 UnDecorator::getSymbolName()
 10b87 3 1139 57
 10b8a a 1140 57
 10b94 6 1142 57
@@ -3366,7 +3366,7 @@ FUNC 10b87 48 0 static UnDecorator::getSymbolName()
 10ba8 13 1150 57
 10bbb c 1155 57
 10bc7 8 1157 57
-FUNC 10be1 29d 0 static UnDecorator::getTemplateArgumentList()
+FUNC 10be1 29d 0 UnDecorator::getTemplateArgumentList()
 10be1 15 2039 57
 10bf6 2 2041 57
 10bf8 5 2040 57
@@ -3425,7 +3425,7 @@ FUNC 10be1 29d 0 static UnDecorator::getTemplateArgumentList()
 10e45 c 2185 57
 10e51 17 2044 57
 10e68 16 2196 57
-FUNC 10f25 332 0 static UnDecorator::getTemplateConstant()
+FUNC 10f25 332 0 UnDecorator::getTemplateConstant()
 10f25 13 2214 57
 10f38 e 2221 57
 10f46 49 2222 57
@@ -3484,7 +3484,7 @@ FUNC 10f25 332 0 static UnDecorator::getTemplateConstant()
 11216 33 2391 57
 11249 7 2370 57
 11250 7 2367 57
-FUNC 11323 162 0 static UnDecorator::getTemplateName(bool)
+FUNC 11323 162 0 UnDecorator::getTemplateName(bool)
 11323 3 1959 57
 11326 1e 1963 57
 11344 9 1972 57
@@ -3515,16 +3515,16 @@ FUNC 11323 162 0 static UnDecorator::getTemplateName(bool)
 11473 2 2035 57
 11475 e 1964 57
 11483 2 2035 57
-FUNC 114dd 33 0 static UnDecorator::getThisType()
+FUNC 114dd 33 0 UnDecorator::getThisType()
 114dd 6 4705 57
 114e3 2b 4708 57
 1150e 2 4709 57
-FUNC 1151c 23 0 static UnDecorator::getThrowTypes()
+FUNC 1151c 23 0 UnDecorator::getThrowTypes()
 1151c 3 3620 57
 1151f 17 3629 57
 11536 7 3630 57
 1153d 2 3633 57
-FUNC 11547 328 0 static UnDecorator::getTypeEncoding()
+FUNC 11547 328 0 UnDecorator::getTypeEncoding()
 11547 e 2712 57
 11555 7 2718 57
 1155c c 2722 57
@@ -3649,7 +3649,7 @@ FUNC 11939 c4 0 UnDecorator::getUndecoratedName(char*, int)
 119f3 2 907 57
 119f5 4 912 57
 119f9 4 914 57
-FUNC 11a2e 47 0 static UnDecorator::getVCallThunkType()
+FUNC 11a2e 47 0 UnDecorator::getVCallThunkType()
 11a2e 3 4744 57
 11a31 10 4746 57
 11a41 e 4754 57
@@ -3657,11 +3657,11 @@ FUNC 11a2e 47 0 static UnDecorator::getVCallThunkType()
 11a51 15 4750 57
 11a66 a 4752 57
 11a70 5 4858 57
-FUNC 11a86 15 0 static UnDecorator::getVbTableType(DName const&)
+FUNC 11a86 15 0 UnDecorator::getVbTableType(DName const&)
 11a86 3 4738 57
 11a89 10 4739 57
 11a99 2 4740 57
-FUNC 11aa0 54 0 static UnDecorator::getVdispMapType(DName const&)
+FUNC 11aa0 54 0 UnDecorator::getVdispMapType(DName const&)
 11aa0 5 4918 57
 11aa5 3 4919 57
 11aa8 1 4918 57
@@ -3677,7 +3677,7 @@ FUNC 11aa0 54 0 static UnDecorator::getVdispMapType(DName const&)
 11ae8 7 4925 57
 11aef 3 4926 57
 11af2 2 4927 57
-FUNC 11b09 163 0 static UnDecorator::getVfTableType(DName const&)
+FUNC 11b09 163 0 UnDecorator::getVfTableType(DName const&)
 11b09 3 4862 57
 11b0c 3 4863 57
 11b0f 3 4862 57
@@ -3706,7 +3706,7 @@ FUNC 11b09 163 0 static UnDecorator::getVfTableType(DName const&)
 11c46 21 4910 57
 11c67 3 4912 57
 11c6a 2 4914 57
-FUNC 11cc4 1ff 0 static UnDecorator::getZName(bool, bool)
+FUNC 11cc4 1ff 0 UnDecorator::getZName(bool, bool)
 11cc4 11 1161 57
 11cd5 15 1162 57
 11cea 5 1167 57
@@ -3747,7 +3747,7 @@ FUNC 11cc4 1ff 0 static UnDecorator::getZName(bool, bool)
 11e9f 9 1256 57
 11ea8 b 1259 57
 11eb3 10 1262 57
-FUNC 11f42 b 0 static UnDecorator::haveTemplateParameters()
+FUNC 11f42 b 0 UnDecorator::haveTemplateParameters()
 11f42 b 4969 57
 FUNC 11f4f a 0 DName::isArray() const
 11f4f 9 467 58
@@ -3809,14 +3809,14 @@ FUNC 12021 46 0 pairNode::length() const
 FUNC 12078 4 0 pcharNode::length() const
 12078 3 927 58
 1207b 1 928 58
-FUNC 1207c 1c 0 static DNameStatusNode::make(DNameStatus)
+FUNC 1207c 1c 0 DNameStatusNode::make(DNameStatus)
 1207c 3 1021 58
 1207f 8 1028 58
 12087 8 1029 58
 1208f 2 1032 58
 12091 5 1031 58
 12096 2 1032 58
-FUNC 1209f ee 0 static UnDecorator::parseDecoratedName()
+FUNC 1209f ee 0 UnDecorator::parseDecoratedName()
 1209f 3 808 57
 120a2 8 814 57
 120aa 2 809 57
@@ -4364,7 +4364,7 @@ FUNC 12fca 8 0 std::forward<__FrameHandler3::TryBlockMap::iterator &>(__FrameHan
 12fd0 2 1575 79
 FUNC 12fd4 14 0 __FrameHandler3::TryBlockMap::iterator::iterator(__FrameHandler3::TryBlockMap&, unsigned int)
 12fd4 14 547 74
-FUNC 12fed 82 0 static __FrameHandler3::GetRangeOfTrysToCheck(__FrameHandler3::TryBlockMap&, int, int)
+FUNC 12fed 82 0 __FrameHandler3::GetRangeOfTrysToCheck(__FrameHandler3::TryBlockMap&, int, int)
 12fed 6 752 73
 12ff3 3 753 73
 12ff6 1 752 73
@@ -5129,9 +5129,9 @@ FUNC 14847 13 0 __FrameHandler3::TryBlockMap::iterator::operator<(__FrameHandler
 14856 4 572 74
 FUNC 1485e 2d 0 std::bad_exception::`scalar deleting destructor'(unsigned int)
 FUNC 14896 2d 0 std::exception::`scalar deleting destructor'(unsigned int)
-FUNC 148ce 5 0 static __FrameHandler3::BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 148ce 5 0 __FrameHandler3::BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 148ce 5 2027 82
-FUNC 148d3 9 0 static __FrameHandler3::BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 148d3 9 0 __FrameHandler3::BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 148d3 3 1915 82
 148d6 1 1917 82
 148d7 5 1916 82
@@ -5188,11 +5188,11 @@ FUNC 14b5b 4a 0 ExFilterRethrow(_EXCEPTION_POINTERS*)
 14b9f 2 1735 82
 14ba1 2 1733 82
 14ba3 2 1735 82
-FUNC 14bb7 18 0 static __FrameHandler3::FrameUnwindToEmptyState(EHRegistrationNode*, void*, _s_FuncInfo const*)
+FUNC 14bb7 18 0 __FrameHandler3::FrameUnwindToEmptyState(EHRegistrationNode*, void*, _s_FuncInfo const*)
 14bb7 3 48 82
 14bba 13 49 82
 14bcd 2 50 82
-FUNC 14bd5 e8 0 static __FrameHandler3::FrameUnwindToState(EHRegistrationNode*, void*, _s_FuncInfo const*, int)
+FUNC 14bd5 e8 0 __FrameHandler3::FrameUnwindToState(EHRegistrationNode*, void*, _s_FuncInfo const*, int)
 14bd5 c 1167 82
 14be1 16 1176 82
 14bf7 8 1177 82
@@ -5216,7 +5216,7 @@ FUNC 14bd5 e8 0 static __FrameHandler3::FrameUnwindToState(EHRegistrationNode*, 
 14ca3 b 1221 82
 14cae 9 1222 82
 14cb7 6 1240 82
-FUNC 14cf7 b 0 static __FrameHandler3::GetMaxState(void*, _s_FuncInfo const*)
+FUNC 14cf7 b 0 __FrameHandler3::GetMaxState(void*, _s_FuncInfo const*)
 14cf7 3 448 74
 14cfa 6 449 74
 14d00 2 450 74
@@ -5244,7 +5244,7 @@ FUNC 14dc4 39 0 Is_bad_exception_allowed(_s_ESTypeList const*)
 14df2 3 2157 82
 14df5 4 2158 82
 14df9 4 2153 82
-FUNC 14e0b 9 0 static __FrameHandler3::TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
+FUNC 14e0b 9 0 __FrameHandler3::TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
 14e0b 3 976 82
 14e0e 1 978 82
 14e0f 5 977 82
@@ -5276,25 +5276,25 @@ FUNC 14e82 11 0 __FrameHandler3::HandlerMap::end()
 14e82 3 668 74
 14e85 a 669 74
 14e8f 4 670 74
-FUNC 14e97 b 0 static __FrameHandler3::getESTypes(_s_FuncInfo const*)
+FUNC 14e97 b 0 __FrameHandler3::getESTypes(_s_FuncInfo const*)
 14e97 3 196 82
 14e9a 6 197 82
 14ea0 2 198 82
 FUNC 14ea4 e 0 __FrameHandler3::HandlerMap::getLastEntry()
 14ea4 d 674 74
 14eb1 1 675 74
-FUNC 14eb5 f 0 static __FrameHandler3::getMagicNum(_s_FuncInfo const*)
+FUNC 14eb5 f 0 __FrameHandler3::getMagicNum(_s_FuncInfo const*)
 14eb5 3 504 74
 14eb8 a 505 74
 14ec2 2 506 74
 FUNC 14ec7 6 0 __FrameHandler3::TryBlockMap::getNumTryBlocks()
 14ec7 5 587 74
 14ecc 1 588 74
-FUNC 14ecd d 0 static __FrameHandler3::isEHs(_s_FuncInfo const*)
+FUNC 14ecd d 0 __FrameHandler3::isEHs(_s_FuncInfo const*)
 14ecd 3 494 74
 14ed0 8 495 74
 14ed8 2 496 74
-FUNC 14edd 10 0 static __FrameHandler3::isNoExcept(_s_FuncInfo const*)
+FUNC 14edd 10 0 __FrameHandler3::isNoExcept(_s_FuncInfo const*)
 14edd 3 499 74
 14ee0 b 500 74
 14eeb 2 501 74
@@ -5369,14 +5369,14 @@ FUNC 14fe3 1d 0 unexpected()
 14ff0 8 43 85
 14ff8 2 43 85
 14ffa 6 46 85
-FUNC 15007 1d 0 static __FrameHandler3::GetCurrentState(EHRegistrationNode*, void*, _s_FuncInfo const*)
+FUNC 15007 1d 0 __FrameHandler3::GetCurrentState(EHRegistrationNode*, void*, _s_FuncInfo const*)
 15007 3 202 86
 1500a f 205 86
 15019 4 207 86
 1501d 2 212 86
 1501f 3 210 86
 15022 2 212 86
-FUNC 1502b e 0 static __FrameHandler3::SetState(EHRegistrationNode*, _s_FuncInfo const*, int)
+FUNC 1502b e 0 __FrameHandler3::SetState(EHRegistrationNode*, _s_FuncInfo const*, int)
 1502b 3 219 86
 1502e 9 220 86
 15037 2 221 86
@@ -6153,7 +6153,7 @@ FUNC 1647b 17 0 __crt_unique_handle_t<__crt_hmodule_traits>::close()
 16485 8 1146 211
 1648d 3 1147 211
 16490 2 1148 211
-FUNC 16497 15 0 static __crt_hmodule_traits::close(HINSTANCE__*)
+FUNC 16497 15 0 __crt_hmodule_traits::close(HINSTANCE__*)
 16497 5 1061 211
 1649c e 1062 211
 164aa 2 1063 211
@@ -6179,7 +6179,7 @@ FUNC 16580 3 0 __crt_unique_handle_t<__crt_hmodule_traits>::get() const
 FUNC 16583 3 0 __crt_unique_handle_t<__crt_hmodule_traits>::get_address_of()
 16583 2 1162 211
 16585 1 1163 211
-FUNC 16586 3 0 static __crt_hmodule_traits::get_invalid_value()
+FUNC 16586 3 0 __crt_hmodule_traits::get_invalid_value()
 16586 2 1067 211
 16588 1 1068 211
 FUNC 16589 43 0 is_managed_app()
@@ -6314,9 +6314,9 @@ FUNC 1690a 12f 0 common_configure_argv<wchar_t>(const _crt_argv_mode)
 16a16 3 390 329
 16a19 1e 391 329
 16a37 2 392 329
-FUNC 16a84 1c 0 static __crt_char_traits<char>::get_module_file_name<std::nullptr_t,char (&)[261],int>(void*&&, char[261]&, int&&)
+FUNC 16a84 1c 0 __crt_char_traits<char>::get_module_file_name<std::nullptr_t,char (&)[261],int>(void*&&, char[261]&, int&&)
 16a84 1c 109 333
-FUNC 16aa7 1a 0 static __crt_char_traits<wchar_t>::get_module_file_name<std::nullptr_t,wchar_t (&)[261],int>(void*&&, wchar_t[261]&, int&&)
+FUNC 16aa7 1a 0 __crt_char_traits<wchar_t>::get_module_file_name<std::nullptr_t,wchar_t (&)[261],int>(void*&&, wchar_t[261]&, int&&)
 16aa7 1a 124 333
 FUNC 16ac7 177 0 parse_command_line<char>(char*, char**, char*, unsigned int*, unsigned int*)
 16ac7 6 102 329
@@ -6448,9 +6448,9 @@ FUNC 16c9b 195 0 parse_command_line<wchar_t>(wchar_t*, wchar_t**, wchar_t*, unsi
 16e24 3 259 329
 16e27 7 261 329
 16e2e 2 262 329
-FUNC 16e95 11 0 static __crt_char_traits<char>::set_program_name<char *>(char*&&)
+FUNC 16e95 11 0 __crt_char_traits<char>::set_program_name<char *>(char*&&)
 16e95 11 109 333
-FUNC 16eaa 11 0 static __crt_char_traits<wchar_t>::set_program_name<wchar_t *>(wchar_t*&&)
+FUNC 16eaa 11 0 __crt_char_traits<wchar_t>::set_program_name<wchar_t *>(wchar_t*&&)
 16eaa 11 124 333
 FUNC 16ebf 10 0 <lambda_a36aafc41185bea294aaaa3896c79ecc>::<lambda_a36aafc41185bea294aaaa3896c79ecc>(__crt_unique_heap_ptr<wchar_t *,__crt_internal_free_policy>&)
 16ebf 10 388 329
@@ -6740,9 +6740,9 @@ FUNC 175ad 2f 0 free_environment<wchar_t>(wchar_t** const)
 175cd 4 95 335
 175d1 9 98 335
 175da 2 99 335
-FUNC 175e7 5 0 static __crt_char_traits<char>::get_environment_from_os<>()
+FUNC 175e7 5 0 __crt_char_traits<char>::get_environment_from_os<>()
 175e7 5 109 333
-FUNC 175ec 5 0 static __crt_char_traits<wchar_t>::get_environment_from_os<>()
+FUNC 175ec 5 0 __crt_char_traits<wchar_t>::get_environment_from_os<>()
 175ec 5 124 333
 FUNC 175f1 83 0 initialize_environment_by_cloning_nolock<char>()
 175f1 5 242 335
@@ -6782,17 +6782,17 @@ FUNC 17694 7d 0 initialize_environment_by_cloning_nolock<wchar_t>()
 176ff 4 268 335
 17703 7 262 335
 1770a 7 269 335
-FUNC 17730 18 0 static __crt_char_traits<char>::set_variable_in_environment_nolock<char *,int>(char*&&, int&&)
+FUNC 17730 18 0 __crt_char_traits<char>::set_variable_in_environment_nolock<char *,int>(char*&&, int&&)
 17730 18 109 333
-FUNC 1774e 18 0 static __crt_char_traits<wchar_t>::set_variable_in_environment_nolock<wchar_t *,int>(wchar_t*&&, int&&)
+FUNC 1774e 18 0 __crt_char_traits<wchar_t>::set_variable_in_environment_nolock<wchar_t *,int>(wchar_t*&&, int&&)
 1774e 18 124 333
-FUNC 1776c 1e 0 static __crt_char_traits<char>::tcscpy_s<char *,unsigned int const &,char * &>(char*&&, unsigned int const&, char*&)
+FUNC 1776c 1e 0 __crt_char_traits<char>::tcscpy_s<char *,unsigned int const &,char * &>(char*&&, unsigned int const&, char*&)
 1776c 1e 109 333
-FUNC 17791 1e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t *,unsigned int const &,wchar_t * &>(wchar_t*&&, unsigned int const&, wchar_t*&)
+FUNC 17791 1e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t *,unsigned int const &,wchar_t * &>(wchar_t*&&, unsigned int const&, wchar_t*&)
 17791 1e 124 333
-FUNC 177b6 18 0 static __crt_char_traits<char>::tcslen<char * &>(char*&)
+FUNC 177b6 18 0 __crt_char_traits<char>::tcslen<char * &>(char*&)
 177b6 18 109 333
-FUNC 177d4 1e 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t * &>(wchar_t*&)
+FUNC 177d4 1e 0 __crt_char_traits<wchar_t>::tcslen<wchar_t * &>(wchar_t*&)
 177d4 1e 124 333
 FUNC 177f9 29 0 __crt_state_management::dual_state_global<char * *>::uninitialize<void (__cdecl&)(char * * &)>(void (&)(char**&))
 177f9 9 177 106
@@ -8529,113 +8529,113 @@ FUNC 1c88b 1c 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::st
 1c890 11 1007 363
 1c8a1 2 1009 363
 1c8a3 4 1010 363
-FUNC 1c8ae 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<char>(char*)
+FUNC 1c8ae 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<char>(char*)
 1c8ae 4 1452 363
-FUNC 1c8b2 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<char>(char*)
+FUNC 1c8b2 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<char>(char*)
 1c8b2 4 1452 363
-FUNC 1c8b6 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
+FUNC 1c8b6 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
 1c8b6 4 1452 363
-FUNC 1c8ba 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
+FUNC 1c8ba 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
 1c8ba 4 1452 363
-FUNC 1c8be 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
+FUNC 1c8be 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
 1c8be 4 1452 363
-FUNC 1c8c2 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
+FUNC 1c8c2 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
 1c8c2 4 1452 363
-FUNC 1c8c6 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
+FUNC 1c8c6 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
 1c8c6 4 1452 363
-FUNC 1c8ca 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
+FUNC 1c8ca 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
 1c8ca 4 1452 363
-FUNC 1c8ce 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<void>(void*)
+FUNC 1c8ce 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<void>(void*)
 1c8ce 4 1452 363
-FUNC 1c8d2 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<void>(void*)
+FUNC 1c8d2 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<void>(void*)
 1c8d2 4 1452 363
-FUNC 1c8d6 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
+FUNC 1c8d6 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
 1c8d6 4 1452 363
-FUNC 1c8da 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
+FUNC 1c8da 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
 1c8da 4 1452 363
-FUNC 1c8de 18 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_character_specifier<char>(const char)
+FUNC 1c8de 18 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_character_specifier<char>(const char)
 1c8de 5 1566 363
 1c8e3 d 1567 363
 1c8f0 2 1568 363
 1c8f2 2 1567 363
 1c8f4 2 1568 363
-FUNC 1c8fc 18 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_character_specifier<char>(const char)
+FUNC 1c8fc 18 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_character_specifier<char>(const char)
 1c8fc 5 1566 363
 1c901 d 1567 363
 1c90e 2 1568 363
 1c910 2 1567 363
 1c912 2 1568 363
-FUNC 1c91a 1b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
+FUNC 1c91a 1b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
 1c91a 5 1566 363
 1c91f 10 1567 363
 1c92f 2 1568 363
 1c931 2 1567 363
 1c933 2 1568 363
-FUNC 1c93b 1b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
+FUNC 1c93b 1b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
 1c93b 5 1566 363
 1c940 10 1567 363
 1c950 2 1568 363
 1c952 2 1567 363
 1c954 2 1568 363
-FUNC 1c95c 2c 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_integral_specifier<char>(const char)
+FUNC 1c95c 2c 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_integral_specifier<char>(const char)
 1c95c 5 1572 363
 1c961 21 1573 363
 1c982 2 1576 363
 1c984 2 1573 363
 1c986 2 1576 363
-FUNC 1c993 2c 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_integral_specifier<char>(const char)
+FUNC 1c993 2c 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_integral_specifier<char>(const char)
 1c993 5 1572 363
 1c998 21 1573 363
 1c9b9 2 1576 363
 1c9bb 2 1573 363
 1c9bd 2 1576 363
-FUNC 1c9ca 3b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
+FUNC 1c9ca 3b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
 1c9ca 5 1572 363
 1c9cf 30 1573 363
 1c9ff 2 1576 363
 1ca01 2 1573 363
 1ca03 2 1576 363
-FUNC 1ca13 3b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
+FUNC 1ca13 3b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
 1ca13 5 1572 363
 1ca18 30 1573 363
 1ca48 2 1576 363
 1ca4a 2 1573 363
 1ca4c 2 1576 363
-FUNC 1ca5c e 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_pointer_specifier<char>(const char)
+FUNC 1ca5c e 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_pointer_specifier<char>(const char)
 1ca5c 5 1554 363
 1ca61 7 1555 363
 1ca68 2 1556 363
-FUNC 1ca6d e 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_pointer_specifier<char>(const char)
+FUNC 1ca6d e 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_pointer_specifier<char>(const char)
 1ca6d 5 1554 363
 1ca72 7 1555 363
 1ca79 2 1556 363
-FUNC 1ca7e f 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
+FUNC 1ca7e f 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
 1ca7e 5 1554 363
 1ca83 8 1555 363
 1ca8b 2 1556 363
-FUNC 1ca90 f 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
+FUNC 1ca90 f 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
 1ca90 5 1554 363
 1ca95 8 1555 363
 1ca9d 2 1556 363
-FUNC 1caa2 18 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_string_specifier<char>(const char)
+FUNC 1caa2 18 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_string_specifier<char>(const char)
 1caa2 5 1560 363
 1caa7 d 1561 363
 1cab4 2 1562 363
 1cab6 2 1561 363
 1cab8 2 1562 363
-FUNC 1cac0 18 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_string_specifier<char>(const char)
+FUNC 1cac0 18 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_string_specifier<char>(const char)
 1cac0 5 1560 363
 1cac5 d 1561 363
 1cad2 2 1562 363
 1cad4 2 1561 363
 1cad6 2 1562 363
-FUNC 1cade 1b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
+FUNC 1cade 1b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
 1cade 5 1560 363
 1cae3 10 1561 363
 1caf3 2 1562 363
 1caf5 2 1561 363
 1caf7 2 1562 363
-FUNC 1caff 1b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
+FUNC 1caff 1b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
 1caff 5 1560 363
 1cb04 10 1561 363
 1cb14 2 1562 363
@@ -8723,9 +8723,9 @@ FUNC 1ccaa d 0 __crt_stdio_output::peek_va_arg<wchar_t>(char*)
 1ccaa 5 39 363
 1ccaf 6 40 363
 1ccb5 2 41 363
-FUNC 1ccba 1a 0 static __crt_char_traits<char>::puttc_nolock<char const &,_iobuf *>(char const&, _iobuf*&&)
+FUNC 1ccba 1a 0 __crt_char_traits<char>::puttc_nolock<char const &,_iobuf *>(char const&, _iobuf*&&)
 1ccba 1a 109 333
-FUNC 1ccda 1a 0 static __crt_char_traits<wchar_t>::puttc_nolock<wchar_t const &,_iobuf *>(wchar_t const&, _iobuf*&&)
+FUNC 1ccda 1a 0 __crt_char_traits<wchar_t>::puttc_nolock<wchar_t const &,_iobuf *>(wchar_t const&, _iobuf*&&)
 1ccda 1a 124 333
 FUNC 1ccfa 12 0 __crt_stdio_output::read_va_arg<signed char>(char*&)
 1ccfa 5 33 363
@@ -8831,13 +8831,13 @@ FUNC 1cf1f 1e 0 __crt_stdio_output::formatting_buffer::scratch_data<char>()
 1cf34 4 389 363
 1cf38 3 391 363
 1cf3b 2 392 363
-FUNC 1cf44 1e 0 static __crt_char_traits<char>::tcstol<char const * &,char * *,int>(char const*&, char**&&, int&&)
+FUNC 1cf44 1e 0 __crt_char_traits<char>::tcstol<char const * &,char * *,int>(char const*&, char**&&, int&&)
 1cf44 1e 109 333
-FUNC 1cf69 1e 0 static __crt_char_traits<wchar_t>::tcstol<wchar_t const * &,wchar_t * *,int>(wchar_t const*&, wchar_t**&&, int&&)
+FUNC 1cf69 1e 0 __crt_char_traits<wchar_t>::tcstol<wchar_t const * &,wchar_t * *,int>(wchar_t const*&, wchar_t**&&, int&&)
 1cf69 1e 124 333
-FUNC 1cf8e 1e 0 static __crt_char_traits<char>::tcstol<char const *,char * *,int>(char const*&&, char**&&, int&&)
+FUNC 1cf8e 1e 0 __crt_char_traits<char>::tcstol<char const *,char * *,int>(char const*&&, char**&&, int&&)
 1cf8e 1e 109 333
-FUNC 1cfb3 1e 0 static __crt_char_traits<wchar_t>::tcstol<wchar_t const *,wchar_t * *,int>(wchar_t const*&&, wchar_t**&&, int&&)
+FUNC 1cfb3 1e 0 __crt_char_traits<wchar_t>::tcstol<wchar_t const *,wchar_t * *,int>(wchar_t const*&&, wchar_t**&&, int&&)
 1cfb3 1e 124 333
 FUNC 1cfd8 73 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_integer_parse_into_buffer<unsigned int>(unsigned int, const unsigned int, const bool)
 1cfd8 a 2584 363
@@ -9527,51 +9527,51 @@ FUNC 1f152 9 0 <lambda_dbd837d1c0b7fc6e2d81c287c81c071b>::operator()() const
 FUNC 1f15d 4 0 _LocaleUpdate::GetLocaleT()
 1f15d 3 1844 211
 1f160 1 1845 211
-FUNC 1f161 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f161 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f161 5 2729 363
 1f166 d 2730 363
 1f173 2 2734 363
-FUNC 1f17a 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f17a 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f17a 5 2729 363
 1f17f d 2730 363
 1f18c 2 2734 363
-FUNC 1f193 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f193 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f193 5 2729 363
 1f198 d 2730 363
 1f1a5 2 2734 363
-FUNC 1f1ac 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f1ac 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f1ac 5 2729 363
 1f1b1 d 2730 363
 1f1be 2 2734 363
-FUNC 1f1c5 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f1c5 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f1c5 5 2729 363
 1f1ca d 2730 363
 1f1d7 2 2734 363
-FUNC 1f1de 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f1de 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f1de 5 2729 363
 1f1e3 d 2730 363
 1f1f0 2 2734 363
-FUNC 1f1f7 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f1f7 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f1f7 5 2729 363
 1f1fc d 2730 363
 1f209 2 2734 363
-FUNC 1f210 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f210 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f210 5 2729 363
 1f215 d 2730 363
 1f222 2 2734 363
-FUNC 1f229 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f229 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f229 5 2729 363
 1f22e d 2730 363
 1f23b 2 2734 363
-FUNC 1f242 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f242 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f242 5 2729 363
 1f247 d 2730 363
 1f254 2 2734 363
-FUNC 1f25b 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f25b 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f25b 5 2729 363
 1f260 d 2730 363
 1f26d 2 2734 363
-FUNC 1f274 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f274 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f274 5 2729 363
 1f279 d 2730 363
 1f286 2 2734 363
@@ -9741,69 +9741,69 @@ FUNC 1f904 14 0 __crt_deferred_errno_cache::get()
 FUNC 1f91d 7 0 __crt_stdio_stream::get_flags() const
 1f91d 6 233 347
 1f923 1 234 347
-FUNC 1f924 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(short)
+FUNC 1f924 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(short)
 1f924 4 1453 363
-FUNC 1f928 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned short)
+FUNC 1f928 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned short)
 1f928 4 1454 363
-FUNC 1f92c 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(int)
+FUNC 1f92c 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(int)
 1f92c 4 1456 363
-FUNC 1f930 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned int)
+FUNC 1f930 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned int)
 1f930 4 1457 363
-FUNC 1f934 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 1f934 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
 1f934 4 1460 363
-FUNC 1f938 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(long long)
+FUNC 1f938 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(long long)
 1f938 4 1458 363
-FUNC 1f93c 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned long long)
+FUNC 1f93c 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned long long)
 1f93c 4 1459 363
-FUNC 1f940 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(wchar_t)
+FUNC 1f940 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(wchar_t)
 1f940 4 1455 363
-FUNC 1f944 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(short)
+FUNC 1f944 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(short)
 1f944 4 1453 363
-FUNC 1f948 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned short)
+FUNC 1f948 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned short)
 1f948 4 1454 363
-FUNC 1f94c 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(int)
+FUNC 1f94c 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(int)
 1f94c 4 1456 363
-FUNC 1f950 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned int)
+FUNC 1f950 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned int)
 1f950 4 1457 363
-FUNC 1f954 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 1f954 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
 1f954 4 1460 363
-FUNC 1f958 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(long long)
+FUNC 1f958 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(long long)
 1f958 4 1458 363
-FUNC 1f95c 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned long long)
+FUNC 1f95c 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned long long)
 1f95c 4 1459 363
-FUNC 1f960 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(wchar_t)
+FUNC 1f960 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(wchar_t)
 1f960 4 1455 363
-FUNC 1f964 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(short)
+FUNC 1f964 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(short)
 1f964 4 1453 363
-FUNC 1f968 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
+FUNC 1f968 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
 1f968 4 1454 363
-FUNC 1f96c 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(int)
+FUNC 1f96c 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(int)
 1f96c 4 1456 363
-FUNC 1f970 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
+FUNC 1f970 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
 1f970 4 1457 363
-FUNC 1f974 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 1f974 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
 1f974 4 1460 363
-FUNC 1f978 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(long long)
+FUNC 1f978 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(long long)
 1f978 4 1458 363
-FUNC 1f97c 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
+FUNC 1f97c 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
 1f97c 4 1459 363
-FUNC 1f980 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
+FUNC 1f980 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
 1f980 4 1455 363
-FUNC 1f984 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(short)
+FUNC 1f984 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(short)
 1f984 4 1453 363
-FUNC 1f988 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
+FUNC 1f988 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
 1f988 4 1454 363
-FUNC 1f98c 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(int)
+FUNC 1f98c 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(int)
 1f98c 4 1456 363
-FUNC 1f990 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
+FUNC 1f990 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
 1f990 4 1457 363
-FUNC 1f994 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 1f994 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
 1f994 4 1460 363
-FUNC 1f998 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(long long)
+FUNC 1f998 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(long long)
 1f998 4 1458 363
-FUNC 1f99c 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
+FUNC 1f99c 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
 1f99c 4 1459 363
-FUNC 1f9a0 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
+FUNC 1f9a0 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
 1f9a0 4 1455 363
 FUNC 1f9a4 12 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::has_flag(const unsigned int) const
 1f9a4 12 2707 363
@@ -9947,29 +9947,29 @@ FUNC 1fec6 118 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_std
 1ffd7 7 1527 363
 FUNC 20024 c 0 __crt_stdio_stream::is_string_backed() const
 20024 c 227 347
-FUNC 20033 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 20033 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 20033 6 2737 363
-FUNC 20039 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 20039 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 20039 6 2737 363
-FUNC 2003f 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 2003f 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 2003f 6 2737 363
-FUNC 20045 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 20045 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 20045 6 2737 363
-FUNC 2004b 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 2004b 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 2004b 6 2737 363
-FUNC 20051 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 20051 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 20051 6 2737 363
-FUNC 20057 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 20057 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 20057 6 2737 363
-FUNC 2005d 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 2005d 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 2005d 6 2737 363
-FUNC 20063 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 20063 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 20063 6 2737 363
-FUNC 20069 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 20069 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 20069 6 2737 363
-FUNC 2006f 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 2006f 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 2006f 6 2737 363
-FUNC 20075 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 20075 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 20075 6 2737 363
 FUNC 2007b 74 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::parse_int_from_format_string(int* const)
 2007b b 1775 363
@@ -12395,52 +12395,52 @@ FUNC 26531 2c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output:
 26556 4 1814 363
 2655a 2 1817 363
 2655c 1 1818 363
-FUNC 26568 4 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
+FUNC 26568 4 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
 26568 3 1103 363
 2656b 1 1104 363
-FUNC 2656c 4 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
+FUNC 2656c 4 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
 2656c 3 1103 363
 2656f 1 1104 363
-FUNC 26570 4 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
+FUNC 26570 4 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
 26570 3 1103 363
 26573 1 1104 363
-FUNC 26574 4 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
+FUNC 26574 4 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
 26574 3 1103 363
 26577 1 1104 363
-FUNC 26578 4 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
+FUNC 26578 4 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
 26578 3 1046 363
 2657b 1 1047 363
-FUNC 2657c 4 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
+FUNC 2657c 4 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
 2657c 3 1046 363
 2657f 1 1047 363
-FUNC 26580 4 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
+FUNC 26580 4 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
 26580 3 1046 363
 26583 1 1047 363
-FUNC 26584 4 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
+FUNC 26584 4 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
 26584 3 1046 363
 26587 1 1047 363
-FUNC 26588 6 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
+FUNC 26588 6 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
 26588 5 1108 363
 2658d 1 1109 363
-FUNC 2658e 6 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
+FUNC 2658e 6 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
 2658e 5 1108 363
 26593 1 1109 363
-FUNC 26594 6 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
+FUNC 26594 6 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
 26594 5 1108 363
 26599 1 1109 363
-FUNC 2659a 6 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
+FUNC 2659a 6 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
 2659a 5 1108 363
 2659f 1 1109 363
-FUNC 265a0 6 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
+FUNC 265a0 6 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
 265a0 5 1051 363
 265a5 1 1052 363
-FUNC 265a6 6 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
+FUNC 265a6 6 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
 265a6 5 1051 363
 265ab 1 1052 363
-FUNC 265ac 6 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
+FUNC 265ac 6 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
 265ac 5 1051 363
 265b1 1 1052 363
-FUNC 265b2 6 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
+FUNC 265b2 6 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
 265b2 5 1051 363
 265b7 1 1052 363
 FUNC 265b8 6 4 __crt_stdio_output::common_data<char>::tchar_string(char)
@@ -14758,39 +14758,39 @@ FUNC 2cd12 3 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::str
 FUNC 2cd15 3 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::validate_state_for_type_case_a() const
 2cd15 2 1026 363
 2cd17 1 1027 363
-FUNC 2cd18 87 0 static __acrt_stdio_char_traits<char>::validate_stream_is_ansi_if_required(_iobuf* const)
+FUNC 2cd18 87 0 __acrt_stdio_char_traits<char>::validate_stream_is_ansi_if_required(_iobuf* const)
 2cd18 5 439 347
 2cd1d 3 440 347
 2cd20 1 439 347
 2cd21 79 440 347
 2cd9a 3 441 347
 2cd9d 2 442 347
-FUNC 2cdc0 3 4 static __acrt_stdio_char_traits<wchar_t>::validate_stream_is_ansi_if_required(_iobuf* const)
+FUNC 2cdc0 3 4 __acrt_stdio_char_traits<wchar_t>::validate_stream_is_ansi_if_required(_iobuf* const)
 2cdc0 2 454 347
 2cdc2 1 455 347
-FUNC 2cdc3 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 2cdc3 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 2cdc3 6 2738 363
-FUNC 2cdc9 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 2cdc9 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 2cdc9 6 2738 363
-FUNC 2cdcf 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 2cdcf 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 2cdcf 6 2738 363
-FUNC 2cdd5 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 2cdd5 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 2cdd5 6 2738 363
-FUNC 2cddb 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 2cddb 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 2cddb 6 2738 363
-FUNC 2cde1 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 2cde1 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 2cde1 6 2738 363
-FUNC 2cde7 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2cde7 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 2cde7 6 2738 363
-FUNC 2cded 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2cded 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 2cded 6 2738 363
-FUNC 2cdf3 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2cdf3 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 2cdf3 6 2738 363
-FUNC 2cdf9 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2cdf9 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 2cdf9 6 2738 363
-FUNC 2cdff 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2cdff 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 2cdff 6 2738 363
-FUNC 2ce05 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2ce05 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 2ce05 6 2738 363
 FUNC 2ce0b 1f 0 __crt_stdio_output::output_adapter_common<char,__crt_stdio_output::stream_output_adapter<char> >::write_character(const char, int* const) const
 2ce0b 5 60 363
@@ -16117,35 +16117,35 @@ FUNC 3134f 2f 0 get_win_policy<`__acrt_get_process_end_policy'::`2'::process_end
 3136a 9 23 377
 31373 9 26 377
 3137c 2 27 377
-FUNC 31389 f 0 static `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_get_policy(AppPolicyThreadInitializationType*)
+FUNC 31389 f 0 `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_get_policy(AppPolicyThreadInitializationType*)
 31389 5 110 377
 3138e 8 111 377
 31396 2 112 377
-FUNC 3139b f 0 static `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_get_policy(AppPolicyShowDeveloperDiagnostic*)
+FUNC 3139b f 0 `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_get_policy(AppPolicyShowDeveloperDiagnostic*)
 3139b 5 141 377
 313a0 8 142 377
 313a8 2 143 377
-FUNC 313ad f 0 static `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_get_policy(AppPolicyProcessTerminationMethod*)
+FUNC 313ad f 0 `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_get_policy(AppPolicyProcessTerminationMethod*)
 313ad 5 79 377
 313b2 8 80 377
 313ba 2 81 377
-FUNC 313bf f 0 static `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_get_policy(AppPolicyWindowingModel*)
+FUNC 313bf f 0 `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_get_policy(AppPolicyWindowingModel*)
 313bf 5 179 377
 313c4 8 180 377
 313cc 2 181 377
-FUNC 313d1 11 0 static `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 313d1 11 0 `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_policy_to_policy_type(const long)
 313d1 5 98 377
 313d6 a 99 377
 313e0 2 107 377
-FUNC 313e6 11 0 static `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 313e6 11 0 `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_policy_to_policy_type(const long)
 313e6 5 129 377
 313eb a 130 377
 313f5 2 138 377
-FUNC 313fb 10 0 static `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_policy_to_policy_type(const AppPolicyProcessTerminationMethod)
+FUNC 313fb 10 0 `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_policy_to_policy_type(const AppPolicyProcessTerminationMethod)
 313fb 5 67 377
 31400 9 68 377
 31409 2 76 377
-FUNC 3140f 29 0 static `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 3140f 29 0 `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_policy_to_policy_type(const long)
 3140f 5 160 377
 31414 12 161 377
 31426 4 174 377
@@ -16242,9 +16242,9 @@ FUNC 316f6 5d 0 _calloc_base(unsigned int, unsigned int)
 3171a 14 45 379
 3172e 15 38 379
 31743 10 53 379
-FUNC 3176a 18 0 static <lambda_838c7f62c73c983481e27c09e84b0b5d>::<lambda_invoker_cdecl>(void const*, void const*)
+FUNC 3176a 18 0 <lambda_838c7f62c73c983481e27c09e84b0b5d>::<lambda_invoker_cdecl>(void const*, void const*)
 3176a 18 301 384
-FUNC 31788 18 0 static <lambda_d388dc2bcbe6079ffc891eec49d9b3b2>::<lambda_invoker_cdecl>(void const*, void const*)
+FUNC 31788 18 0 <lambda_d388dc2bcbe6079ffc891eec49d9b3b2>::<lambda_invoker_cdecl>(void const*, void const*)
 31788 18 301 384
 FUNC 317a6 b2 0 __acrt_convert_wcs_mbs_cp<char,wchar_t,<lambda_62f6974d9771e494a5ea317cc32e971c>,__crt_win32_buffer_internal_dynamic_resizing>(char const* const, __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>&, __acrt_mbs_to_wcs_cp::__l2::<lambda_62f6974d9771e494a5ea317cc32e971c> const&, const unsigned int)
 317a6 6 494 334
@@ -16495,25 +16495,25 @@ FUNC 32394 172 0 expand_argument_wildcards<wchar_t>(wchar_t* const, wchar_t* con
 324d4 16 292 384
 324ea d 303 384
 324f7 f 304 384
-FUNC 32562 18 0 static __crt_char_traits<char>::tcslen<char const * const &>(char const* const&)
+FUNC 32562 18 0 __crt_char_traits<char>::tcslen<char const * const &>(char const* const&)
 32562 18 109 333
-FUNC 32580 1e 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t const * const &>(wchar_t const* const&)
+FUNC 32580 1e 0 __crt_char_traits<wchar_t>::tcslen<wchar_t const * const &>(wchar_t const* const&)
 32580 1e 124 333
-FUNC 325a5 23 0 static __crt_char_traits<char>::tcsncpy_s<char * &,unsigned int,char * &,unsigned int const &>(char*&, unsigned int&&, char*&, unsigned int const&)
+FUNC 325a5 23 0 __crt_char_traits<char>::tcsncpy_s<char * &,unsigned int,char * &,unsigned int const &>(char*&, unsigned int&&, char*&, unsigned int const&)
 325a5 23 109 333
-FUNC 325d0 23 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t * &,unsigned int,wchar_t * &,unsigned int const &>(wchar_t*&, unsigned int&&, wchar_t*&, unsigned int const&)
+FUNC 325d0 23 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t * &,unsigned int,wchar_t * &,unsigned int const &>(wchar_t*&, unsigned int&&, wchar_t*&, unsigned int const&)
 325d0 23 124 333
-FUNC 325fb 23 0 static __crt_char_traits<char>::tcsncpy_s<char *,unsigned int const &,char const * const &,unsigned int const &>(char*&&, unsigned int const&, char const* const&, unsigned int const&)
+FUNC 325fb 23 0 __crt_char_traits<char>::tcsncpy_s<char *,unsigned int const &,char const * const &,unsigned int const &>(char*&&, unsigned int const&, char const* const&, unsigned int const&)
 325fb 23 109 333
-FUNC 32626 23 0 static __crt_char_traits<char>::tcsncpy_s<char *,unsigned int,char const * const &,unsigned int const &>(char*&&, unsigned int&&, char const* const&, unsigned int const&)
+FUNC 32626 23 0 __crt_char_traits<char>::tcsncpy_s<char *,unsigned int,char const * const &,unsigned int const &>(char*&&, unsigned int&&, char const* const&, unsigned int const&)
 32626 23 109 333
-FUNC 32651 23 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned int const &,wchar_t const * const &,unsigned int const &>(wchar_t*&&, unsigned int const&, wchar_t const* const&, unsigned int const&)
+FUNC 32651 23 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned int const &,wchar_t const * const &,unsigned int const &>(wchar_t*&&, unsigned int const&, wchar_t const* const&, unsigned int const&)
 32651 23 124 333
-FUNC 3267c 23 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned int,wchar_t const * const &,unsigned int const &>(wchar_t*&&, unsigned int&&, wchar_t const* const&, unsigned int const&)
+FUNC 3267c 23 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned int,wchar_t const * const &,unsigned int const &>(wchar_t*&&, unsigned int&&, wchar_t const* const&, unsigned int const&)
 3267c 23 124 333
-FUNC 326a7 16 0 static __crt_char_traits<char>::tcspbrk<char * &,char const (&)[3]>(char*&, const char[3]&)
+FUNC 326a7 16 0 __crt_char_traits<char>::tcspbrk<char * &,char const (&)[3]>(char*&, const char[3]&)
 326a7 16 109 333
-FUNC 326c2 16 0 static __crt_char_traits<wchar_t>::tcspbrk<wchar_t * &,wchar_t const (&)[3]>(wchar_t*&, const wchar_t[3]&)
+FUNC 326c2 16 0 __crt_char_traits<wchar_t>::tcspbrk<wchar_t * &,wchar_t const (&)[3]>(wchar_t*&, const wchar_t[3]&)
 326c2 16 124 333
 FUNC 326dd 10 0 __crt_unique_handle_t<__crt_findfile_traits>::__crt_unique_handle_t<__crt_findfile_traits>(void* const)
 326dd 5 1098 211
@@ -16626,7 +16626,7 @@ FUNC 329a0 3f 0 __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_r
 329d0 4 360 334
 329d4 5 362 334
 329d9 6 363 334
-FUNC 329ee 1f 0 static __crt_win32_buffer_internal_dynamic_resizing::allocate(void** const, const unsigned int, __crt_win32_buffer_empty_debug_info const&)
+FUNC 329ee 1f 0 __crt_win32_buffer_internal_dynamic_resizing::allocate(void** const, const unsigned int, __crt_win32_buffer_empty_debug_info const&)
 329ee 5 82 334
 329f3 9 83 334
 329fc 5 84 334
@@ -16666,7 +16666,7 @@ FUNC 32aa6 17 0 __crt_unique_handle_t<__crt_findfile_traits>::close()
 32ab0 8 1146 211
 32ab8 3 1147 211
 32abb 2 1148 211
-FUNC 32ac2 15 0 static __crt_findfile_traits::close(void*)
+FUNC 32ac2 15 0 __crt_findfile_traits::close(void*)
 32ac2 5 1076 211
 32ac7 e 1077 211
 32ad5 2 1078 211
@@ -16676,7 +16676,7 @@ FUNC 32adc 4 0 __crt_win32_buffer<char,__crt_win32_buffer_internal_dynamic_resiz
 FUNC 32ae0 4 0 __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>::data()
 32ae0 3 248 334
 32ae3 1 249 334
-FUNC 32ae4 10 0 static __crt_win32_buffer_internal_dynamic_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
+FUNC 32ae4 10 0 __crt_win32_buffer_internal_dynamic_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
 32ae4 5 92 334
 32ae9 9 93 334
 32af2 2 94 334
@@ -16748,7 +16748,7 @@ FUNC 32c8c a 0 get_file_name(__crt_win32_buffer<wchar_t,__crt_win32_buffer_inter
 32c8c 5 207 384
 32c91 3 208 384
 32c94 2 209 384
-FUNC 32c98 4 0 static __crt_findfile_traits::get_invalid_value()
+FUNC 32c98 4 0 __crt_findfile_traits::get_invalid_value()
 32c98 3 1082 211
 32c9b 1 1083 211
 FUNC 32c9c a 0 get_wide(__crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>*, wchar_t* const)
@@ -16865,7 +16865,7 @@ FUNC 32f2e 27 4 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::allocat
 32f3d a 348 334
 32f47 b 357 334
 32f52 3 363 334
-FUNC 32f5e d c static __crt_win32_buffer_no_resizing::allocate(void** const, const unsigned int, __crt_win32_buffer_empty_debug_info const&)
+FUNC 32f5e d c __crt_win32_buffer_no_resizing::allocate(void** const, const unsigned int, __crt_win32_buffer_empty_debug_info const&)
 32f5e a 132 334
 32f68 2 133 334
 32f6a 1 134 334
@@ -16875,7 +16875,7 @@ FUNC 32f6e 4 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::capacity
 FUNC 32f72 4 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::data()
 32f72 3 248 334
 32f75 1 249 334
-FUNC 32f76 3 8 static __crt_win32_buffer_no_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
+FUNC 32f76 3 8 __crt_win32_buffer_no_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
 32f76 3 138 334
 FUNC 32f79 3 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::debug_info() const
 32f79 2 341 334
@@ -17409,7 +17409,7 @@ FUNC 34443 17 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings
 3444d 8 1146 211
 34455 3 1147 211
 34458 2 1148 211
-FUNC 3445f 12 0 static `anonymous namespace'::environment_strings_traits::close(wchar_t*)
+FUNC 3445f 12 0 `anonymous namespace'::environment_strings_traits::close(wchar_t*)
 3445f 5 24 398
 34464 9 25 398
 3446d 2 26 398
@@ -17423,7 +17423,7 @@ FUNC 34475 37 0 find_end_of_double_null_terminated_sequence(wchar_t const* const
 FUNC 344b9 3 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings_traits>::get() const
 344b9 2 1138 211
 344bb 1 1139 211
-FUNC 344bc 3 0 static `anonymous namespace'::environment_strings_traits::get_invalid_value()
+FUNC 344bc 3 0 `anonymous namespace'::environment_strings_traits::get_invalid_value()
 344bc 2 31 398
 344be 1 32 398
 FUNC 344bf 7 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings_traits>::is_valid() const
@@ -17640,33 +17640,33 @@ FUNC 34df6 58 0 find_in_environment_nolock<wchar_t>(wchar_t const* const, const 
 34e39 7 125 399
 34e40 7 126 399
 34e47 7 121 399
-FUNC 34e64 5 0 static __crt_char_traits<char>::get_or_create_environment_nolock<>()
+FUNC 34e64 5 0 __crt_char_traits<char>::get_or_create_environment_nolock<>()
 34e64 5 109 333
-FUNC 34e69 5 0 static __crt_char_traits<wchar_t>::get_or_create_environment_nolock<>()
+FUNC 34e69 5 0 __crt_char_traits<wchar_t>::get_or_create_environment_nolock<>()
 34e69 5 124 333
-FUNC 34e6e 18 0 static __crt_char_traits<char>::set_environment_variable<char * const &,char * const>(char* const&, char* const&&)
+FUNC 34e6e 18 0 __crt_char_traits<char>::set_environment_variable<char * const &,char * const>(char* const&, char* const&&)
 34e6e 18 109 333
-FUNC 34e8c 17 0 static __crt_char_traits<wchar_t>::set_environment_variable<wchar_t * const &,wchar_t * const>(wchar_t* const&, wchar_t* const&&)
+FUNC 34e8c 17 0 __crt_char_traits<wchar_t>::set_environment_variable<wchar_t * const &,wchar_t * const>(wchar_t* const&, wchar_t* const&&)
 34e8c 17 124 333
-FUNC 34ea8 1a 0 static __crt_char_traits<char>::tcschr<char * const &,char>(char* const&, char&&)
+FUNC 34ea8 1a 0 __crt_char_traits<char>::tcschr<char * const &,char>(char* const&, char&&)
 34ea8 1a 109 333
-FUNC 34ec8 1e 0 static __crt_char_traits<wchar_t>::tcschr<wchar_t * const &,char>(wchar_t* const&, char&&)
+FUNC 34ec8 1e 0 __crt_char_traits<wchar_t>::tcschr<wchar_t * const &,char>(wchar_t* const&, char&&)
 34ec8 1e 124 333
-FUNC 34eed 1e 0 static __crt_char_traits<char>::tcscpy_s<char * &,unsigned int const &,char * &>(char*&, unsigned int const&, char*&)
+FUNC 34eed 1e 0 __crt_char_traits<char>::tcscpy_s<char * &,unsigned int const &,char * &>(char*&, unsigned int const&, char*&)
 34eed 1e 109 333
-FUNC 34f12 1e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * &,unsigned int const &,wchar_t * &>(wchar_t*&, unsigned int const&, wchar_t*&)
+FUNC 34f12 1e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * &,unsigned int const &,wchar_t * &>(wchar_t*&, unsigned int const&, wchar_t*&)
 34f12 1e 124 333
-FUNC 34f37 1e 0 static __crt_char_traits<char>::tcscpy_s<char * const &,unsigned int const &,char * const &>(char* const&, unsigned int const&, char* const&)
+FUNC 34f37 1e 0 __crt_char_traits<char>::tcscpy_s<char * const &,unsigned int const &,char * const &>(char* const&, unsigned int const&, char* const&)
 34f37 1e 109 333
-FUNC 34f5c 1e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * const &,unsigned int const &,wchar_t * const &>(wchar_t* const&, unsigned int const&, wchar_t* const&)
+FUNC 34f5c 1e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * const &,unsigned int const &,wchar_t * const &>(wchar_t* const&, unsigned int const&, wchar_t* const&)
 34f5c 1e 124 333
-FUNC 34f81 18 0 static __crt_char_traits<char>::tcslen<char * const &>(char* const&)
+FUNC 34f81 18 0 __crt_char_traits<char>::tcslen<char * const &>(char* const&)
 34f81 18 109 333
-FUNC 34f9f 1e 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t * const &>(wchar_t* const&)
+FUNC 34f9f 1e 0 __crt_char_traits<wchar_t>::tcslen<wchar_t * const &>(wchar_t* const&)
 34f9f 1e 124 333
-FUNC 34fc4 1e 0 static __crt_char_traits<char>::tcsnicoll<char const * const &,char * &,unsigned int const &>(char const* const&, char*&, unsigned int const&)
+FUNC 34fc4 1e 0 __crt_char_traits<char>::tcsnicoll<char const * const &,char * &,unsigned int const &>(char const* const&, char*&, unsigned int const&)
 34fc4 1e 109 333
-FUNC 34fe9 1e 0 static __crt_char_traits<wchar_t>::tcsnicoll<wchar_t const * const &,wchar_t * &,unsigned int const &>(wchar_t const* const&, wchar_t*&, unsigned int const&)
+FUNC 34fe9 1e 0 __crt_char_traits<wchar_t>::tcsnicoll<wchar_t const * const &,wchar_t * &,unsigned int const &>(wchar_t const* const&, wchar_t*&, unsigned int const&)
 34fe9 1e 124 333
 FUNC 3500e 6 4 get_environment(char)
 3500e 6 17 399
@@ -17710,7 +17710,7 @@ FUNC 35073 6d 0 _recalloc_base(void*, unsigned int, unsigned int)
 350c8 11 40 400
 350d9 5 43 400
 350de 2 44 400
-FUNC 350fb d 0 static <lambda_29d3c280b90b41c2ae070ffca879996a>::<lambda_invoker_stdcall>(wchar_t*)
+FUNC 350fb d 0 <lambda_29d3c280b90b41c2ae070ffca879996a>::<lambda_invoker_stdcall>(wchar_t*)
 350fb d 425 402
 FUNC 3510b 6 0 __crt_fast_encoded_nullptr_t::operator<int __stdcall(wchar_t *,unsigned long,long)> int (__stdcall*)(wchar_t *,unsigned long,long)() const
 3510b 5 536 156
@@ -19355,28 +19355,28 @@ FUNC 396d9 4 0 __crt_simd_cleanup_guard<1>::~__crt_simd_cleanup_guard<1>()
 396dc 1 116 425
 FUNC 396dd 3 0 __crt_simd_cleanup_guard<0>::~__crt_simd_cleanup_guard<0>()
 396dd 3 63 425
-FUNC 396e0 5 0 static __crt_simd_traits<1,unsigned char>::compare_equals(const __m256i, const __m256i)
+FUNC 396e0 5 0 __crt_simd_traits<1,unsigned char>::compare_equals(const __m256i, const __m256i)
 396e0 4 143 425
 396e4 1 144 425
-FUNC 396e5 5 0 static __crt_simd_traits<1,unsigned short>::compare_equals(const __m256i, const __m256i)
+FUNC 396e5 5 0 __crt_simd_traits<1,unsigned short>::compare_equals(const __m256i, const __m256i)
 396e5 4 153 425
 396e9 1 154 425
-FUNC 396ea 5 0 static __crt_simd_traits<0,unsigned char>::compare_equals(const __m128i, const __m128i)
+FUNC 396ea 5 0 __crt_simd_traits<0,unsigned char>::compare_equals(const __m128i, const __m128i)
 396ea 4 90 425
 396ee 1 91 425
-FUNC 396ef 5 0 static __crt_simd_traits<0,unsigned short>::compare_equals(const __m128i, const __m128i)
+FUNC 396ef 5 0 __crt_simd_traits<0,unsigned short>::compare_equals(const __m128i, const __m128i)
 396ef 4 100 425
 396f3 1 101 425
-FUNC 396f4 5 0 static __crt_simd_pack_traits<1>::compute_byte_mask(const __m256i)
+FUNC 396f4 5 0 __crt_simd_pack_traits<1>::compute_byte_mask(const __m256i)
 396f4 4 133 425
 396f8 1 134 425
-FUNC 396f9 5 0 static __crt_simd_pack_traits<0>::compute_byte_mask(const __m128i)
+FUNC 396f9 5 0 __crt_simd_pack_traits<0>::compute_byte_mask(const __m128i)
 396f9 4 80 425
 396fd 1 81 425
-FUNC 396fe 5 0 static __crt_simd_pack_traits<1>::get_zero_pack()
+FUNC 396fe 5 0 __crt_simd_pack_traits<1>::get_zero_pack()
 396fe 4 128 425
 39702 1 129 425
-FUNC 39703 4 0 static __crt_simd_pack_traits<0>::get_zero_pack()
+FUNC 39703 4 0 __crt_simd_pack_traits<0>::get_zero_pack()
 39703 3 75 425
 39706 1 76 425
 FUNC 39707 122 8 strnlen(char const*, unsigned int)
@@ -24566,17 +24566,17 @@ FUNC 4c853 7e 0 common_show_message_box<wchar_t>(wchar_t const* const, wchar_t c
 4c8b8 f 75 511
 4c8c7 6 64 511
 4c8cd 4 76 511
-FUNC 4c8f0 20 0 static __crt_char_traits<char>::message_box<std::nullptr_t,char const * const &,char const * const &,unsigned long>(void*&&, char const* const&, char const* const&, unsigned long&&)
+FUNC 4c8f0 20 0 __crt_char_traits<char>::message_box<std::nullptr_t,char const * const &,char const * const &,unsigned long>(void*&&, char const* const&, char const* const&, unsigned long&&)
 4c8f0 20 109 333
-FUNC 4c918 20 0 static __crt_char_traits<wchar_t>::message_box<std::nullptr_t,wchar_t const * const &,wchar_t const * const &,unsigned long>(void*&&, wchar_t const* const&, wchar_t const* const&, unsigned long&&)
+FUNC 4c918 20 0 __crt_char_traits<wchar_t>::message_box<std::nullptr_t,wchar_t const * const &,wchar_t const * const &,unsigned long>(void*&&, wchar_t const* const&, wchar_t const* const&, unsigned long&&)
 4c918 20 124 333
-FUNC 4c940 20 0 static __crt_char_traits<char>::message_box<HWND__ *,char const * const &,char const * const &,unsigned int const &>(HWND__*&&, char const* const&, char const* const&, unsigned int const&)
+FUNC 4c940 20 0 __crt_char_traits<char>::message_box<HWND__ *,char const * const &,char const * const &,unsigned int const &>(HWND__*&&, char const* const&, char const* const&, unsigned int const&)
 4c940 20 109 333
-FUNC 4c968 20 0 static __crt_char_traits<wchar_t>::message_box<HWND__ *,wchar_t const * const &,wchar_t const * const &,unsigned int const &>(HWND__*&&, wchar_t const* const&, wchar_t const* const&, unsigned int const&)
+FUNC 4c968 20 0 __crt_char_traits<wchar_t>::message_box<HWND__ *,wchar_t const * const &,wchar_t const * const &,unsigned int const &>(HWND__*&&, wchar_t const* const&, wchar_t const* const&, unsigned int const&)
 4c968 20 124 333
-FUNC 4c990 11 0 static __crt_char_traits<char>::output_debug_string<char const * const &>(char const* const&)
+FUNC 4c990 11 0 __crt_char_traits<char>::output_debug_string<char const * const &>(char const* const&)
 4c990 11 109 333
-FUNC 4c9a5 12 0 static __crt_char_traits<wchar_t>::output_debug_string<wchar_t const * const &>(wchar_t const* const&)
+FUNC 4c9a5 12 0 __crt_char_traits<wchar_t>::output_debug_string<wchar_t const * const &>(wchar_t const* const&)
 4c9a5 12 124 333
 FUNC 4c9bb b 0 __acrt_show_narrow_message_box(char const*, char const*, unsigned int)
 4c9bb 5 83 511

--- a/test_data/windows/basic-opt64.sym
+++ b/test_data/windows/basic-opt64.sym
@@ -580,7 +580,7 @@ FUNC 6c50 1 0 A::meth2(int)
 6c50 1 72 0
 FUNC 6c60 4 0 A::meth2(double)
 6c60 4 75 0
-FUNC 6c70 1 0 static A::meth2(short, signed char)
+FUNC 6c70 1 0 A::meth2(short, signed char)
 6c70 1 78 0
 FUNC 6c80 4 0 A::meth4(A*, A::B&&)
 6c80 4 89 0
@@ -726,7 +726,7 @@ FUNC 9a18 9 0 __crt_rotate_pointer_value(const unsigned long long, const int)
 9a18 3 497 22
 9a1b 5 498 22
 9a20 1 499 22
-FUNC 9a24 14 0 static __scrt_narrow_argv_policy::configure_argv()
+FUNC 9a24 14 0 __scrt_narrow_argv_policy::configure_argv()
 9a24 14 400 25
 FUNC 9a40 49 0 find_pe_section(unsigned char* const, const unsigned long long)
 9a40 4 63 37
@@ -738,7 +738,7 @@ FUNC 9a40 49 0 find_pe_section(unsigned char* const, const unsigned long long)
 9a85 1 80 37
 9a86 2 79 37
 9a88 1 80 37
-FUNC 9a9c 5 0 static __scrt_narrow_environment_policy::initialize_environment()
+FUNC 9a9c 5 0 __scrt_narrow_environment_policy::initialize_environment()
 9a9c 5 421 25
 FUNC 9aa4 2f 0 is_potentially_valid_image_base(void* const)
 9aa4 5 29 37
@@ -1063,9 +1063,9 @@ a7f5 1a 406 49
 a80f d 344 49
 a81c 5 421 49
 a821 1e 422 49
-FUNC a8c4 5 0 static <lambda_02a71323d951a238fa4826e9f186893b>::<lambda_invoker_cdecl>(void* const)
+FUNC a8c4 5 0 <lambda_02a71323d951a238fa4826e9f186893b>::<lambda_invoker_cdecl>(void* const)
 a8c4 5 84 50
-FUNC a8cc 5 0 static <lambda_ab747d7d039e86ead2ea2c584b0f6318>::<lambda_invoker_cdecl>(const unsigned long long)
+FUNC a8cc 5 0 <lambda_ab747d7d039e86ead2ea2c584b0f6318>::<lambda_invoker_cdecl>(const unsigned long long)
 a8cc 5 83 50
 FUNC a8d4 8 0 __crt_internal_free_policy::operator()<char>(char const* const) const
 a8d4 8 335 22
@@ -1755,7 +1755,7 @@ c09e b 134 69
 c0a9 12 136 69
 c0bb 5 132 69
 c0c0 6 139 69
-FUNC c0d8 20 0 static UnDecorator::UScore(Tokens)
+FUNC c0d8 20 0 UnDecorator::UScore(Tokens)
 c0d8 1b 4984 69
 c0f3 4 4987 69
 c0f7 1 4989 69
@@ -1768,7 +1768,7 @@ c14e 4 617 70
 c152 2 619 70
 c154 4 620 70
 c158 b 621 70
-FUNC c17c db3 0 static UnDecorator::composeDeclaration(DName const&)
+FUNC c17c db3 0 UnDecorator::composeDeclaration(DName const&)
 c17c 1c 2394 69
 c198 6 2396 69
 c19e 3 2395 69
@@ -1908,25 +1908,25 @@ cec7 6 2701 69
 cecd 35 2703 69
 cf02 c 2706 69
 cf0e 21 2708 69
-FUNC d29c f 0 static UnDecorator::doAccessSpecifiers()
+FUNC d29c f 0 UnDecorator::doAccessSpecifiers()
 d29c f 4960 69
-FUNC d2b0 f 0 static UnDecorator::doAllocationLanguage()
+FUNC d2b0 f 0 UnDecorator::doAllocationLanguage()
 d2b0 f 4952 69
-FUNC d2c4 f 0 static UnDecorator::doAllocationModel()
+FUNC d2c4 f 0 UnDecorator::doAllocationModel()
 d2c4 f 4951 69
-FUNC d2d8 f 0 static UnDecorator::doEcsu()
+FUNC d2d8 f 0 UnDecorator::doEcsu()
 d2d8 f 4970 69
-FUNC d2ec f 0 static UnDecorator::doEllipsis()
+FUNC d2ec f 0 UnDecorator::doEllipsis()
 d2ec f 4972 69
-FUNC d300 f 0 static UnDecorator::doFunctionReturns()
+FUNC d300 f 0 UnDecorator::doFunctionReturns()
 d300 f 4950 69
-FUNC d314 e 0 static UnDecorator::doMSKeywords()
+FUNC d314 e 0 UnDecorator::doMSKeywords()
 d314 e 4948 69
-FUNC d328 f 0 static UnDecorator::doMemberTypes()
+FUNC d328 f 0 UnDecorator::doMemberTypes()
 d328 f 4962 69
-FUNC d33c c 0 static UnDecorator::doNameOnly()
+FUNC d33c c 0 UnDecorator::doNameOnly()
 d33c c 4967 69
-FUNC d34c c 0 static UnDecorator::doNoIdentCharCheck()
+FUNC d34c c 0 UnDecorator::doNoIdentCharCheck()
 d34c c 4971 69
 FUNC d35c a6 0 DName::doPchar(char const*, int)
 d35c f 828 70
@@ -1939,19 +1939,19 @@ d3be 20 842 70
 d3de 10 860 70
 d3ee 4 858 70
 d3f2 10 860 70
-FUNC d42c f 0 static UnDecorator::doPtr64()
+FUNC d42c f 0 UnDecorator::doPtr64()
 d42c f 4949 69
-FUNC d440 f 0 static UnDecorator::doRestrictionSpec()
+FUNC d440 f 0 UnDecorator::doRestrictionSpec()
 d440 f 4975 69
-FUNC d454 12 0 static UnDecorator::doThisTypes()
+FUNC d454 12 0 UnDecorator::doThisTypes()
 d454 12 4959 69
-FUNC d46c f 0 static UnDecorator::doThrowTypes()
+FUNC d46c f 0 UnDecorator::doThrowTypes()
 d46c f 4961 69
-FUNC d480 c 0 static UnDecorator::doTypeOnly()
+FUNC d480 c 0 UnDecorator::doTypeOnly()
 d480 c 4968 69
-FUNC d490 c 0 static UnDecorator::doUnderScore()
+FUNC d490 c 0 UnDecorator::doUnderScore()
 d490 c 4947 69
-FUNC d4a0 12b 0 static UnDecorator::getArgumentList()
+FUNC d4a0 12b 0 UnDecorator::getArgumentList()
 d4a0 f 3544 69
 d4af 4 3546 69
 d4b3 3 3544 69
@@ -1980,7 +1980,7 @@ d58c c 3598 69
 d598 13 3549 69
 d5ab d 3605 69
 d5b8 13 3616 69
-FUNC d618 f3 0 static UnDecorator::getArgumentTypes()
+FUNC d618 f3 0 UnDecorator::getArgumentTypes()
 d618 6 3503 69
 d61e 1c 3504 69
 d63a a 3514 69
@@ -1993,7 +1993,7 @@ d6b4 d 3540 69
 d6c1 2b 3507 69
 d6ec 11 3510 69
 d6fd e 3540 69
-FUNC d748 253 0 static UnDecorator::getArrayType(DName const&)
+FUNC d748 253 0 UnDecorator::getArrayType(DName const&)
 d748 1e 4647 69
 d766 19 4648 69
 d77f 5 4650 69
@@ -2020,7 +2020,7 @@ d8f1 1b 4685 69
 d90c 39 4686 69
 d945 20 4688 69
 d965 36 4690 69
-FUNC da30 c8 0 static UnDecorator::getBasedType()
+FUNC da30 c8 0 UnDecorator::getBasedType()
 da30 6 3057 69
 da36 6 3058 69
 da3c 3 3057 69
@@ -2036,7 +2036,7 @@ dac0 f 3116 69
 dacf 11 3120 69
 dae0 f 3124 69
 daef 9 3126 69
-FUNC db2c 468 0 static UnDecorator::getBasicDataType(DName const&)
+FUNC db2c 468 0 UnDecorator::getBasicDataType(DName const&)
 db2c 1b 3725 69
 db47 19 3726 69
 db60 5 3731 69
@@ -2149,9 +2149,9 @@ e177 16 973 69
 e18d 16 974 69
 e1a3 22 975 69
 e1c5 8 979 69
-FUNC e214 19 0 static UnDecorator::getCallIndex()
+FUNC e214 19 0 UnDecorator::getCallIndex()
 e214 19 4734 69
-FUNC e234 13e 0 static UnDecorator::getCallingConvention()
+FUNC e234 13e 0 UnDecorator::getCallingConvention()
 e234 d 3229 69
 e241 16 3230 69
 e257 14 3232 69
@@ -2183,7 +2183,7 @@ e326 23 3307 69
 e349 d 3311 69
 e356 e 3315 69
 e364 e 3317 69
-FUNC e3c4 7b8 0 static UnDecorator::getDataIndirectType(DName const&, char const*, DName const&, int)
+FUNC e3c4 7b8 0 UnDecorator::getDataIndirectType(DName const&, char const*, DName const&, int)
 e3c4 25 4321 69
 e3e9 7 4327 69
 e3f0 3 4324 69
@@ -2304,13 +2304,13 @@ eb46 5 4570 69
 eb4b 5 4571 69
 eb50 e 4573 69
 eb5e 1e 4575 69
-FUNC ed6c 3e 0 static UnDecorator::getDataIndirectType()
+FUNC ed6c 3e 0 UnDecorator::getDataIndirectType()
 ed6c 8 4698 69
 ed74 1d 4701 69
 ed91 3 4698 69
 ed94 10 4701 69
 eda4 6 4702 69
-FUNC edbc e6 0 static UnDecorator::getDataType(DName*)
+FUNC edbc e6 0 UnDecorator::getDataType(DName*)
 edbc 10 3338 69
 edcc 9 3339 69
 edd5 1b 3344 69
@@ -2324,7 +2324,7 @@ ee3a 37 3364 69
 ee71 5 3365 69
 ee76 12 3347 69
 ee88 1a 3375 69
-FUNC eedc 2a8 0 static UnDecorator::getDecoratedName()
+FUNC eedc 2a8 0 UnDecorator::getDecoratedName()
 eedc 26 992 69
 ef02 6 1003 69
 ef08 c 1007 69
@@ -2372,7 +2372,7 @@ f141 e 1121 69
 f14f 8 1129 69
 f157 a 1132 69
 f161 23 1134 69
-FUNC f230 179 0 static UnDecorator::getDimension(bool)
+FUNC f230 179 0 UnDecorator::getDimension(bool)
 f230 17 1871 69
 f247 19 1873 69
 f260 11 1876 69
@@ -2396,7 +2396,7 @@ f34a 21 1910 69
 f36b 17 1914 69
 f382 e 1893 69
 f390 19 1918 69
-FUNC f408 4c 0 static UnDecorator::getDispatchTarget()
+FUNC f408 4c 0 UnDecorator::getDispatchTarget()
 f408 12 3703 69
 f41a b 3707 69
 f425 10 3709 69
@@ -2404,9 +2404,9 @@ f435 5 3710 69
 f43a e 3713 69
 f448 8 3720 69
 f450 4 3721 69
-FUNC f468 19 0 static UnDecorator::getDisplacement()
+FUNC f468 19 0 UnDecorator::getDisplacement()
 f468 19 4733 69
-FUNC f488 160 0 static UnDecorator::getECSUDataType()
+FUNC f488 160 0 UnDecorator::getECSUDataType()
 f488 17 3967 69
 f49f d 3970 69
 f4ac 3 3967 69
@@ -2432,9 +2432,9 @@ f5a6 f 4025 69
 f5b5 4 3977 69
 f5b9 16 3979 69
 f5cf 19 4027 69
-FUNC f640 17 0 static UnDecorator::getECSUName()
+FUNC f640 17 0 UnDecorator::getECSUName()
 f640 17 3162 69
-FUNC f65c fc 0 static UnDecorator::getEnumType()
+FUNC f65c fc 0 UnDecorator::getEnumType()
 f65c d 3166 69
 f669 a 3170 69
 f673 9 3167 69
@@ -2453,7 +2453,7 @@ f722 f 3218 69
 f731 c 3199 69
 f73d d 3222 69
 f74a e 3224 69
-FUNC f798 214 0 static UnDecorator::getExtendedDataIndirectType(char const*&, bool&, int)
+FUNC f798 214 0 UnDecorator::getExtendedDataIndirectType(char const*&, bool&, int)
 f798 12 4236 69
 f7aa a 4243 69
 f7b4 5 4239 69
@@ -2494,7 +2494,7 @@ f970 16 4252 69
 f986 4 4254 69
 f98a b 4317 69
 f995 17 4318 69
-FUNC fa34 c6 0 static UnDecorator::getExternalDataType(DName const&)
+FUNC fa34 c6 0 UnDecorator::getExternalDataType(DName const&)
 fa34 12 4932 69
 fa46 3 4935 69
 fa49 6 4932 69
@@ -2505,7 +2505,7 @@ fad6 c 4945 69
 fae2 c 4941 69
 faee 3 4943 69
 faf1 9 4945 69
-FUNC fb2c 556 0 static UnDecorator::getFunctionIndirectType(DName const&)
+FUNC fb2c 556 0 UnDecorator::getFunctionIndirectType(DName const&)
 fb2c 26 4036 69
 fb52 12 4037 69
 fb64 23 4179 69
@@ -2571,7 +2571,7 @@ fff5 11 4164 69
 10049 a 4174 69
 10053 8 4097 69
 1005b 27 4179 69
-FUNC 101d8 19 0 static UnDecorator::getGuardNumber()
+FUNC 101d8 19 0 UnDecorator::getGuardNumber()
 101d8 19 4735 69
 FUNC 101f8 19 0 DName::getLastChar() const
 101f8 8 512 70
@@ -2597,7 +2597,7 @@ FUNC 10260 35 0 pairNode::getLastChar() const
 FUNC 102a4 14 0 pcharNode::getLastChar() const
 102a4 13 932 70
 102b7 1 933 70
-FUNC 102c0 71 0 static UnDecorator::getLexicalFrame()
+FUNC 102c0 71 0 UnDecorator::getLexicalFrame()
 102c0 71 4693 69
 FUNC 10350 a9 0 _HeapManager::getMemory(unsigned long long, int)
 10350 f 151 70
@@ -2616,14 +2616,14 @@ FUNC 10350 a9 0 _HeapManager::getMemory(unsigned long long, int)
 103d3 12 202 70
 103e5 10 205 70
 103f5 4 194 70
-FUNC 10424 45 0 static UnDecorator::getNoexcept()
+FUNC 10424 45 0 UnDecorator::getNoexcept()
 10424 6 3636 69
 1042a 15 3637 69
 1043f 4 3639 69
 10443 15 3640 69
 10458 8 3643 69
 10460 9 3644 69
-FUNC 1047c 73 0 static UnDecorator::getNumberOfDimensions()
+FUNC 1047c 73 0 UnDecorator::getNumberOfDimensions()
 1047c d 1923 69
 10489 7 1925 69
 10490 10 1926 69
@@ -2642,7 +2642,7 @@ FUNC 1047c 73 0 static UnDecorator::getNumberOfDimensions()
 104eb 1 1955 69
 104ec 2 1937 69
 104ee 1 1955 69
-FUNC 1050c 76d 0 static UnDecorator::getOperatorName(bool, bool*)
+FUNC 1050c 76d 0 UnDecorator::getOperatorName(bool, bool*)
 1050c 19 1267 69
 10525 7 1276 69
 1052c 3 1268 69
@@ -2746,15 +2746,15 @@ FUNC 1050c 76d 0 static UnDecorator::getOperatorName(bool, bool*)
 10c5d 8 1645 69
 10c65 f 1646 69
 10c74 5 1647 69
-FUNC 10e54 1e 0 static UnDecorator::getPointerType(DName const&, DName const&)
+FUNC 10e54 1e 0 UnDecorator::getPointerType(DName const&, DName const&)
 10e54 6 4712 69
 10e5a 12 4715 69
 10e6c 6 4716 69
-FUNC 10e7c 1e 0 static UnDecorator::getPointerTypeArray(DName const&, DName const&)
+FUNC 10e7c 1e 0 UnDecorator::getPointerTypeArray(DName const&, DName const&)
 10e7c 6 4719 69
 10e82 12 4722 69
 10e94 6 4723 69
-FUNC 10ea4 24d 0 static UnDecorator::getPrimaryDataType(DName const&)
+FUNC 10ea4 24d 0 UnDecorator::getPrimaryDataType(DName const&)
 10ea4 17 3380 69
 10ebb 2 3381 69
 10ebd 3 3380 69
@@ -2794,7 +2794,7 @@ FUNC 10ea4 24d 0 static UnDecorator::getPrimaryDataType(DName const&)
 110b9 1d 3432 69
 110d6 4 3427 69
 110da 17 3428 69
-FUNC 11184 162 0 static UnDecorator::getPtrRefDataType(DName const&, int)
+FUNC 11184 162 0 UnDecorator::getPtrRefDataType(DName const&, int)
 11184 12 4579 69
 11196 17 4581 69
 111ad 5 4584 69
@@ -2825,7 +2825,7 @@ FUNC 11184 162 0 static UnDecorator::getPtrRefDataType(DName const&, int)
 112ae 8 4637 69
 112b6 12 4641 69
 112c8 1e 4643 69
-FUNC 11340 136 0 static UnDecorator::getPtrRefType(DName const&, DName const&, char const*)
+FUNC 11340 136 0 UnDecorator::getPtrRefType(DName const&, DName const&, char const*)
 11340 1b 4183 69
 1135b 1f 4188 69
 1137a c 4189 69
@@ -2849,11 +2849,11 @@ FUNC 11340 136 0 static UnDecorator::getPtrRefType(DName const&, DName const&, c
 11441 c 4225 69
 1144d d 4229 69
 1145a 1c 4232 69
-FUNC 114c4 17 0 static UnDecorator::getReferenceType(DName const&, DName const&, char const*)
+FUNC 114c4 17 0 UnDecorator::getReferenceType(DName const&, DName const&, char const*)
 114c4 9 4726 69
 114cd 8 4727 69
 114d5 6 4728 69
-FUNC 114e0 13d 0 static UnDecorator::getRestrictionSpec()
+FUNC 114e0 13d 0 UnDecorator::getRestrictionSpec()
 114e0 14 3648 69
 114f4 2a 3649 69
 1151e 7 3652 69
@@ -2880,14 +2880,14 @@ FUNC 114e0 13d 0 static UnDecorator::getRestrictionSpec()
 115f3 c 3693 69
 115ff 6 3697 69
 11605 18 3699 69
-FUNC 1166c 34 0 static UnDecorator::getReturnType(DName*)
+FUNC 1166c 34 0 UnDecorator::getReturnType(DName*)
 1166c 6 3322 69
 11672 f 3323 69
 11681 a 3325 69
 1168b 7 3327 69
 11692 5 3331 69
 11697 9 3333 69
-FUNC 116b0 478 0 static UnDecorator::getScope()
+FUNC 116b0 478 0 UnDecorator::getScope()
 116b0 1d 1693 69
 116cd 3 1694 69
 116d0 3 1693 69
@@ -2947,7 +2947,7 @@ FUNC 116b0 478 0 static UnDecorator::getScope()
 11ad1 2 1836 69
 11ad3 3a 1837 69
 11b0d 1b 1853 69
-FUNC 11c48 103 0 static UnDecorator::getScopedName()
+FUNC 11c48 103 0 UnDecorator::getScopedName()
 11c48 6 3131 69
 11c4e 4 3132 69
 11c52 3 3131 69
@@ -2968,7 +2968,7 @@ FUNC 11c48 103 0 static UnDecorator::getScopedName()
 11d06 3c 3153 69
 11d42 3 3157 69
 11d45 6 3159 69
-FUNC 11d8c 94 0 static UnDecorator::getSignedDimension()
+FUNC 11d8c 94 0 UnDecorator::getSignedDimension()
 11d8c d 1857 69
 11d99 d 1858 69
 11da6 10 1859 69
@@ -2977,7 +2977,7 @@ FUNC 11d8c 94 0 static UnDecorator::getSignedDimension()
 11dc6 44 1863 69
 11e0a 8 1866 69
 11e12 e 1867 69
-FUNC 11e48 3e 0 static UnDecorator::getStorageConvention()
+FUNC 11e48 3e 0 UnDecorator::getStorageConvention()
 11e48 3e 4694 69
 FUNC 11e98 1a 0 DName::getString(char*, char*) const
 11e98 8 555 70
@@ -3025,7 +3025,7 @@ FUNC 1201c 4b 0 pairNode::getString(char*, char*) const
 FUNC 1207c 36 0 pcharNode::getString(char*, char*) const
 1207c 35 972 70
 120b1 1 973 70
-FUNC 120c0 d0 0 static UnDecorator::getStringEncoding(char const*, int)
+FUNC 120c0 d0 0 UnDecorator::getStringEncoding(char const*, int)
 120c0 9 1655 69
 120c9 a 1656 69
 120d3 2d 1659 69
@@ -3050,7 +3050,7 @@ FUNC 121c4 2d 0 getStringHelper(char*, char const*, char const*, int)
 121cd 1d 212 70
 121ea 6 213 70
 121f0 1 214 70
-FUNC 121fc 4c 0 static UnDecorator::getSymbolName()
+FUNC 121fc 4c 0 UnDecorator::getSymbolName()
 121fc 6 1139 69
 12202 f 1140 69
 12211 8 1142 69
@@ -3058,7 +3058,7 @@ FUNC 121fc 4c 0 static UnDecorator::getSymbolName()
 12222 13 1150 69
 12235 a 1155 69
 1223f 9 1157 69
-FUNC 1225c 31a 0 static UnDecorator::getTemplateArgumentList()
+FUNC 1225c 31a 0 UnDecorator::getTemplateArgumentList()
 1225c 2d 2039 69
 12289 3 2041 69
 1228c 3 2040 69
@@ -3117,7 +3117,7 @@ FUNC 1225c 31a 0 static UnDecorator::getTemplateArgumentList()
 12543 7 2192 69
 1254a 3 2194 69
 1254d 29 2196 69
-FUNC 1263c 3a0 0 static UnDecorator::getTemplateConstant()
+FUNC 1263c 3a0 0 UnDecorator::getTemplateConstant()
 1263c 29 2214 69
 12665 18 2221 69
 1267d 3c 2222 69
@@ -3172,7 +3172,7 @@ FUNC 1263c 3a0 0 static UnDecorator::getTemplateConstant()
 12999 31 2391 69
 129ca 9 2370 69
 129d3 9 2367 69
-FUNC 12ac4 1fa 0 static UnDecorator::getTemplateName(bool)
+FUNC 12ac4 1fa 0 UnDecorator::getTemplateName(bool)
 12ac4 1f 1959 69
 12ae3 20 1963 69
 12b03 7 1973 69
@@ -3207,17 +3207,17 @@ FUNC 12ac4 1fa 0 static UnDecorator::getTemplateName(bool)
 12c8d 5 2033 69
 12c92 c 1964 69
 12c9e 20 2035 69
-FUNC 12d3c 42 0 static UnDecorator::getThisType()
+FUNC 12d3c 42 0 UnDecorator::getThisType()
 12d3c 8 4705 69
 12d44 29 4708 69
 12d6d 3 4705 69
 12d70 8 4708 69
 12d78 6 4709 69
-FUNC 12d90 23 0 static UnDecorator::getThrowTypes()
+FUNC 12d90 23 0 UnDecorator::getThrowTypes()
 12d90 18 3629 69
 12da8 a 3630 69
 12db2 1 3633 69
-FUNC 12dbc 35e 0 static UnDecorator::getTypeEncoding()
+FUNC 12dbc 35e 0 UnDecorator::getTypeEncoding()
 12dbc 17 2712 69
 12dd3 2 2713 69
 12dd5 6 2718 69
@@ -3336,7 +3336,7 @@ FUNC 131f4 109 0 UnDecorator::getUndecoratedName(char*, int)
 132ed 2 907 69
 132ef 3 912 69
 132f2 b 914 69
-FUNC 13340 58 0 static UnDecorator::getVCallThunkType()
+FUNC 13340 58 0 UnDecorator::getVCallThunkType()
 13340 6 4744 69
 13346 15 4746 69
 1335b c 4754 69
@@ -3344,11 +3344,11 @@ FUNC 13340 58 0 static UnDecorator::getVCallThunkType()
 1336a 18 4750 69
 13382 d 4752 69
 1338f 9 4858 69
-FUNC 133b0 17 0 static UnDecorator::getVbTableType(DName const&)
+FUNC 133b0 17 0 UnDecorator::getVbTableType(DName const&)
 133b0 9 4738 69
 133b9 8 4739 69
 133c1 6 4740 69
-FUNC 133cc 5f 0 static UnDecorator::getVdispMapType(DName const&)
+FUNC 133cc 5f 0 UnDecorator::getVdispMapType(DName const&)
 133cc 6 4918 69
 133d2 3 4919 69
 133d5 3 4918 69
@@ -3362,7 +3362,7 @@ FUNC 133cc 5f 0 static UnDecorator::getVdispMapType(DName const&)
 13418 a 4925 69
 13422 3 4926 69
 13425 6 4927 69
-FUNC 13444 1fd 0 static UnDecorator::getVfTableType(DName const&)
+FUNC 13444 1fd 0 UnDecorator::getVfTableType(DName const&)
 13444 15 4862 69
 13459 3 4863 69
 1345c 3 4862 69
@@ -3388,7 +3388,7 @@ FUNC 13444 1fd 0 static UnDecorator::getVfTableType(DName const&)
 135ff 2 4909 69
 13601 28 4910 69
 13629 18 4914 69
-FUNC 136c0 2d9 0 static UnDecorator::getZName(bool, bool)
+FUNC 136c0 2d9 0 UnDecorator::getZName(bool, bool)
 136c0 28 1161 69
 136e8 18 1162 69
 13700 6 1167 69
@@ -3432,7 +3432,7 @@ FUNC 136c0 2d9 0 static UnDecorator::getZName(bool, bool)
 1395c 9 1256 69
 13965 d 1259 69
 13972 27 1262 69
-FUNC 13a50 c 0 static UnDecorator::haveTemplateParameters()
+FUNC 13a50 c 0 UnDecorator::haveTemplateParameters()
 13a50 c 4969 69
 FUNC 13a60 a 0 DName::isArray() const
 13a60 9 467 70
@@ -3490,13 +3490,13 @@ FUNC 13b64 53 0 pairNode::length() const
 FUNC 13bcc 4 0 pcharNode::length() const
 13bcc 3 927 70
 13bcf 1 928 70
-FUNC 13bd0 1f 0 static DNameStatusNode::make(DNameStatus)
+FUNC 13bd0 1f 0 DNameStatusNode::make(DNameStatus)
 13bd0 5 1028 70
 13bd5 11 1029 70
 13be6 1 1032 70
 13be7 7 1031 70
 13bee 1 1032 70
-FUNC 13bf8 f5 0 static UnDecorator::parseDecoratedName()
+FUNC 13bf8 f5 0 UnDecorator::parseDecoratedName()
 13bf8 a 808 69
 13c02 7 814 69
 13c09 5 809 69
@@ -3978,7 +3978,7 @@ FUNC 154e0 a8 0 __FrameHandler4::TryBlockMap::iterator::operator++()
 1557f 4 835 60
 15583 4 836 60
 15587 1 838 60
-FUNC 155b4 56 0 static __FrameHandler3::CatchTryBlock(_s_FuncInfo const*, int)
+FUNC 155b4 56 0 __FrameHandler3::CatchTryBlock(_s_FuncInfo const*, int)
 155b4 f 162 77
 155c3 8 167 77
 155cb 1e 168 77
@@ -4009,27 +4009,27 @@ FUNC 156dc 9e 0 __FrameHandler4::TryBlockMap::DecompTryBlock()
 1573c 2b 913 60
 15767 12 914 60
 15779 1 915 60
-FUNC 157a4 2a 0 static __FrameHandler3::ExecutionInCatch(_xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 157a4 2a 0 __FrameHandler3::ExecutionInCatch(_xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 157a4 9 193 77
 157ad b 194 77
 157b8 10 195 77
 157c8 6 196 77
-FUNC 157d8 a 0 static __FrameHandler4::ExecutionInCatch(_xDISPATCHER_CONTEXT*, FuncInfo4*)
+FUNC 157d8 a 0 __FrameHandler4::ExecutionInCatch(_xDISPATCHER_CONTEXT*, FuncInfo4*)
 157d8 9 186 77
 157e1 1 187 77
-FUNC 157e4 64 0 static __FrameHandler3::FrameUnwindToEmptyState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 157e4 64 0 __FrameHandler3::FrameUnwindToEmptyState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 157e4 f 231 77
 157f3 10 236 77
 15803 e 241 77
 15811 a 242 77
 1581b 1d 244 77
 15838 10 246 77
-FUNC 15864 35 0 static __FrameHandler4::FrameUnwindToEmptyState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*)
+FUNC 15864 35 0 __FrameHandler4::FrameUnwindToEmptyState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*)
 15864 4 218 77
 15868 1e 221 77
 15886 e 223 77
 15894 5 224 77
-FUNC 158a8 c9 0 static __FrameHandler3::GetEstablisherFrame(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, unsigned long long*)
+FUNC 158a8 c9 0 __FrameHandler3::GetEstablisherFrame(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, unsigned long long*)
 158a8 16 110 77
 158be 7 114 77
 158c5 11 118 77
@@ -4044,13 +4044,13 @@ FUNC 158a8 c9 0 static __FrameHandler3::GetEstablisherFrame(unsigned long long*,
 1593e 5 132 77
 15943 14 136 77
 15957 1a 153 77
-FUNC 159a4 24 0 static __FrameHandler4::GetEstablisherFrame(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*, unsigned long long*)
+FUNC 159a4 24 0 __FrameHandler4::GetEstablisherFrame(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*, unsigned long long*)
 159a4 9 77 77
 159ad 9 79 77
 159b6 e 84 77
 159c4 3 97 77
 159c7 1 98 77
-FUNC 159d4 159 0 static __FrameHandler3::GetRangeOfTrysToCheck(__FrameHandler3::TryBlockMap&, int, int)
+FUNC 159d4 159 0 __FrameHandler3::GetRangeOfTrysToCheck(__FrameHandler3::TryBlockMap&, int, int)
 159d4 1e 483 77
 159f2 3 485 77
 159f5 3 483 77
@@ -4087,7 +4087,7 @@ FUNC 159d4 159 0 static __FrameHandler3::GetRangeOfTrysToCheck(__FrameHandler3::
 15b11 6 530 77
 15b17 10 531 77
 15b27 6 491 77
-FUNC 15b84 d3 0 static __FrameHandler4::GetRangeOfTrysToCheck(__FrameHandler4::TryBlockMap&, int, int)
+FUNC 15b84 d3 0 __FrameHandler4::GetRangeOfTrysToCheck(__FrameHandler4::TryBlockMap&, int, int)
 15b84 1e 456 77
 15ba2 8 457 77
 15baa 3 456 77
@@ -4123,13 +4123,13 @@ FUNC 15c9c 30 0 ReadUnsigned(unsigned char**)
 15cc0 8 198 60
 15cc8 3 199 60
 15ccb 1 202 60
-FUNC 15cd8 121 0 static __FrameHandler3::UnwindNestedFrames(unsigned long long*, EHExceptionRecord*, _CONTEXT*, unsigned long long*, void*, _s_FuncInfo const*, int, int, _s_HandlerType const*, _xDISPATCHER_CONTEXT*, unsigned char)
+FUNC 15cd8 121 0 __FrameHandler3::UnwindNestedFrames(unsigned long long*, EHExceptionRecord*, _CONTEXT*, unsigned long long*, void*, _s_FuncInfo const*, int, int, _s_HandlerType const*, _xDISPATCHER_CONTEXT*, unsigned char)
 15cd8 29 674 77
 15d01 69 705 77
 15d6a 7 706 77
 15d71 70 738 77
 15de1 18 744 77
-FUNC 15e44 170 0 static __FrameHandler4::UnwindNestedFrames(unsigned long long*, EHExceptionRecord*, _CONTEXT*, unsigned long long*, void*, FuncInfo4*, int, int, HandlerType4*, _xDISPATCHER_CONTEXT*, unsigned char)
+FUNC 15e44 170 0 __FrameHandler4::UnwindNestedFrames(unsigned long long*, EHExceptionRecord*, _CONTEXT*, unsigned long long*, void*, FuncInfo4*, int, int, HandlerType4*, _xDISPATCHER_CONTEXT*, unsigned char)
 15e44 2d 582 77
 15e71 68 613 77
 15ed9 c 614 77
@@ -4494,30 +4494,30 @@ FUNC 164f0 435 0 memcpy()
 1691e 3 671 78
 16921 3 672 78
 16924 1 673 78
-FUNC 16a40 27 0 static __FrameHandler3::GetCurrentState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 16a40 27 0 __FrameHandler3::GetCurrentState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 16a40 4 179 79
 16a44 13 180 79
 16a57 b 181 79
 16a62 5 186 79
-FUNC 16a70 29 0 static __FrameHandler3::GetUnwindTryBlock(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 16a70 29 0 __FrameHandler3::GetUnwindTryBlock(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 16a70 6 168 79
 16a76 10 170 79
 16a86 d 171 79
 16a93 6 172 79
-FUNC 16aa4 c 0 static __FrameHandler3::SetState(unsigned long long*, _s_FuncInfo const*, int)
+FUNC 16aa4 c 0 __FrameHandler3::SetState(unsigned long long*, _s_FuncInfo const*, int)
 16aa4 b 194 79
 16aaf 1 195 79
-FUNC 16ab4 3b 0 static __FrameHandler3::SetUnwindTryBlock(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, int)
+FUNC 16ab4 3b 0 __FrameHandler3::SetUnwindTryBlock(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, int)
 16ab4 10 155 79
 16ac4 d 157 79
 16ad1 f 158 79
 16ae0 4 159 79
 16ae4 b 161 79
-FUNC 16b00 8 0 static __FrameHandler3::StateFromControlPc(_s_FuncInfo const*, _xDISPATCHER_CONTEXT*)
+FUNC 16b00 8 0 __FrameHandler3::StateFromControlPc(_s_FuncInfo const*, _xDISPATCHER_CONTEXT*)
 16b00 8 136 79
-FUNC 16b0c 8 0 static __FrameHandler4::StateFromControlPc(FuncInfo4*, _xDISPATCHER_CONTEXT*)
+FUNC 16b0c 8 0 __FrameHandler4::StateFromControlPc(FuncInfo4*, _xDISPATCHER_CONTEXT*)
 16b0c 8 146 79
-FUNC 16b18 66 0 static __FrameHandler3::StateFromIp(_s_FuncInfo const*, _xDISPATCHER_CONTEXT*, unsigned long long)
+FUNC 16b18 66 0 __FrameHandler3::StateFromIp(_s_FuncInfo const*, _xDISPATCHER_CONTEXT*, unsigned long long)
 16b18 9 98 79
 16b21 5 105 79
 16b26 11 108 79
@@ -4529,7 +4529,7 @@ FUNC 16b18 66 0 static __FrameHandler3::StateFromIp(_s_FuncInfo const*, _xDISPAT
 16b6d 6 127 79
 16b73 5 120 79
 16b78 6 105 79
-FUNC 16b98 ed 0 static __FrameHandler4::StateFromIp(FuncInfo4*, _xDISPATCHER_CONTEXT*, unsigned long long)
+FUNC 16b98 ed 0 __FrameHandler4::StateFromIp(FuncInfo4*, _xDISPATCHER_CONTEXT*, unsigned long long)
 16b98 1c 60 79
 16bb4 10 66 79
 16bc4 4 68 79
@@ -5013,15 +5013,15 @@ FUNC 1942c c 0 UWMap::iterator::operator>=(UWMap::iterator const&) const
 19437 1 283 60
 FUNC 1943c 42 0 std::bad_exception::`scalar deleting destructor'(unsigned int)
 FUNC 19490 42 0 std::exception::`scalar deleting destructor'(unsigned int)
-FUNC 194e4 5 0 static __FrameHandler3::BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 194e4 5 0 __FrameHandler3::BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 194e4 5 2027 80
-FUNC 194ec 5 0 static __FrameHandler4::BuildCatchObject(EHExceptionRecord*, void*, HandlerType4*, _s_CatchableType const*)
+FUNC 194ec 5 0 __FrameHandler4::BuildCatchObject(EHExceptionRecord*, void*, HandlerType4*, _s_CatchableType const*)
 194ec 5 2038 80
-FUNC 194f4 5 0 static __FrameHandler3::BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 194f4 5 0 __FrameHandler3::BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 194f4 5 1916 80
-FUNC 194fc 5 0 static __FrameHandler4::BuildCatchObjectHelper(EHExceptionRecord*, void*, HandlerType4*, _s_CatchableType const*)
+FUNC 194fc 5 0 __FrameHandler4::BuildCatchObjectHelper(EHExceptionRecord*, void*, HandlerType4*, _s_CatchableType const*)
 194fc 5 1927 80
-FUNC 19504 1ea 0 static __FrameHandler3::CxxCallCatchBlock(_EXCEPTION_RECORD*)
+FUNC 19504 1ea 0 __FrameHandler3::CxxCallCatchBlock(_EXCEPTION_RECORD*)
 19504 13 1489 80
 19517 10 1490 80
 19527 5 1492 80
@@ -5057,7 +5057,7 @@ FUNC 19504 1ea 0 static __FrameHandler3::CxxCallCatchBlock(_EXCEPTION_RECORD*)
 196c7 14 1563 80
 196db 3 1565 80
 196de 10 1566 80
-FUNC 19768 240 0 static __FrameHandler4::CxxCallCatchBlock(_EXCEPTION_RECORD*)
+FUNC 19768 240 0 __FrameHandler4::CxxCallCatchBlock(_EXCEPTION_RECORD*)
 19768 16 1382 80
 1977e 10 1383 80
 1978e 5 1385 80
@@ -5138,7 +5138,7 @@ FUNC 19bd0 87 0 ExFilterRethrow(_EXCEPTION_POINTERS*, EHExceptionRecord*, int*)
 19c42 d 1595 80
 19c4f 2 1597 80
 19c51 6 1598 80
-FUNC 19c78 193 0 static __FrameHandler3::FrameUnwindToState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, int)
+FUNC 19c78 193 0 __FrameHandler3::FrameUnwindToState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, int)
 19c78 2a 1167 80
 19ca2 d 1173 80
 19caf 10 1176 80
@@ -5161,7 +5161,7 @@ FUNC 19c78 193 0 static __FrameHandler3::FrameUnwindToState(unsigned long long*,
 19def 10 1240 80
 19dff 6 1185 80
 19e05 6 1230 80
-FUNC 19e70 2d9 0 static __FrameHandler4::FrameUnwindToState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*, int)
+FUNC 19e70 2d9 0 __FrameHandler4::FrameUnwindToState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*, int)
 19e70 41 1017 80
 19eb1 a 1023 80
 19ebb 3 1027 80
@@ -5203,7 +5203,7 @@ FUNC 19e70 2d9 0 static __FrameHandler4::FrameUnwindToState(unsigned long long*,
 1a106 8 1142 80
 1a10e 10 1149 80
 1a11e 2b 1156 80
-FUNC 1a200 96 0 static __FrameHandler3::GetHandlerSearchState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 1a200 96 0 __FrameHandler3::GetHandlerSearchState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 1a200 1a 444 80
 1a21a b 446 80
 1a225 15 448 80
@@ -5213,7 +5213,7 @@ FUNC 1a200 96 0 static __FrameHandler3::GetHandlerSearchState(unsigned long long
 1a26d 2 453 80
 1a26f 10 454 80
 1a27f 17 458 80
-FUNC 1a2bc 37 0 static __FrameHandler4::GetHandlerSearchState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*)
+FUNC 1a2bc 37 0 __FrameHandler4::GetHandlerSearchState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*)
 1a2bc 6 465 80
 1a2c2 a 466 80
 1a2cc b 468 80
@@ -5221,10 +5221,10 @@ FUNC 1a2bc 37 0 static __FrameHandler4::GetHandlerSearchState(unsigned long long
 1a2df c 471 80
 1a2eb 2 474 80
 1a2ed 6 475 80
-FUNC 1a300 4 0 static __FrameHandler3::GetMaxState(_xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 1a300 4 0 __FrameHandler3::GetMaxState(_xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 1a300 3 449 60
 1a303 1 450 60
-FUNC 1a304 38 0 static __FrameHandler4::GetMaxState(_xDISPATCHER_CONTEXT*, FuncInfo4*)
+FUNC 1a304 38 0 __FrameHandler4::GetMaxState(_xDISPATCHER_CONTEXT*, FuncInfo4*)
 1a304 6 731 60
 1a30a 4 733 60
 1a30e 7 734 60
@@ -5272,9 +5272,9 @@ FUNC 1a510 99 0 UWMap::ReadEntry()
 1a56f e 375 60
 1a57d 2b 376 60
 1a5a8 1 382 60
-FUNC 1a5d0 5 0 static __FrameHandler3::TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
+FUNC 1a5d0 5 0 __FrameHandler3::TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
 1a5d0 5 977 80
-FUNC 1a5d8 5 0 static __FrameHandler4::TypeMatch(HandlerType4*, _s_CatchableType const*, _s_ThrowInfo const*)
+FUNC 1a5d8 5 0 __FrameHandler4::TypeMatch(HandlerType4*, _s_CatchableType const*, _s_ThrowInfo const*)
 1a5d8 5 987 80
 FUNC 1a5e0 2e 0 UWMap::WalkBack()
 1a5e0 a 385 60
@@ -5315,11 +5315,11 @@ FUNC 1a6a4 c 0 __FrameHandler3::HandlerMap::end()
 FUNC 1a6b4 c 0 __FrameHandler4::HandlerMap::end()
 1a6b4 b 984 60
 1a6bf 1 985 60
-FUNC 1a6c4 28 0 static __FrameHandler3::getESTypes(_s_FuncInfo const*)
+FUNC 1a6c4 28 0 __FrameHandler3::getESTypes(_s_FuncInfo const*)
 1a6c4 6 196 80
 1a6ca 1c 197 80
 1a6e6 6 198 80
-FUNC 1a6f8 3 0 static __FrameHandler4::getESTypes(FuncInfo4*)
+FUNC 1a6f8 3 0 __FrameHandler4::getESTypes(FuncInfo4*)
 1a6f8 2 801 60
 1a6fa 1 802 60
 FUNC 1a6fc 13 0 __FrameHandler3::HandlerMap::getLastEntry()
@@ -5333,10 +5333,10 @@ FUNC 1a714 4e 0 __FrameHandler4::HandlerMap::getLastEntry()
 1a72e 25 1009 60
 1a753 4 1010 60
 1a757 b 1011 60
-FUNC 1a778 8 0 static __FrameHandler3::getMagicNum(_s_FuncInfo const*)
+FUNC 1a778 8 0 __FrameHandler3::getMagicNum(_s_FuncInfo const*)
 1a778 7 505 60
 1a77f 1 506 60
-FUNC 1a784 6 0 static __FrameHandler4::getMagicNum(FuncInfo4*)
+FUNC 1a784 6 0 __FrameHandler4::getMagicNum(FuncInfo4*)
 1a784 5 795 60
 1a789 1 796 60
 FUNC 1a78c 7 0 __FrameHandler3::TryBlockMap::getNumTryBlocks()
@@ -5381,16 +5381,16 @@ FUNC 1a87c 86 0 UWMap::getStateIter(int)
 1a8d5 8 346 60
 1a8dd 7 347 60
 1a8e4 1e 348 60
-FUNC 1a924 6 0 static __FrameHandler3::isEHs(_s_FuncInfo const*)
+FUNC 1a924 6 0 __FrameHandler3::isEHs(_s_FuncInfo const*)
 1a924 5 495 60
 1a929 1 496 60
-FUNC 1a92c 8 0 static __FrameHandler4::isEHs(FuncInfo4*)
+FUNC 1a92c 8 0 __FrameHandler4::isEHs(FuncInfo4*)
 1a92c 7 784 60
 1a933 1 785 60
-FUNC 1a938 9 0 static __FrameHandler3::isNoExcept(_s_FuncInfo const*)
+FUNC 1a938 9 0 __FrameHandler3::isNoExcept(_s_FuncInfo const*)
 1a938 8 500 60
 1a940 1 501 60
-FUNC 1a944 8 0 static __FrameHandler4::isNoExcept(FuncInfo4*)
+FUNC 1a944 8 0 __FrameHandler4::isNoExcept(FuncInfo4*)
 1a944 7 789 60
 1a94b 1 790 60
 FUNC 1a950 11 0 HandlerType4::reset()
@@ -5767,7 +5767,7 @@ FUNC 1b764 21 0 __crt_unique_handle_t<__crt_hmodule_traits>::close()
 1b775 6 1146 201
 1b77b 4 1147 201
 1b77f 6 1148 201
-FUNC 1b790 14 0 static __crt_hmodule_traits::close(HINSTANCE__*)
+FUNC 1b790 14 0 __crt_hmodule_traits::close(HINSTANCE__*)
 1b790 4 1061 201
 1b794 b 1062 201
 1b79f 5 1063 201
@@ -5793,7 +5793,7 @@ FUNC 1b8f4 4 0 __crt_unique_handle_t<__crt_hmodule_traits>::get() const
 FUNC 1b8f8 4 0 __crt_unique_handle_t<__crt_hmodule_traits>::get_address_of()
 1b8f8 3 1162 201
 1b8fb 1 1163 201
-FUNC 1b8fc 3 0 static __crt_hmodule_traits::get_invalid_value()
+FUNC 1b8fc 3 0 __crt_hmodule_traits::get_invalid_value()
 1b8fc 2 1067 201
 1b8fe 1 1068 201
 FUNC 1b900 52 0 is_managed_app()
@@ -5910,9 +5910,9 @@ FUNC 1bcd0 171 0 common_configure_argv<wchar_t>(const _crt_argv_mode)
 1be0f e 390 321
 1be1d 13 391 321
 1be30 11 392 321
-FUNC 1bea0 b 0 static __crt_char_traits<char>::get_module_file_name<std::nullptr_t,char (&)[261],int>(void*&&, char[261]&, int&&)
+FUNC 1bea0 b 0 __crt_char_traits<char>::get_module_file_name<std::nullptr_t,char (&)[261],int>(void*&&, char[261]&, int&&)
 1bea0 b 109 322
-FUNC 1beb0 d 0 static __crt_char_traits<wchar_t>::get_module_file_name<std::nullptr_t,wchar_t (&)[261],int>(void*&&, wchar_t[261]&, int&&)
+FUNC 1beb0 d 0 __crt_char_traits<wchar_t>::get_module_file_name<std::nullptr_t,wchar_t (&)[261],int>(void*&&, wchar_t[261]&, int&&)
 1beb0 d 124 322
 FUNC 1bec0 1c3 0 parse_command_line<char>(char*, char**, char*, unsigned long long*, unsigned long long*)
 1bec0 1d 102 321
@@ -6044,9 +6044,9 @@ FUNC 1c0f4 1a2 0 parse_command_line<wchar_t>(wchar_t*, wchar_t**, wchar_t*, unsi
 1c279 3 259 321
 1c27c 3 261 321
 1c27f 17 262 321
-FUNC 1c300 b 0 static __crt_char_traits<char>::set_program_name<char *>(char*&&)
+FUNC 1c300 b 0 __crt_char_traits<char>::set_program_name<char *>(char*&&)
 1c300 b 109 322
-FUNC 1c310 b 0 static __crt_char_traits<wchar_t>::set_program_name<wchar_t *>(wchar_t*&&)
+FUNC 1c310 b 0 __crt_char_traits<wchar_t>::set_program_name<wchar_t *>(wchar_t*&&)
 1c310 b 124 322
 FUNC 1c320 7 0 <lambda_a36aafc41185bea294aaaa3896c79ecc>::<lambda_a36aafc41185bea294aaaa3896c79ecc>(__crt_unique_heap_ptr<wchar_t *,__crt_internal_free_policy>&)
 1c320 7 388 321
@@ -6305,9 +6305,9 @@ FUNC 1cf70 41 0 free_environment<wchar_t>(wchar_t** const)
 1cf99 5 95 329
 1cf9e 8 98 329
 1cfa6 b 99 329
-FUNC 1cfc4 5 0 static __crt_char_traits<char>::get_environment_from_os<>()
+FUNC 1cfc4 5 0 __crt_char_traits<char>::get_environment_from_os<>()
 1cfc4 5 109 322
-FUNC 1cfcc 5 0 static __crt_char_traits<wchar_t>::get_environment_from_os<>()
+FUNC 1cfcc 5 0 __crt_char_traits<wchar_t>::get_environment_from_os<>()
 1cfcc 5 124 322
 FUNC 1cfd4 d1 0 initialize_environment_by_cloning_nolock<char>()
 1cfd4 f 242 329
@@ -6341,17 +6341,17 @@ FUNC 1d0dc b1 0 initialize_environment_by_cloning_nolock<wchar_t>()
 1d16f c 250 329
 1d17b 5 268 329
 1d180 d 262 329
-FUNC 1d1bc a 0 static __crt_char_traits<char>::set_variable_in_environment_nolock<char *,int>(char*&&, int&&)
+FUNC 1d1bc a 0 __crt_char_traits<char>::set_variable_in_environment_nolock<char *,int>(char*&&, int&&)
 1d1bc a 109 322
-FUNC 1d1c8 a 0 static __crt_char_traits<wchar_t>::set_variable_in_environment_nolock<wchar_t *,int>(wchar_t*&&, int&&)
+FUNC 1d1c8 a 0 __crt_char_traits<wchar_t>::set_variable_in_environment_nolock<wchar_t *,int>(wchar_t*&&, int&&)
 1d1c8 a 124 322
-FUNC 1d1d4 e 0 static __crt_char_traits<char>::tcscpy_s<char *,unsigned __int64 const &,char * &>(char*&&, unsigned long long const&, char*&)
+FUNC 1d1d4 e 0 __crt_char_traits<char>::tcscpy_s<char *,unsigned __int64 const &,char * &>(char*&&, unsigned long long const&, char*&)
 1d1d4 e 109 322
-FUNC 1d1e8 e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t *,unsigned __int64 const &,wchar_t * &>(wchar_t*&&, unsigned long long const&, wchar_t*&)
+FUNC 1d1e8 e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t *,unsigned __int64 const &,wchar_t * &>(wchar_t*&&, unsigned long long const&, wchar_t*&)
 1d1e8 e 124 322
-FUNC 1d1fc 11 0 static __crt_char_traits<char>::tcslen<char * &>(char*&)
+FUNC 1d1fc 11 0 __crt_char_traits<char>::tcslen<char * &>(char*&)
 1d1fc 11 109 322
-FUNC 1d214 12 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t * &>(wchar_t*&)
+FUNC 1d214 12 0 __crt_char_traits<wchar_t>::tcslen<wchar_t * &>(wchar_t*&)
 1d214 12 124 322
 FUNC 1d22c 43 0 __crt_state_management::dual_state_global<char * *>::uninitialize<void (__cdecl&)(char * * &)>(void (&)(char**&))
 1d22c f 177 180
@@ -8021,84 +8021,84 @@ FUNC 23d34 13 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::st
 23d34 d 1007 353
 23d41 5 1009 353
 23d46 1 1010 353
-FUNC 23d4c 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<char>(char*)
+FUNC 23d4c 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<char>(char*)
 23d4c 6 1452 353
-FUNC 23d54 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<char>(char*)
+FUNC 23d54 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<char>(char*)
 23d54 6 1452 353
-FUNC 23d5c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
+FUNC 23d5c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
 23d5c 6 1452 353
-FUNC 23d64 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
+FUNC 23d64 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
 23d64 6 1452 353
-FUNC 23d6c 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
+FUNC 23d6c 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
 23d6c 6 1452 353
-FUNC 23d74 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
+FUNC 23d74 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
 23d74 6 1452 353
-FUNC 23d7c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
+FUNC 23d7c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
 23d7c 6 1452 353
-FUNC 23d84 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
+FUNC 23d84 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
 23d84 6 1452 353
-FUNC 23d8c 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<void>(void*)
+FUNC 23d8c 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<void>(void*)
 23d8c 6 1452 353
-FUNC 23d94 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<void>(void*)
+FUNC 23d94 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<void>(void*)
 23d94 6 1452 353
-FUNC 23d9c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
+FUNC 23d9c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
 23d9c 6 1452 353
-FUNC 23da4 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
+FUNC 23da4 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
 23da4 6 1452 353
-FUNC 23dac a 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_character_specifier<char>(const char)
+FUNC 23dac a 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_character_specifier<char>(const char)
 23dac 9 1567 353
 23db5 1 1568 353
-FUNC 23db8 a 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_character_specifier<char>(const char)
+FUNC 23db8 a 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_character_specifier<char>(const char)
 23db8 9 1567 353
 23dc1 1 1568 353
-FUNC 23dc4 10 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
+FUNC 23dc4 10 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
 23dc4 f 1567 353
 23dd3 1 1568 353
-FUNC 23dd8 10 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
+FUNC 23dd8 10 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
 23dd8 f 1567 353
 23de7 1 1568 353
-FUNC 23dec 26 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_integral_specifier<char>(const char)
+FUNC 23dec 26 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_integral_specifier<char>(const char)
 23dec 22 1573 353
 23e0e 1 1576 353
 23e0f 2 1573 353
 23e11 1 1576 353
-FUNC 23e1c 26 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_integral_specifier<char>(const char)
+FUNC 23e1c 26 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_integral_specifier<char>(const char)
 23e1c 22 1573 353
 23e3e 1 1576 353
 23e3f 2 1573 353
 23e41 1 1576 353
-FUNC 23e4c 28 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
+FUNC 23e4c 28 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
 23e4c 24 1573 353
 23e70 1 1576 353
 23e71 2 1573 353
 23e73 1 1576 353
-FUNC 23e80 28 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
+FUNC 23e80 28 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
 23e80 24 1573 353
 23ea4 1 1576 353
 23ea5 2 1573 353
 23ea7 1 1576 353
-FUNC 23eb4 7 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_pointer_specifier<char>(const char)
+FUNC 23eb4 7 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_pointer_specifier<char>(const char)
 23eb4 6 1555 353
 23eba 1 1556 353
-FUNC 23ebc 7 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_pointer_specifier<char>(const char)
+FUNC 23ebc 7 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_pointer_specifier<char>(const char)
 23ebc 6 1555 353
 23ec2 1 1556 353
-FUNC 23ec4 8 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
+FUNC 23ec4 8 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
 23ec4 7 1555 353
 23ecb 1 1556 353
-FUNC 23ed0 8 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
+FUNC 23ed0 8 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
 23ed0 7 1555 353
 23ed7 1 1556 353
-FUNC 23edc a 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_string_specifier<char>(const char)
+FUNC 23edc a 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_string_specifier<char>(const char)
 23edc 9 1561 353
 23ee5 1 1562 353
-FUNC 23ee8 a 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_string_specifier<char>(const char)
+FUNC 23ee8 a 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_string_specifier<char>(const char)
 23ee8 9 1561 353
 23ef1 1 1562 353
-FUNC 23ef4 10 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
+FUNC 23ef4 10 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
 23ef4 f 1561 353
 23f03 1 1562 353
-FUNC 23f08 10 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
+FUNC 23f08 10 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
 23f08 f 1561 353
 23f17 1 1562 353
 FUNC 23f1c 28 0 __crt_stdio_output::is_wide_character_specifier<char>(const unsigned long long, const char, const __crt_stdio_output::length_modifier)
@@ -8168,9 +8168,9 @@ FUNC 23fd8 4 0 __crt_stdio_output::peek_va_arg<unsigned __int64>(char*)
 FUNC 23fdc 4 0 __crt_stdio_output::peek_va_arg<wchar_t>(char*)
 23fdc 3 40 353
 23fdf 1 41 353
-FUNC 23fe0 b 0 static __crt_char_traits<char>::puttc_nolock<char const &,_iobuf *>(char const&, _iobuf*&&)
+FUNC 23fe0 b 0 __crt_char_traits<char>::puttc_nolock<char const &,_iobuf *>(char const&, _iobuf*&&)
 23fe0 b 109 322
-FUNC 23ff0 b 0 static __crt_char_traits<wchar_t>::puttc_nolock<wchar_t const &,_iobuf *>(wchar_t const&, _iobuf*&&)
+FUNC 23ff0 b 0 __crt_char_traits<wchar_t>::puttc_nolock<wchar_t const &,_iobuf *>(wchar_t const&, _iobuf*&&)
 23ff0 b 124 322
 FUNC 24000 b 0 __crt_stdio_output::read_va_arg<signed char>(char*&)
 24000 a 34 353
@@ -8255,13 +8255,13 @@ FUNC 241a4 22 0 __crt_stdio_output::formatting_buffer::scratch_data<char>()
 241b7 1 392 353
 241b8 d 391 353
 241c5 1 392 353
-FUNC 241d0 e 0 static __crt_char_traits<char>::tcstol<char const * &,char * *,int>(char const*&, char**&&, int&&)
+FUNC 241d0 e 0 __crt_char_traits<char>::tcstol<char const * &,char * *,int>(char const*&, char**&&, int&&)
 241d0 e 109 322
-FUNC 241e4 e 0 static __crt_char_traits<wchar_t>::tcstol<wchar_t const * &,wchar_t * *,int>(wchar_t const*&, wchar_t**&&, int&&)
+FUNC 241e4 e 0 __crt_char_traits<wchar_t>::tcstol<wchar_t const * &,wchar_t * *,int>(wchar_t const*&, wchar_t**&&, int&&)
 241e4 e 124 322
-FUNC 241f8 e 0 static __crt_char_traits<char>::tcstol<char const *,char * *,int>(char const*&&, char**&&, int&&)
+FUNC 241f8 e 0 __crt_char_traits<char>::tcstol<char const *,char * *,int>(char const*&&, char**&&, int&&)
 241f8 e 109 322
-FUNC 2420c e 0 static __crt_char_traits<wchar_t>::tcstol<wchar_t const *,wchar_t * *,int>(wchar_t const*&&, wchar_t**&&, int&&)
+FUNC 2420c e 0 __crt_char_traits<wchar_t>::tcstol<wchar_t const *,wchar_t * *,int>(wchar_t const*&&, wchar_t**&&, int&&)
 2420c e 124 322
 FUNC 24220 87 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_integer_parse_into_buffer<unsigned int>(unsigned int, const unsigned int, const bool)
 24220 5 2584 353
@@ -8968,40 +8968,40 @@ FUNC 27270 8 0 <lambda_fe5404e9642edbb7c8ae71e1dcfa4018>::operator()() const
 FUNC 2727c 5 0 _LocaleUpdate::GetLocaleT()
 2727c 4 1844 201
 27280 1 1845 201
-FUNC 27284 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 27284 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 27284 b 2730 353
 2728f 1 2734 353
-FUNC 27294 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 27294 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 27294 b 2730 353
 2729f 1 2734 353
-FUNC 272a4 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 272a4 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 272a4 b 2730 353
 272af 1 2734 353
-FUNC 272b4 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 272b4 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 272b4 b 2730 353
 272bf 1 2734 353
-FUNC 272c4 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 272c4 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 272c4 b 2730 353
 272cf 1 2734 353
-FUNC 272d4 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 272d4 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 272d4 b 2730 353
 272df 1 2734 353
-FUNC 272e4 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 272e4 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 272e4 b 2730 353
 272ef 1 2734 353
-FUNC 272f4 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 272f4 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 272f4 b 2730 353
 272ff 1 2734 353
-FUNC 27304 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 27304 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 27304 b 2730 353
 2730f 1 2734 353
-FUNC 27314 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 27314 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 27314 b 2730 353
 2731f 1 2734 353
-FUNC 27324 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 27324 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 27324 b 2730 353
 2732f 1 2734 353
-FUNC 27334 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 27334 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 27334 b 2730 353
 2733f 1 2734 353
 FUNC 27344 50 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::advance_to_next_pass()
@@ -9147,69 +9147,69 @@ FUNC 2792c 1f 0 __crt_deferred_errno_cache::get()
 FUNC 27954 7 0 __crt_stdio_stream::get_flags() const
 27954 6 233 337
 2795a 1 234 337
-FUNC 2795c 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(short)
+FUNC 2795c 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(short)
 2795c 6 1453 353
-FUNC 27964 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned short)
+FUNC 27964 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned short)
 27964 6 1454 353
-FUNC 2796c 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(int)
+FUNC 2796c 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(int)
 2796c 6 1456 353
-FUNC 27974 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned int)
+FUNC 27974 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned int)
 27974 6 1457 353
-FUNC 2797c 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 2797c 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
 2797c 6 1460 353
-FUNC 27984 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(long long)
+FUNC 27984 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(long long)
 27984 6 1458 353
-FUNC 2798c 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned long long)
+FUNC 2798c 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned long long)
 2798c 6 1459 353
-FUNC 27994 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(wchar_t)
+FUNC 27994 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(wchar_t)
 27994 6 1455 353
-FUNC 2799c 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(short)
+FUNC 2799c 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(short)
 2799c 6 1453 353
-FUNC 279a4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned short)
+FUNC 279a4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned short)
 279a4 6 1454 353
-FUNC 279ac 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(int)
+FUNC 279ac 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(int)
 279ac 6 1456 353
-FUNC 279b4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned int)
+FUNC 279b4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned int)
 279b4 6 1457 353
-FUNC 279bc 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 279bc 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
 279bc 6 1460 353
-FUNC 279c4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(long long)
+FUNC 279c4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(long long)
 279c4 6 1458 353
-FUNC 279cc 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned long long)
+FUNC 279cc 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned long long)
 279cc 6 1459 353
-FUNC 279d4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(wchar_t)
+FUNC 279d4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(wchar_t)
 279d4 6 1455 353
-FUNC 279dc 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(short)
+FUNC 279dc 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(short)
 279dc 6 1453 353
-FUNC 279e4 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
+FUNC 279e4 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
 279e4 6 1454 353
-FUNC 279ec 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(int)
+FUNC 279ec 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(int)
 279ec 6 1456 353
-FUNC 279f4 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
+FUNC 279f4 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
 279f4 6 1457 353
-FUNC 279fc 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 279fc 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
 279fc 6 1460 353
-FUNC 27a04 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(long long)
+FUNC 27a04 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(long long)
 27a04 6 1458 353
-FUNC 27a0c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
+FUNC 27a0c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
 27a0c 6 1459 353
-FUNC 27a14 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
+FUNC 27a14 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
 27a14 6 1455 353
-FUNC 27a1c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(short)
+FUNC 27a1c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(short)
 27a1c 6 1453 353
-FUNC 27a24 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
+FUNC 27a24 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
 27a24 6 1454 353
-FUNC 27a2c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(int)
+FUNC 27a2c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(int)
 27a2c 6 1456 353
-FUNC 27a34 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
+FUNC 27a34 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
 27a34 6 1457 353
-FUNC 27a3c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 27a3c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
 27a3c 6 1460 353
-FUNC 27a44 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(long long)
+FUNC 27a44 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(long long)
 27a44 6 1458 353
-FUNC 27a4c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
+FUNC 27a4c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
 27a4c 6 1459 353
-FUNC 27a54 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
+FUNC 27a54 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
 27a54 6 1455 353
 FUNC 27a5c 7 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::has_flag(const unsigned int) const
 27a5c 7 2707 353
@@ -9373,29 +9373,29 @@ FUNC 282b4 200 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_std
 284a4 10 1527 353
 FUNC 28534 c 0 __crt_stdio_stream::is_string_backed() const
 28534 c 227 337
-FUNC 28544 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 28544 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 28544 8 2737 353
-FUNC 28550 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 28550 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 28550 8 2737 353
-FUNC 2855c 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 2855c 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 2855c 8 2737 353
-FUNC 28568 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 28568 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 28568 8 2737 353
-FUNC 28574 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 28574 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 28574 8 2737 353
-FUNC 28580 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 28580 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 28580 8 2737 353
-FUNC 2858c 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 2858c 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 2858c 8 2737 353
-FUNC 28598 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 28598 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 28598 8 2737 353
-FUNC 285a4 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 285a4 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 285a4 8 2737 353
-FUNC 285b0 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 285b0 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 285b0 8 2737 353
-FUNC 285bc 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 285bc 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 285bc 8 2737 353
-FUNC 285c8 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 285c8 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 285c8 8 2737 353
 FUNC 285d4 a1 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::parse_int_from_format_string(int* const)
 285d4 12 1775 353
@@ -11834,52 +11834,52 @@ FUNC 31160 32 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output:
 3118a 5 1814 353
 3118f 2 1817 353
 31191 1 1818 353
-FUNC 311a0 6 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
+FUNC 311a0 6 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
 311a0 5 1103 353
 311a5 1 1104 353
-FUNC 311a8 6 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
+FUNC 311a8 6 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
 311a8 5 1103 353
 311ad 1 1104 353
-FUNC 311b0 6 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
+FUNC 311b0 6 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
 311b0 5 1103 353
 311b5 1 1104 353
-FUNC 311b8 6 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
+FUNC 311b8 6 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
 311b8 5 1103 353
 311bd 1 1104 353
-FUNC 311c0 6 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
+FUNC 311c0 6 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
 311c0 5 1046 353
 311c5 1 1047 353
-FUNC 311c8 6 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
+FUNC 311c8 6 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
 311c8 5 1046 353
 311cd 1 1047 353
-FUNC 311d0 6 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
+FUNC 311d0 6 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
 311d0 5 1046 353
 311d5 1 1047 353
-FUNC 311d8 6 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
+FUNC 311d8 6 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
 311d8 5 1046 353
 311dd 1 1047 353
-FUNC 311e0 8 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
+FUNC 311e0 8 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
 311e0 7 1108 353
 311e7 1 1109 353
-FUNC 311ec 8 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
+FUNC 311ec 8 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
 311ec 7 1108 353
 311f3 1 1109 353
-FUNC 311f8 8 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
+FUNC 311f8 8 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
 311f8 7 1108 353
 311ff 1 1109 353
-FUNC 31204 8 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
+FUNC 31204 8 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
 31204 7 1108 353
 3120b 1 1109 353
-FUNC 31210 8 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
+FUNC 31210 8 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
 31210 7 1051 353
 31217 1 1052 353
-FUNC 3121c 8 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
+FUNC 3121c 8 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
 3121c 7 1051 353
 31223 1 1052 353
-FUNC 31228 8 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
+FUNC 31228 8 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
 31228 7 1051 353
 3122f 1 1052 353
-FUNC 31234 8 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
+FUNC 31234 8 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
 31234 7 1051 353
 3123b 1 1052 353
 FUNC 31240 5 0 __crt_stdio_output::common_data<char>::tchar_string(char)
@@ -14283,37 +14283,37 @@ FUNC 3a3a4 3 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::str
 FUNC 3a3a8 3 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::validate_state_for_type_case_a() const
 3a3a8 2 1026 353
 3a3aa 1 1027 353
-FUNC 3a3ac 9a 0 static __acrt_stdio_char_traits<char>::validate_stream_is_ansi_if_required(_iobuf* const)
+FUNC 3a3ac 9a 0 __acrt_stdio_char_traits<char>::validate_stream_is_ansi_if_required(_iobuf* const)
 3a3ac 4 439 337
 3a3b0 8f 440 337
 3a43f 2 441 337
 3a441 5 442 337
-FUNC 3a46c 3 0 static __acrt_stdio_char_traits<wchar_t>::validate_stream_is_ansi_if_required(_iobuf* const)
+FUNC 3a46c 3 0 __acrt_stdio_char_traits<wchar_t>::validate_stream_is_ansi_if_required(_iobuf* const)
 3a46c 2 454 337
 3a46e 1 455 337
-FUNC 3a470 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 3a470 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 3a470 8 2738 353
-FUNC 3a47c 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 3a47c 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 3a47c 8 2738 353
-FUNC 3a488 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 3a488 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 3a488 8 2738 353
-FUNC 3a494 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 3a494 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 3a494 8 2738 353
-FUNC 3a4a0 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 3a4a0 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 3a4a0 8 2738 353
-FUNC 3a4ac 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 3a4ac 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 3a4ac 8 2738 353
-FUNC 3a4b8 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3a4b8 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 3a4b8 8 2738 353
-FUNC 3a4c4 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3a4c4 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 3a4c4 8 2738 353
-FUNC 3a4d0 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3a4d0 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 3a4d0 8 2738 353
-FUNC 3a4dc 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3a4dc 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 3a4dc 8 2738 353
-FUNC 3a4e8 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3a4e8 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 3a4e8 8 2738 353
-FUNC 3a4f4 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3a4f4 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 3a4f4 8 2738 353
 FUNC 3a500 48 0 __crt_stdio_output::output_adapter_common<char,__crt_stdio_output::stream_output_adapter<char> >::write_character(const char, int* const) const
 3a500 6 60 353
@@ -15605,24 +15605,24 @@ FUNC 3fc08 38 0 get_win_policy<`__acrt_get_process_end_policy'::`2'::process_end
 3fc26 a 23 369
 3fc30 a 26 369
 3fc3a 6 27 369
-FUNC 3fc50 5 0 static `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_get_policy(AppPolicyThreadInitializationType*)
+FUNC 3fc50 5 0 `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_get_policy(AppPolicyThreadInitializationType*)
 3fc50 5 111 369
-FUNC 3fc58 5 0 static `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_get_policy(AppPolicyShowDeveloperDiagnostic*)
+FUNC 3fc58 5 0 `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_get_policy(AppPolicyShowDeveloperDiagnostic*)
 3fc58 5 142 369
-FUNC 3fc60 5 0 static `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_get_policy(AppPolicyProcessTerminationMethod*)
+FUNC 3fc60 5 0 `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_get_policy(AppPolicyProcessTerminationMethod*)
 3fc60 5 80 369
-FUNC 3fc68 5 0 static `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_get_policy(AppPolicyWindowingModel*)
+FUNC 3fc68 5 0 `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_get_policy(AppPolicyWindowingModel*)
 3fc68 5 180 369
-FUNC 3fc70 b 0 static `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 3fc70 b 0 `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_policy_to_policy_type(const long)
 3fc70 a 99 369
 3fc7a 1 107 369
-FUNC 3fc80 b 0 static `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 3fc80 b 0 `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_policy_to_policy_type(const long)
 3fc80 a 130 369
 3fc8a 1 138 369
-FUNC 3fc90 9 0 static `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_policy_to_policy_type(const AppPolicyProcessTerminationMethod)
+FUNC 3fc90 9 0 `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_policy_to_policy_type(const AppPolicyProcessTerminationMethod)
 3fc90 8 68 369
 3fc98 1 76 369
-FUNC 3fc9c 27 0 static `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 3fc9c 27 0 `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_policy_to_policy_type(const long)
 3fc9c f 161 369
 3fcab 5 174 369
 3fcb0 1 176 369
@@ -15715,9 +15715,9 @@ FUNC 400a4 75 0 calloc_base(unsigned long long, unsigned long long)
 400d5 15 45 371
 400ea 1c 38 371
 40106 13 53 371
-FUNC 40138 12 0 static <lambda_861af8918f661c876f88da8747958ced>::<lambda_invoker_cdecl>(void const*, void const*)
+FUNC 40138 12 0 <lambda_861af8918f661c876f88da8747958ced>::<lambda_invoker_cdecl>(void const*, void const*)
 40138 12 301 375
-FUNC 40150 12 0 static <lambda_a1ce4c8ae42411fd470c77163914f50e>::<lambda_invoker_cdecl>(void const*, void const*)
+FUNC 40150 12 0 <lambda_a1ce4c8ae42411fd470c77163914f50e>::<lambda_invoker_cdecl>(void const*, void const*)
 40150 12 301 375
 FUNC 40168 179 0 __acrt_convert_wcs_mbs_cp<char,wchar_t,<lambda_7c9dea7b4ca7285d2cdb541a38da6275>,__crt_win32_buffer_internal_dynamic_resizing>(char const* const, __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>&, __acrt_mbs_to_wcs_cp::__l2::<lambda_7c9dea7b4ca7285d2cdb541a38da6275> const&, const unsigned int)
 40168 19 494 323
@@ -15974,25 +15974,25 @@ FUNC 417e0 19b 0 expand_argument_wildcards<wchar_t>(wchar_t* const, wchar_t* con
 4192c 19 292 375
 41945 f 303 375
 41954 27 304 375
-FUNC 419e4 11 0 static __crt_char_traits<char>::tcslen<char const * const &>(char const* const&)
+FUNC 419e4 11 0 __crt_char_traits<char>::tcslen<char const * const &>(char const* const&)
 419e4 11 109 322
-FUNC 419fc 12 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t const * const &>(wchar_t const* const&)
+FUNC 419fc 12 0 __crt_char_traits<wchar_t>::tcslen<wchar_t const * const &>(wchar_t const* const&)
 419fc 12 124 322
-FUNC 41a14 11 0 static __crt_char_traits<char>::tcsncpy_s<char * &,unsigned __int64,char * &,unsigned __int64 const &>(char*&, unsigned long long&&, char*&, unsigned long long const&)
+FUNC 41a14 11 0 __crt_char_traits<char>::tcsncpy_s<char * &,unsigned __int64,char * &,unsigned __int64 const &>(char*&, unsigned long long&&, char*&, unsigned long long const&)
 41a14 11 109 322
-FUNC 41a2c 11 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t * &,unsigned __int64,wchar_t * &,unsigned __int64 const &>(wchar_t*&, unsigned long long&&, wchar_t*&, unsigned long long const&)
+FUNC 41a2c 11 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t * &,unsigned __int64,wchar_t * &,unsigned __int64 const &>(wchar_t*&, unsigned long long&&, wchar_t*&, unsigned long long const&)
 41a2c 11 124 322
-FUNC 41a44 11 0 static __crt_char_traits<char>::tcsncpy_s<char *,unsigned __int64 const &,char const * const &,unsigned __int64 const &>(char*&&, unsigned long long const&, char const* const&, unsigned long long const&)
+FUNC 41a44 11 0 __crt_char_traits<char>::tcsncpy_s<char *,unsigned __int64 const &,char const * const &,unsigned __int64 const &>(char*&&, unsigned long long const&, char const* const&, unsigned long long const&)
 41a44 11 109 322
-FUNC 41a5c 11 0 static __crt_char_traits<char>::tcsncpy_s<char *,unsigned __int64,char const * const &,unsigned __int64 const &>(char*&&, unsigned long long&&, char const* const&, unsigned long long const&)
+FUNC 41a5c 11 0 __crt_char_traits<char>::tcsncpy_s<char *,unsigned __int64,char const * const &,unsigned __int64 const &>(char*&&, unsigned long long&&, char const* const&, unsigned long long const&)
 41a5c 11 109 322
-FUNC 41a74 11 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned __int64 const &,wchar_t const * const &,unsigned __int64 const &>(wchar_t*&&, unsigned long long const&, wchar_t const* const&, unsigned long long const&)
+FUNC 41a74 11 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned __int64 const &,wchar_t const * const &,unsigned __int64 const &>(wchar_t*&&, unsigned long long const&, wchar_t const* const&, unsigned long long const&)
 41a74 11 124 322
-FUNC 41a8c 11 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned __int64,wchar_t const * const &,unsigned __int64 const &>(wchar_t*&&, unsigned long long&&, wchar_t const* const&, unsigned long long const&)
+FUNC 41a8c 11 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned __int64,wchar_t const * const &,unsigned __int64 const &>(wchar_t*&&, unsigned long long&&, wchar_t const* const&, unsigned long long const&)
 41a8c 11 124 322
-FUNC 41aa4 8 0 static __crt_char_traits<char>::tcspbrk<char * &,char const (&)[3]>(char*&, const char[3]&)
+FUNC 41aa4 8 0 __crt_char_traits<char>::tcspbrk<char * &,char const (&)[3]>(char*&, const char[3]&)
 41aa4 8 109 322
-FUNC 41ab0 8 0 static __crt_char_traits<wchar_t>::tcspbrk<wchar_t * &,wchar_t const (&)[3]>(wchar_t*&, const wchar_t[3]&)
+FUNC 41ab0 8 0 __crt_char_traits<wchar_t>::tcspbrk<wchar_t * &,wchar_t const (&)[3]>(wchar_t*&, const wchar_t[3]&)
 41ab0 8 124 322
 FUNC 41abc 7 0 __crt_unique_handle_t<__crt_findfile_traits>::__crt_unique_handle_t<__crt_findfile_traits>(void* const)
 41abc 3 1097 201
@@ -16120,7 +16120,7 @@ FUNC 41e8c 5c 0 __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_r
 41ed3 4 360 323
 41ed7 6 362 323
 41edd b 363 323
-FUNC 41f00 24 0 static __crt_win32_buffer_internal_dynamic_resizing::allocate(void** const, const unsigned long long, __crt_win32_buffer_empty_debug_info const&)
+FUNC 41f00 24 0 __crt_win32_buffer_internal_dynamic_resizing::allocate(void** const, const unsigned long long, __crt_win32_buffer_empty_debug_info const&)
 41f00 9 82 323
 41f09 8 83 323
 41f11 3 84 323
@@ -16160,7 +16160,7 @@ FUNC 42178 22 0 __crt_unique_handle_t<__crt_findfile_traits>::close()
 42187 9 1146 201
 42190 4 1147 201
 42194 6 1148 201
-FUNC 421a4 14 0 static __crt_findfile_traits::close(void*)
+FUNC 421a4 14 0 __crt_findfile_traits::close(void*)
 421a4 4 1076 201
 421a8 b 1077 201
 421b3 5 1078 201
@@ -16170,7 +16170,7 @@ FUNC 421c0 5 0 __crt_win32_buffer<char,__crt_win32_buffer_internal_dynamic_resiz
 FUNC 421c8 5 0 __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>::data()
 421c8 4 248 323
 421cc 1 249 323
-FUNC 421d0 5 0 static __crt_win32_buffer_internal_dynamic_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
+FUNC 421d0 5 0 __crt_win32_buffer_internal_dynamic_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
 421d0 5 93 323
 FUNC 421d8 4 0 __crt_win32_buffer<char,__crt_win32_buffer_internal_dynamic_resizing>::debug_info() const
 421d8 3 341 323
@@ -16233,7 +16233,7 @@ FUNC 423e4 9d 0 get_file_name(__crt_win32_buffer<char,__crt_win32_buffer_interna
 FUNC 424a8 4 0 get_file_name(__crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>*, wchar_t* const)
 424a8 3 208 375
 424ab 1 209 375
-FUNC 424ac 5 0 static __crt_findfile_traits::get_invalid_value()
+FUNC 424ac 5 0 __crt_findfile_traits::get_invalid_value()
 424ac 4 1082 201
 424b0 1 1083 201
 FUNC 424b4 4 0 get_wide(__crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>*, wchar_t* const)
@@ -16336,7 +16336,7 @@ FUNC 42994 30 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::allocat
 429a7 c 348 323
 429b3 b 357 323
 429be 6 363 323
-FUNC 429d0 17 0 static __crt_win32_buffer_no_resizing::allocate(void** const, const unsigned long long, __crt_win32_buffer_empty_debug_info const&)
+FUNC 429d0 17 0 __crt_win32_buffer_no_resizing::allocate(void** const, const unsigned long long, __crt_win32_buffer_empty_debug_info const&)
 429d0 4 131 323
 429d4 c 132 323
 429e0 2 133 323
@@ -16347,7 +16347,7 @@ FUNC 429ec 5 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::capacity
 FUNC 429f4 5 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::data()
 429f4 4 248 323
 429f8 1 249 323
-FUNC 429fc 3 0 static __crt_win32_buffer_no_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
+FUNC 429fc 3 0 __crt_win32_buffer_no_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
 429fc 3 138 323
 FUNC 42a00 4 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::debug_info() const
 42a00 3 341 323
@@ -16828,7 +16828,7 @@ FUNC 44520 21 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings
 44531 6 1146 201
 44537 4 1147 201
 4453b 6 1148 201
-FUNC 4454c 11 0 static `anonymous namespace'::environment_strings_traits::close(wchar_t*)
+FUNC 4454c 11 0 `anonymous namespace'::environment_strings_traits::close(wchar_t*)
 4454c 4 24 390
 44550 6 25 390
 44556 2 26 390
@@ -16840,7 +16840,7 @@ FUNC 44564 23 0 find_end_of_double_null_terminated_sequence(wchar_t const* const
 FUNC 44590 4 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings_traits>::get() const
 44590 3 1138 201
 44593 1 1139 201
-FUNC 44594 3 0 static `anonymous namespace'::environment_strings_traits::get_invalid_value()
+FUNC 44594 3 0 `anonymous namespace'::environment_strings_traits::get_invalid_value()
 44594 2 31 390
 44596 1 32 390
 FUNC 44598 8 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings_traits>::is_valid() const
@@ -17060,33 +17060,33 @@ FUNC 452d4 91 0 find_in_environment_nolock<wchar_t>(wchar_t const* const, const 
 45334 9 121 391
 4533d a 125 391
 45347 1e 126 391
-FUNC 4538c 5 0 static __crt_char_traits<char>::get_or_create_environment_nolock<>()
+FUNC 4538c 5 0 __crt_char_traits<char>::get_or_create_environment_nolock<>()
 4538c 5 109 322
-FUNC 45394 5 0 static __crt_char_traits<wchar_t>::get_or_create_environment_nolock<>()
+FUNC 45394 5 0 __crt_char_traits<wchar_t>::get_or_create_environment_nolock<>()
 45394 5 124 322
-FUNC 4539c b 0 static __crt_char_traits<char>::set_environment_variable<char * const &,char * const>(char* const&, char* const&&)
+FUNC 4539c b 0 __crt_char_traits<char>::set_environment_variable<char * const &,char * const>(char* const&, char* const&&)
 4539c b 109 322
-FUNC 453ac d 0 static __crt_char_traits<wchar_t>::set_environment_variable<wchar_t * const &,wchar_t * const>(wchar_t* const&, wchar_t* const&&)
+FUNC 453ac d 0 __crt_char_traits<wchar_t>::set_environment_variable<wchar_t * const &,wchar_t * const>(wchar_t* const&, wchar_t* const&&)
 453ac d 124 322
-FUNC 453bc b 0 static __crt_char_traits<char>::tcschr<char * const &,char>(char* const&, char&&)
+FUNC 453bc b 0 __crt_char_traits<char>::tcschr<char * const &,char>(char* const&, char&&)
 453bc b 109 322
-FUNC 453cc b 0 static __crt_char_traits<wchar_t>::tcschr<wchar_t * const &,char>(wchar_t* const&, char&&)
+FUNC 453cc b 0 __crt_char_traits<wchar_t>::tcschr<wchar_t * const &,char>(wchar_t* const&, char&&)
 453cc b 124 322
-FUNC 453dc e 0 static __crt_char_traits<char>::tcscpy_s<char * &,unsigned __int64 const &,char * &>(char*&, unsigned long long const&, char*&)
+FUNC 453dc e 0 __crt_char_traits<char>::tcscpy_s<char * &,unsigned __int64 const &,char * &>(char*&, unsigned long long const&, char*&)
 453dc e 109 322
-FUNC 453f0 e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * &,unsigned __int64 const &,wchar_t * &>(wchar_t*&, unsigned long long const&, wchar_t*&)
+FUNC 453f0 e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * &,unsigned __int64 const &,wchar_t * &>(wchar_t*&, unsigned long long const&, wchar_t*&)
 453f0 e 124 322
-FUNC 45404 e 0 static __crt_char_traits<char>::tcscpy_s<char * const &,unsigned __int64 const &,char * const &>(char* const&, unsigned long long const&, char* const&)
+FUNC 45404 e 0 __crt_char_traits<char>::tcscpy_s<char * const &,unsigned __int64 const &,char * const &>(char* const&, unsigned long long const&, char* const&)
 45404 e 109 322
-FUNC 45418 e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * const &,unsigned __int64 const &,wchar_t * const &>(wchar_t* const&, unsigned long long const&, wchar_t* const&)
+FUNC 45418 e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * const &,unsigned __int64 const &,wchar_t * const &>(wchar_t* const&, unsigned long long const&, wchar_t* const&)
 45418 e 124 322
-FUNC 4542c 11 0 static __crt_char_traits<char>::tcslen<char * const &>(char* const&)
+FUNC 4542c 11 0 __crt_char_traits<char>::tcslen<char * const &>(char* const&)
 4542c 11 109 322
-FUNC 45444 12 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t * const &>(wchar_t* const&)
+FUNC 45444 12 0 __crt_char_traits<wchar_t>::tcslen<wchar_t * const &>(wchar_t* const&)
 45444 12 124 322
-FUNC 4545c e 0 static __crt_char_traits<char>::tcsnicoll<char const * const &,char * &,unsigned __int64 const &>(char const* const&, char*&, unsigned long long const&)
+FUNC 4545c e 0 __crt_char_traits<char>::tcsnicoll<char const * const &,char * &,unsigned __int64 const &>(char const* const&, char*&, unsigned long long const&)
 4545c e 109 322
-FUNC 45470 e 0 static __crt_char_traits<wchar_t>::tcsnicoll<wchar_t const * const &,wchar_t * &,unsigned __int64 const &>(wchar_t const* const&, wchar_t*&, unsigned long long const&)
+FUNC 45470 e 0 __crt_char_traits<wchar_t>::tcsnicoll<wchar_t const * const &,wchar_t * &,unsigned __int64 const &>(wchar_t const* const&, wchar_t*&, unsigned long long const&)
 45470 e 124 322
 FUNC 45484 8 0 get_environment(char)
 45484 8 17 391
@@ -17120,7 +17120,7 @@ FUNC 454f4 95 0 recalloc_base(void*, unsigned long long, unsigned long long)
 45560 11 40 392
 45571 3 43 392
 45574 15 44 392
-FUNC 455b0 28 0 static <lambda_795c6bd18aed400428efeb9a5f0e1479>::<lambda_invoker_cdecl>(wchar_t*)
+FUNC 455b0 28 0 <lambda_795c6bd18aed400428efeb9a5f0e1479>::<lambda_invoker_cdecl>(wchar_t*)
 455b0 28 425 393
 FUNC 455e4 8 0 __crt_fast_encoded_nullptr_t::operator<int __cdecl(wchar_t *,unsigned long,__int64)> int (__cdecl*)(wchar_t *,unsigned long,__int64)() const
 455e4 7 536 99
@@ -18741,28 +18741,28 @@ FUNC 4adf8 4 0 __crt_simd_cleanup_guard<1>::~__crt_simd_cleanup_guard<1>()
 4adfb 1 116 417
 FUNC 4adfc 3 0 __crt_simd_cleanup_guard<0>::~__crt_simd_cleanup_guard<0>()
 4adfc 3 63 417
-FUNC 4ae00 9 0 static __crt_simd_traits<1,unsigned char>::compare_equals(const __m256i, const __m256i)
+FUNC 4ae00 9 0 __crt_simd_traits<1,unsigned char>::compare_equals(const __m256i, const __m256i)
 4ae00 8 143 417
 4ae08 1 144 417
-FUNC 4ae0c 9 0 static __crt_simd_traits<1,unsigned short>::compare_equals(const __m256i, const __m256i)
+FUNC 4ae0c 9 0 __crt_simd_traits<1,unsigned short>::compare_equals(const __m256i, const __m256i)
 4ae0c 8 153 417
 4ae14 1 154 417
-FUNC 4ae18 9 0 static __crt_simd_traits<0,unsigned char>::compare_equals(const __m128i, const __m128i)
+FUNC 4ae18 9 0 __crt_simd_traits<0,unsigned char>::compare_equals(const __m128i, const __m128i)
 4ae18 8 90 417
 4ae20 1 91 417
-FUNC 4ae24 9 0 static __crt_simd_traits<0,unsigned short>::compare_equals(const __m128i, const __m128i)
+FUNC 4ae24 9 0 __crt_simd_traits<0,unsigned short>::compare_equals(const __m128i, const __m128i)
 4ae24 8 100 417
 4ae2c 1 101 417
-FUNC 4ae30 c 0 static __crt_simd_pack_traits<1>::compute_byte_mask(const __m256i)
+FUNC 4ae30 c 0 __crt_simd_pack_traits<1>::compute_byte_mask(const __m256i)
 4ae30 b 133 417
 4ae3b 1 134 417
-FUNC 4ae40 9 0 static __crt_simd_pack_traits<0>::compute_byte_mask(const __m128i)
+FUNC 4ae40 9 0 __crt_simd_pack_traits<0>::compute_byte_mask(const __m128i)
 4ae40 8 80 417
 4ae48 1 81 417
-FUNC 4ae4c 5 0 static __crt_simd_pack_traits<1>::get_zero_pack()
+FUNC 4ae4c 5 0 __crt_simd_pack_traits<1>::get_zero_pack()
 4ae4c 4 127 417
 4ae50 1 129 417
-FUNC 4ae54 4 0 static __crt_simd_pack_traits<0>::get_zero_pack()
+FUNC 4ae54 4 0 __crt_simd_pack_traits<0>::get_zero_pack()
 4ae54 3 74 417
 4ae57 1 76 417
 FUNC 4ae58 150 0 strnlen(char const*, unsigned long long)
@@ -23880,17 +23880,17 @@ FUNC 618a8 a4 0 common_show_message_box<wchar_t>(wchar_t const* const, wchar_t c
 61926 a 75 504
 61930 7 64 504
 61937 15 76 504
-FUNC 61978 11 0 static __crt_char_traits<char>::message_box<std::nullptr_t,char const * const &,char const * const &,unsigned long>(void*&&, char const* const&, char const* const&, unsigned long&&)
+FUNC 61978 11 0 __crt_char_traits<char>::message_box<std::nullptr_t,char const * const &,char const * const &,unsigned long>(void*&&, char const* const&, char const* const&, unsigned long&&)
 61978 11 109 322
-FUNC 61990 11 0 static __crt_char_traits<wchar_t>::message_box<std::nullptr_t,wchar_t const * const &,wchar_t const * const &,unsigned long>(void*&&, wchar_t const* const&, wchar_t const* const&, unsigned long&&)
+FUNC 61990 11 0 __crt_char_traits<wchar_t>::message_box<std::nullptr_t,wchar_t const * const &,wchar_t const * const &,unsigned long>(void*&&, wchar_t const* const&, wchar_t const* const&, unsigned long&&)
 61990 11 124 322
-FUNC 619a8 11 0 static __crt_char_traits<char>::message_box<HWND__ *,char const * const &,char const * const &,unsigned int const &>(HWND__*&&, char const* const&, char const* const&, unsigned int const&)
+FUNC 619a8 11 0 __crt_char_traits<char>::message_box<HWND__ *,char const * const &,char const * const &,unsigned int const &>(HWND__*&&, char const* const&, char const* const&, unsigned int const&)
 619a8 11 109 322
-FUNC 619c0 11 0 static __crt_char_traits<wchar_t>::message_box<HWND__ *,wchar_t const * const &,wchar_t const * const &,unsigned int const &>(HWND__*&&, wchar_t const* const&, wchar_t const* const&, unsigned int const&)
+FUNC 619c0 11 0 __crt_char_traits<wchar_t>::message_box<HWND__ *,wchar_t const * const &,wchar_t const * const &,unsigned int const &>(HWND__*&&, wchar_t const* const&, wchar_t const* const&, unsigned int const&)
 619c0 11 124 322
-FUNC 619d8 8 0 static __crt_char_traits<char>::output_debug_string<char const * const &>(char const* const&)
+FUNC 619d8 8 0 __crt_char_traits<char>::output_debug_string<char const * const &>(char const* const&)
 619d8 8 109 322
-FUNC 619e4 a 0 static __crt_char_traits<wchar_t>::output_debug_string<wchar_t const * const &>(wchar_t const* const&)
+FUNC 619e4 a 0 __crt_char_traits<wchar_t>::output_debug_string<wchar_t const * const &>(wchar_t const* const&)
 619e4 a 124 322
 FUNC 619f0 a3 0 _acrt_show_narrow_message_box(char const*, char const*, unsigned int)
 619f0 1d 83 504

--- a/test_data/windows/basic32.sym
+++ b/test_data/windows/basic32.sym
@@ -633,7 +633,7 @@ FUNC 6f10 16 0 A::meth2(int)
 FUNC 6f30 22 0 A::meth2(double)
 6f30 1c 74 0
 6f4c 6 75 0
-FUNC 6f60 17 0 static A::meth2(short, signed char)
+FUNC 6f60 17 0 A::meth2(short, signed char)
 6f60 12 77 0
 6f72 5 78 0
 FUNC 6f80 21 0 A::meth4(A*, A::B&&)
@@ -669,7 +669,7 @@ FUNC 7120 20 0 std::_String_val<std::_Simple_types<char> >::_Large_string_engage
 FUNC 7150 14 0 std::_String_alloc<std::_String_base_types<char,std::allocator<char> > >::_Getal()
 7150 a 2032 1
 715a a 2033 1
-FUNC 7170 17 0 static std::_Default_allocator_traits<std::allocator<char> >::destroy<char *>(std::allocator<char>&, char** const)
+FUNC 7170 17 0 std::_Default_allocator_traits<std::allocator<char> >::destroy<char *>(std::allocator<char>&, char** const)
 7170 12 886 2
 7182 5 888 2
 FUNC 7190 14 0 std::addressof<char *>(char*&)
@@ -679,7 +679,7 @@ FUNC 71b0 33 0 std::allocator<char>::deallocate(char* const, const unsigned int)
 71b0 10 990 2
 71c0 1b 992 2
 71db 8 993 2
-FUNC 71f0 23 0 static std::char_traits<char>::assign(char&, char const&)
+FUNC 71f0 23 0 std::char_traits<char>::assign(char&, char const&)
 71f0 d 505 4
 71fd 10 506 4
 720d 6 507 4
@@ -1000,7 +1000,7 @@ FUNC a486 d 0 __crt_rotate_pointer_value(const unsigned int, const int)
 a486 3 491 18
 a489 8 492 18
 a491 2 493 18
-FUNC a496 d 0 static __scrt_narrow_argv_policy::configure_argv()
+FUNC a496 d 0 __scrt_narrow_argv_policy::configure_argv()
 a496 d 400 28
 FUNC a4a6 44 0 find_pe_section(unsigned char* const, const unsigned int)
 a4a6 3 61 42
@@ -1013,7 +1013,7 @@ a4da 7 71 42
 a4e1 3 79 42
 a4e4 2 80 42
 a4e6 4 75 42
-FUNC a4fb 5 0 static __scrt_narrow_environment_policy::initialize_environment()
+FUNC a4fb 5 0 __scrt_narrow_environment_policy::initialize_environment()
 a4fb 5 421 28
 FUNC a500 34 0 is_potentially_valid_image_base(void* const)
 a500 3 28 42
@@ -1388,9 +1388,9 @@ b080 8 472 51
 b088 12 474 51
 b09a c 500 51
 b0a6 11 515 51
-FUNC b10c 5 0 static <lambda_02a71323d951a238fa4826e9f186893b>::<lambda_invoker_cdecl>(void* const)
+FUNC b10c 5 0 <lambda_02a71323d951a238fa4826e9f186893b>::<lambda_invoker_cdecl>(void* const)
 b10c 5 84 52
-FUNC b111 9 0 static <lambda_cea3005bd909f0fdd45a57e92f4e3309>::<lambda_invoker_cdecl>(const unsigned int)
+FUNC b111 9 0 <lambda_cea3005bd909f0fdd45a57e92f4e3309>::<lambda_invoker_cdecl>(const unsigned int)
 b111 9 83 52
 FUNC b11c 10 0 __crt_internal_free_policy::operator()<char>(char const* const) const
 b11c 3 334 18
@@ -2124,7 +2124,7 @@ c2cd 3 134 60
 c2d0 11 136 60
 c2e1 f 136 60
 c2f0 1 139 60
-FUNC c2ff 1f 0 static UnDecorator::UScore(Tokens)
+FUNC c2ff 1f 0 UnDecorator::UScore(Tokens)
 c2ff 3 4979 60
 c302 17 4984 60
 c319 3 4987 60
@@ -2135,7 +2135,7 @@ c32a 9 613 61
 c333 2a 615 61
 c35d 4 616 61
 c361 a 621 61
-FUNC c37c cdd 0 static UnDecorator::composeDeclaration(DName const&)
+FUNC c37c cdd 0 UnDecorator::composeDeclaration(DName const&)
 c37c 9 2394 60
 c385 e 2396 60
 c393 2 2395 60
@@ -2276,25 +2276,25 @@ d016 8 2701 60
 d01e 28 2703 60
 d046 b 2706 60
 d051 8 2708 60
-FUNC d390 e 0 static UnDecorator::doAccessSpecifiers()
+FUNC d390 e 0 UnDecorator::doAccessSpecifiers()
 d390 e 4960 60
-FUNC d3a1 e 0 static UnDecorator::doAllocationLanguage()
+FUNC d3a1 e 0 UnDecorator::doAllocationLanguage()
 d3a1 e 4952 60
-FUNC d3b2 e 0 static UnDecorator::doAllocationModel()
+FUNC d3b2 e 0 UnDecorator::doAllocationModel()
 d3b2 e 4951 60
-FUNC d3c3 e 0 static UnDecorator::doEcsu()
+FUNC d3c3 e 0 UnDecorator::doEcsu()
 d3c3 e 4970 60
-FUNC d3d4 e 0 static UnDecorator::doEllipsis()
+FUNC d3d4 e 0 UnDecorator::doEllipsis()
 d3d4 e 4972 60
-FUNC d3e5 e 0 static UnDecorator::doFunctionReturns()
+FUNC d3e5 e 0 UnDecorator::doFunctionReturns()
 d3e5 e 4950 60
-FUNC d3f6 d 0 static UnDecorator::doMSKeywords()
+FUNC d3f6 d 0 UnDecorator::doMSKeywords()
 d3f6 d 4948 60
-FUNC d406 e 0 static UnDecorator::doMemberTypes()
+FUNC d406 e 0 UnDecorator::doMemberTypes()
 d406 e 4962 60
-FUNC d417 b 0 static UnDecorator::doNameOnly()
+FUNC d417 b 0 UnDecorator::doNameOnly()
 d417 b 4967 60
-FUNC d424 b 0 static UnDecorator::doNoIdentCharCheck()
+FUNC d424 b 0 UnDecorator::doNoIdentCharCheck()
 d424 b 4971 60
 FUNC d431 86 0 DName::doPchar(char const*, int)
 d431 7 828 61
@@ -2310,19 +2310,19 @@ d4a4 6 838 61
 d4aa 2 857 61
 d4ac 6 858 61
 d4b2 5 860 61
-FUNC d4d8 e 0 static UnDecorator::doPtr64()
+FUNC d4d8 e 0 UnDecorator::doPtr64()
 d4d8 e 4949 60
-FUNC d4e9 e 0 static UnDecorator::doRestrictionSpec()
+FUNC d4e9 e 0 UnDecorator::doRestrictionSpec()
 d4e9 e 4975 60
-FUNC d4fa 12 0 static UnDecorator::doThisTypes()
+FUNC d4fa 12 0 UnDecorator::doThisTypes()
 d4fa 12 4959 60
-FUNC d510 e 0 static UnDecorator::doThrowTypes()
+FUNC d510 e 0 UnDecorator::doThrowTypes()
 d510 e 4961 60
-FUNC d521 b 0 static UnDecorator::doTypeOnly()
+FUNC d521 b 0 UnDecorator::doTypeOnly()
 d521 b 4968 60
-FUNC d52e b 0 static UnDecorator::doUnderScore()
+FUNC d52e b 0 UnDecorator::doUnderScore()
 d52e b 4947 60
-FUNC d53b f6 0 static UnDecorator::getArgumentList()
+FUNC d53b f6 0 UnDecorator::getArgumentList()
 d53b 8 3544 60
 d543 3 3546 60
 d546 4 3545 60
@@ -2350,7 +2350,7 @@ d60f 12 3549 60
 d621 9 3605 60
 d62a 5 3614 60
 d62f 2 3616 60
-FUNC d66e ca 0 static UnDecorator::getArgumentTypes()
+FUNC d66e ca 0 UnDecorator::getArgumentTypes()
 d66e 5 3503 60
 d673 17 3504 60
 d68a 9 3514 60
@@ -2364,7 +2364,7 @@ d6f2 d 3540 60
 d6ff 21 3507 60
 d720 b 3510 60
 d72b d 3540 60
-FUNC d76a 1b1 0 static UnDecorator::getArrayType(DName const&)
+FUNC d76a 1b1 0 UnDecorator::getArrayType(DName const&)
 d76a 3 4647 60
 d76d 13 4648 60
 d780 7 4650 60
@@ -2396,7 +2396,7 @@ d8a7 b 4685 60
 d8b2 36 4686 60
 d8e8 17 4688 60
 d8ff 1c 4690 60
-FUNC d987 98 0 static UnDecorator::getBasedType()
+FUNC d987 98 0 UnDecorator::getBasedType()
 d987 6 3057 60
 d98d 11 3058 60
 d99e c 3063 60
@@ -2411,7 +2411,7 @@ d9f8 a 3116 60
 da02 d 3120 60
 da0f e 3124 60
 da1d 2 3126 60
-FUNC da45 3df 0 static UnDecorator::getBasicDataType(DName const&)
+FUNC da45 3df 0 UnDecorator::getBasicDataType(DName const&)
 da45 3 3725 60
 da48 14 3726 60
 da5c 3 3728 60
@@ -2522,9 +2522,9 @@ dfb2 12 973 60
 dfc4 12 974 60
 dfd6 20 975 60
 dff6 4 979 60
-FUNC e031 14 0 static UnDecorator::getCallIndex()
+FUNC e031 14 0 UnDecorator::getCallIndex()
 e031 14 4734 60
-FUNC e04a d3 0 static UnDecorator::getCallingConvention()
+FUNC e04a d3 0 UnDecorator::getCallingConvention()
 e04a 5 3229 60
 e04f f 3230 60
 e05e c 3232 60
@@ -2562,7 +2562,7 @@ e0fe e 3311 60
 e10c 2 3317 60
 e10e d 3315 60
 e11b 2 3317 60
-FUNC e151 5ea 0 static UnDecorator::getDataIndirectType(DName const&, char const*, DName const&, int)
+FUNC e151 5ea 0 UnDecorator::getDataIndirectType(DName const&, char const*, DName const&, int)
 e151 6 4321 60
 e157 16 4327 60
 e16d 7 4329 60
@@ -2678,11 +2678,11 @@ e71e 8 4570 60
 e726 3 4571 60
 e729 a 4573 60
 e733 8 4575 60
-FUNC e8b5 32 0 static UnDecorator::getDataIndirectType()
+FUNC e8b5 32 0 UnDecorator::getDataIndirectType()
 e8b5 6 4698 60
 e8bb 2a 4701 60
 e8e5 2 4702 60
-FUNC e8f3 c5 0 static UnDecorator::getDataType(DName*)
+FUNC e8f3 c5 0 UnDecorator::getDataType(DName*)
 e8f3 6 3338 60
 e8f9 b 3339 60
 e904 19 3344 60
@@ -2698,7 +2698,7 @@ e960 2a 3364 60
 e98a 11 3365 60
 e99b a 3347 60
 e9a5 13 3375 60
-FUNC e9e9 242 0 static UnDecorator::getDecoratedName()
+FUNC e9e9 242 0 UnDecorator::getDecoratedName()
 e9e9 c 992 60
 e9f5 6 1003 60
 e9fb 5 1007 60
@@ -2761,7 +2761,7 @@ ec00 4 1129 60
 ec04 e 1130 60
 ec12 a 1132 60
 ec1c f 1134 60
-FUNC ecbb 11f 0 static UnDecorator::getDimension(bool)
+FUNC ecbb 11f 0 UnDecorator::getDimension(bool)
 ecbb 3 1871 60
 ecbe 13 1873 60
 ecd1 c 1876 60
@@ -2784,7 +2784,7 @@ ed96 1e 1910 60
 edb4 14 1914 60
 edc8 d 1893 60
 edd5 5 1918 60
-FUNC ee21 54 0 static UnDecorator::getDispatchTarget()
+FUNC ee21 54 0 UnDecorator::getDispatchTarget()
 ee21 3 3702 60
 ee24 1c 3703 60
 ee40 8 3707 60
@@ -2794,9 +2794,9 @@ ee59 e 3713 60
 ee67 2 3721 60
 ee69 a 3720 60
 ee73 2 3721 60
-FUNC ee8a 14 0 static UnDecorator::getDisplacement()
+FUNC ee8a 14 0 UnDecorator::getDisplacement()
 ee8a 14 4733 60
-FUNC eea3 118 0 static UnDecorator::getECSUDataType()
+FUNC eea3 118 0 UnDecorator::getECSUDataType()
 eea3 3 3967 60
 eea6 5 3970 60
 eeab 3 3967 60
@@ -2823,9 +2823,9 @@ ef7b 16 4021 60
 ef91 10 4025 60
 efa1 16 3979 60
 efb7 4 4027 60
-FUNC f001 11 0 static UnDecorator::getECSUName()
+FUNC f001 11 0 UnDecorator::getECSUName()
 f001 11 3162 60
-FUNC f016 f0 0 static UnDecorator::getEnumType()
+FUNC f016 f0 0 UnDecorator::getEnumType()
 f016 6 3166 60
 f01c 5 3170 60
 f021 8 3167 60
@@ -2846,7 +2846,7 @@ f0c8 c 3199 60
 f0d4 2 3224 60
 f0d6 d 3222 60
 f0e3 23 3224 60
-FUNC f142 1b7 0 static UnDecorator::getExtendedDataIndirectType(char const*&, bool&, int)
+FUNC f142 1b7 0 UnDecorator::getExtendedDataIndirectType(char const*&, bool&, int)
 f142 6 4236 60
 f148 11 4243 60
 f159 2 4239 60
@@ -2890,7 +2890,7 @@ f2d4 10 4252 60
 f2e4 3 4254 60
 f2e7 b 4317 60
 f2f2 7 4318 60
-FUNC f366 67 0 static UnDecorator::getExternalDataType(DName const&)
+FUNC f366 67 0 UnDecorator::getExternalDataType(DName const&)
 f366 6 4932 60
 f36c 5 4935 60
 f371 1 4932 60
@@ -2901,7 +2901,7 @@ f3c4 3 4943 60
 f3c7 3 4941 60
 f3ca 1 4943 60
 f3cb 2 4945 60
-FUNC f3e6 3d8 0 static UnDecorator::getFunctionIndirectType(DName const&)
+FUNC f3e6 3d8 0 UnDecorator::getFunctionIndirectType(DName const&)
 f3e6 3 4036 60
 f3e9 16 4037 60
 f3ff 10 4040 60
@@ -2964,7 +2964,7 @@ f78b b 4174 60
 f796 10 4097 60
 f7a6 10 4057 60
 f7b6 8 4179 60
-FUNC f8b4 14 0 static UnDecorator::getGuardNumber()
+FUNC f8b4 14 0 UnDecorator::getGuardNumber()
 f8b4 14 4735 60
 FUNC f8cd 20 0 DName::getLastChar() const
 f8cd 1 511 61
@@ -2997,7 +2997,7 @@ f95b e 932 61
 f969 1 933 61
 f96a 2 932 61
 f96c 1 933 61
-FUNC f971 3f 0 static UnDecorator::getLexicalFrame()
+FUNC f971 3f 0 UnDecorator::getLexicalFrame()
 f971 3f 4693 60
 FUNC f9bf 87 0 _HeapManager::getMemory(unsigned int, int)
 f9bf 6 151 61
@@ -3019,14 +3019,14 @@ fa2b 3 190 61
 fa2e d 202 61
 fa3b 7 205 61
 fa42 4 194 61
-FUNC fa67 45 0 static UnDecorator::getNoexcept()
+FUNC fa67 45 0 UnDecorator::getNoexcept()
 fa67 3 3636 60
 fa6a 1c 3637 60
 fa86 18 3640 60
 fa9e 2 3644 60
 faa0 a 3643 60
 faaa 2 3644 60
-FUNC fabd 61 0 static UnDecorator::getNumberOfDimensions()
+FUNC fabd 61 0 UnDecorator::getNumberOfDimensions()
 fabd c 1923 60
 fac9 8 1925 60
 fad1 d 1926 60
@@ -3044,7 +3044,7 @@ fb18 2 1952 60
 fb1a 1 1955 60
 fb1b 2 1937 60
 fb1d 1 1955 60
-FUNC fb36 658 0 static UnDecorator::getOperatorName(bool, bool*)
+FUNC fb36 658 0 UnDecorator::getOperatorName(bool, bool*)
 fb36 6 1267 60
 fb3c d 1276 60
 fb49 2 1268 60
@@ -3152,15 +3152,15 @@ fff9 d 1652 60
 10155 8 1645 60
 1015d 11 1646 60
 1016e 20 1647 60
-FUNC 10324 1e 0 static UnDecorator::getPointerType(DName const&, DName const&)
+FUNC 10324 1e 0 UnDecorator::getPointerType(DName const&, DName const&)
 10324 3 4712 60
 10327 19 4715 60
 10340 2 4716 60
-FUNC 10349 1e 0 static UnDecorator::getPointerTypeArray(DName const&, DName const&)
+FUNC 10349 1e 0 UnDecorator::getPointerTypeArray(DName const&, DName const&)
 10349 3 4719 60
 1034c 19 4722 60
 10365 2 4723 60
-FUNC 1036e 1e4 0 static UnDecorator::getPrimaryDataType(DName const&)
+FUNC 1036e 1e4 0 UnDecorator::getPrimaryDataType(DName const&)
 1036e 6 3380 60
 10374 8 3384 60
 1037c 2 3381 60
@@ -3199,7 +3199,7 @@ FUNC 1036e 1e4 0 static UnDecorator::getPrimaryDataType(DName const&)
 10538 a 3449 60
 10542 6 3455 60
 10548 a 3461 60
-FUNC 105cb 129 0 static UnDecorator::getPtrRefDataType(DName const&, int)
+FUNC 105cb 129 0 UnDecorator::getPtrRefDataType(DName const&, int)
 105cb 3 4579 60
 105ce 12 4581 60
 105e0 6 4584 60
@@ -3230,7 +3230,7 @@ FUNC 105cb 129 0 static UnDecorator::getPtrRefDataType(DName const&, int)
 106dd 2 4643 60
 106df d 4641 60
 106ec 8 4643 60
-FUNC 1073e fa 0 static UnDecorator::getPtrRefType(DName const&, DName const&, char const*)
+FUNC 1073e fa 0 UnDecorator::getPtrRefType(DName const&, DName const&, char const*)
 1073e 5 4183 60
 10743 11 4188 60
 10754 c 4189 60
@@ -3253,11 +3253,11 @@ FUNC 1073e fa 0 static UnDecorator::getPtrRefType(DName const&, DName const&, ch
 1081c 9 4225 60
 10825 10 4229 60
 10835 3 4232 60
-FUNC 10876 1c 0 static UnDecorator::getReferenceType(DName const&, DName const&, char const*)
+FUNC 10876 1c 0 UnDecorator::getReferenceType(DName const&, DName const&, char const*)
 10876 3 4726 60
 10879 17 4727 60
 10890 2 4728 60
-FUNC 10899 f9 0 static UnDecorator::getRestrictionSpec()
+FUNC 10899 f9 0 UnDecorator::getRestrictionSpec()
 10899 5 3648 60
 1089e 31 3649 60
 108cf 5 3652 60
@@ -3283,13 +3283,13 @@ FUNC 10899 f9 0 static UnDecorator::getRestrictionSpec()
 10977 c 3693 60
 10983 9 3697 60
 1098c 6 3699 60
-FUNC 109d0 2f 0 static UnDecorator::getReturnType(DName*)
+FUNC 109d0 2f 0 UnDecorator::getReturnType(DName*)
 109d0 3 3322 60
 109d3 d 3323 60
 109e0 10 3327 60
 109f0 a 3331 60
 109fa 5 3333 60
-FUNC 10a0a 394 0 static UnDecorator::getScope()
+FUNC 10a0a 394 0 UnDecorator::getScope()
 10a0a c 1693 60
 10a16 a 1694 60
 10a20 2 1695 60
@@ -3348,7 +3348,7 @@ FUNC 10a0a 394 0 static UnDecorator::getScope()
 10d69 2e 1837 60
 10d97 5 1851 60
 10d9c 2 1853 60
-FUNC 10e83 d4 0 static UnDecorator::getScopedName()
+FUNC 10e83 d4 0 UnDecorator::getScopedName()
 10e83 6 3131 60
 10e89 5 3137 60
 10e8e 3 3132 60
@@ -3374,7 +3374,7 @@ FUNC 10e83 d4 0 static UnDecorator::getScopedName()
 10f26 2a 3153 60
 10f50 5 3157 60
 10f55 2 3159 60
-FUNC 10f8c 51 0 static UnDecorator::getSignedDimension()
+FUNC 10f8c 51 0 UnDecorator::getSignedDimension()
 10f8c 5 1857 60
 10f91 b 1858 60
 10f9c c 1859 60
@@ -3383,7 +3383,7 @@ FUNC 10f8c 51 0 static UnDecorator::getSignedDimension()
 10fb5 19 1863 60
 10fce a 1866 60
 10fd8 5 1867 60
-FUNC 10ff1 11 0 static UnDecorator::getStorageConvention()
+FUNC 10ff1 11 0 UnDecorator::getStorageConvention()
 10ff1 11 4694 60
 FUNC 11006 2d 0 DName::getString(char*, char*) const
 11006 4 554 61
@@ -3438,7 +3438,7 @@ FUNC 11166 1b 0 pcharNode::getString(char*, char*) const
 11166 3 971 61
 11169 14 972 61
 1117d 4 973 61
-FUNC 11187 b0 0 static UnDecorator::getStringEncoding(char const*, int)
+FUNC 11187 b0 0 UnDecorator::getStringEncoding(char const*, int)
 11187 6 1655 60
 1118d b 1656 60
 11198 22 1659 60
@@ -3464,7 +3464,7 @@ FUNC 11263 37 0 getStringHelper(char*, char const*, char const*, int)
 11277 1e 212 61
 11295 3 213 61
 11298 2 214 61
-FUNC 112a7 48 0 static UnDecorator::getSymbolName()
+FUNC 112a7 48 0 UnDecorator::getSymbolName()
 112a7 3 1139 60
 112aa a 1140 60
 112b4 6 1142 60
@@ -3472,7 +3472,7 @@ FUNC 112a7 48 0 static UnDecorator::getSymbolName()
 112c8 13 1150 60
 112db c 1155 60
 112e7 8 1157 60
-FUNC 11301 29d 0 static UnDecorator::getTemplateArgumentList()
+FUNC 11301 29d 0 UnDecorator::getTemplateArgumentList()
 11301 15 2039 60
 11316 2 2041 60
 11318 5 2040 60
@@ -3531,7 +3531,7 @@ FUNC 11301 29d 0 static UnDecorator::getTemplateArgumentList()
 11565 c 2185 60
 11571 17 2044 60
 11588 16 2196 60
-FUNC 11645 332 0 static UnDecorator::getTemplateConstant()
+FUNC 11645 332 0 UnDecorator::getTemplateConstant()
 11645 13 2214 60
 11658 e 2221 60
 11666 49 2222 60
@@ -3590,7 +3590,7 @@ FUNC 11645 332 0 static UnDecorator::getTemplateConstant()
 11936 33 2391 60
 11969 7 2370 60
 11970 7 2367 60
-FUNC 11a43 162 0 static UnDecorator::getTemplateName(bool)
+FUNC 11a43 162 0 UnDecorator::getTemplateName(bool)
 11a43 3 1959 60
 11a46 1e 1963 60
 11a64 9 1972 60
@@ -3621,16 +3621,16 @@ FUNC 11a43 162 0 static UnDecorator::getTemplateName(bool)
 11b93 2 2035 60
 11b95 e 1964 60
 11ba3 2 2035 60
-FUNC 11bfd 33 0 static UnDecorator::getThisType()
+FUNC 11bfd 33 0 UnDecorator::getThisType()
 11bfd 6 4705 60
 11c03 2b 4708 60
 11c2e 2 4709 60
-FUNC 11c3c 23 0 static UnDecorator::getThrowTypes()
+FUNC 11c3c 23 0 UnDecorator::getThrowTypes()
 11c3c 3 3620 60
 11c3f 17 3629 60
 11c56 7 3630 60
 11c5d 2 3633 60
-FUNC 11c67 328 0 static UnDecorator::getTypeEncoding()
+FUNC 11c67 328 0 UnDecorator::getTypeEncoding()
 11c67 e 2712 60
 11c75 7 2718 60
 11c7c c 2722 60
@@ -3755,7 +3755,7 @@ FUNC 12059 c4 0 UnDecorator::getUndecoratedName(char*, int)
 12113 2 907 60
 12115 4 912 60
 12119 4 914 60
-FUNC 1214e 47 0 static UnDecorator::getVCallThunkType()
+FUNC 1214e 47 0 UnDecorator::getVCallThunkType()
 1214e 3 4744 60
 12151 10 4746 60
 12161 e 4754 60
@@ -3763,11 +3763,11 @@ FUNC 1214e 47 0 static UnDecorator::getVCallThunkType()
 12171 15 4750 60
 12186 a 4752 60
 12190 5 4858 60
-FUNC 121a6 15 0 static UnDecorator::getVbTableType(DName const&)
+FUNC 121a6 15 0 UnDecorator::getVbTableType(DName const&)
 121a6 3 4738 60
 121a9 10 4739 60
 121b9 2 4740 60
-FUNC 121c0 54 0 static UnDecorator::getVdispMapType(DName const&)
+FUNC 121c0 54 0 UnDecorator::getVdispMapType(DName const&)
 121c0 5 4918 60
 121c5 3 4919 60
 121c8 1 4918 60
@@ -3783,7 +3783,7 @@ FUNC 121c0 54 0 static UnDecorator::getVdispMapType(DName const&)
 12208 7 4925 60
 1220f 3 4926 60
 12212 2 4927 60
-FUNC 12229 163 0 static UnDecorator::getVfTableType(DName const&)
+FUNC 12229 163 0 UnDecorator::getVfTableType(DName const&)
 12229 3 4862 60
 1222c 3 4863 60
 1222f 3 4862 60
@@ -3812,7 +3812,7 @@ FUNC 12229 163 0 static UnDecorator::getVfTableType(DName const&)
 12366 21 4910 60
 12387 3 4912 60
 1238a 2 4914 60
-FUNC 123e4 1ff 0 static UnDecorator::getZName(bool, bool)
+FUNC 123e4 1ff 0 UnDecorator::getZName(bool, bool)
 123e4 11 1161 60
 123f5 15 1162 60
 1240a 5 1167 60
@@ -3853,7 +3853,7 @@ FUNC 123e4 1ff 0 static UnDecorator::getZName(bool, bool)
 125bf 9 1256 60
 125c8 b 1259 60
 125d3 10 1262 60
-FUNC 12662 b 0 static UnDecorator::haveTemplateParameters()
+FUNC 12662 b 0 UnDecorator::haveTemplateParameters()
 12662 b 4969 60
 FUNC 1266f a 0 DName::isArray() const
 1266f 9 467 61
@@ -3915,14 +3915,14 @@ FUNC 12741 46 0 pairNode::length() const
 FUNC 12798 4 0 pcharNode::length() const
 12798 3 927 61
 1279b 1 928 61
-FUNC 1279c 1c 0 static DNameStatusNode::make(DNameStatus)
+FUNC 1279c 1c 0 DNameStatusNode::make(DNameStatus)
 1279c 3 1021 61
 1279f 8 1028 61
 127a7 8 1029 61
 127af 2 1032 61
 127b1 5 1031 61
 127b6 2 1032 61
-FUNC 127bf ee 0 static UnDecorator::parseDecoratedName()
+FUNC 127bf ee 0 UnDecorator::parseDecoratedName()
 127bf 3 808 60
 127c2 8 814 60
 127ca 2 809 60
@@ -4470,7 +4470,7 @@ FUNC 136ea 8 0 std::forward<__FrameHandler3::TryBlockMap::iterator &>(__FrameHan
 136f0 2 1575 82
 FUNC 136f4 14 0 __FrameHandler3::TryBlockMap::iterator::iterator(__FrameHandler3::TryBlockMap&, unsigned int)
 136f4 14 547 77
-FUNC 1370d 82 0 static __FrameHandler3::GetRangeOfTrysToCheck(__FrameHandler3::TryBlockMap&, int, int)
+FUNC 1370d 82 0 __FrameHandler3::GetRangeOfTrysToCheck(__FrameHandler3::TryBlockMap&, int, int)
 1370d 6 752 76
 13713 3 753 76
 13716 1 752 76
@@ -5235,9 +5235,9 @@ FUNC 14f67 13 0 __FrameHandler3::TryBlockMap::iterator::operator<(__FrameHandler
 14f76 4 572 77
 FUNC 14f7e 2d 0 std::bad_exception::`scalar deleting destructor'(unsigned int)
 FUNC 14fb6 2d 0 std::exception::`scalar deleting destructor'(unsigned int)
-FUNC 14fee 5 0 static __FrameHandler3::BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 14fee 5 0 __FrameHandler3::BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 14fee 5 2027 85
-FUNC 14ff3 9 0 static __FrameHandler3::BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 14ff3 9 0 __FrameHandler3::BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 14ff3 3 1915 85
 14ff6 1 1917 85
 14ff7 5 1916 85
@@ -5294,11 +5294,11 @@ FUNC 1527b 4a 0 ExFilterRethrow(_EXCEPTION_POINTERS*)
 152bf 2 1735 85
 152c1 2 1733 85
 152c3 2 1735 85
-FUNC 152d7 18 0 static __FrameHandler3::FrameUnwindToEmptyState(EHRegistrationNode*, void*, _s_FuncInfo const*)
+FUNC 152d7 18 0 __FrameHandler3::FrameUnwindToEmptyState(EHRegistrationNode*, void*, _s_FuncInfo const*)
 152d7 3 48 85
 152da 13 49 85
 152ed 2 50 85
-FUNC 152f5 e8 0 static __FrameHandler3::FrameUnwindToState(EHRegistrationNode*, void*, _s_FuncInfo const*, int)
+FUNC 152f5 e8 0 __FrameHandler3::FrameUnwindToState(EHRegistrationNode*, void*, _s_FuncInfo const*, int)
 152f5 c 1167 85
 15301 16 1176 85
 15317 8 1177 85
@@ -5322,7 +5322,7 @@ FUNC 152f5 e8 0 static __FrameHandler3::FrameUnwindToState(EHRegistrationNode*, 
 153c3 b 1221 85
 153ce 9 1222 85
 153d7 6 1240 85
-FUNC 15417 b 0 static __FrameHandler3::GetMaxState(void*, _s_FuncInfo const*)
+FUNC 15417 b 0 __FrameHandler3::GetMaxState(void*, _s_FuncInfo const*)
 15417 3 448 77
 1541a 6 449 77
 15420 2 450 77
@@ -5350,7 +5350,7 @@ FUNC 154e4 39 0 Is_bad_exception_allowed(_s_ESTypeList const*)
 15512 3 2157 85
 15515 4 2158 85
 15519 4 2153 85
-FUNC 1552b 9 0 static __FrameHandler3::TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
+FUNC 1552b 9 0 __FrameHandler3::TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
 1552b 3 976 85
 1552e 1 978 85
 1552f 5 977 85
@@ -5382,25 +5382,25 @@ FUNC 155a2 11 0 __FrameHandler3::HandlerMap::end()
 155a2 3 668 77
 155a5 a 669 77
 155af 4 670 77
-FUNC 155b7 b 0 static __FrameHandler3::getESTypes(_s_FuncInfo const*)
+FUNC 155b7 b 0 __FrameHandler3::getESTypes(_s_FuncInfo const*)
 155b7 3 196 85
 155ba 6 197 85
 155c0 2 198 85
 FUNC 155c4 e 0 __FrameHandler3::HandlerMap::getLastEntry()
 155c4 d 674 77
 155d1 1 675 77
-FUNC 155d5 f 0 static __FrameHandler3::getMagicNum(_s_FuncInfo const*)
+FUNC 155d5 f 0 __FrameHandler3::getMagicNum(_s_FuncInfo const*)
 155d5 3 504 77
 155d8 a 505 77
 155e2 2 506 77
 FUNC 155e7 6 0 __FrameHandler3::TryBlockMap::getNumTryBlocks()
 155e7 5 587 77
 155ec 1 588 77
-FUNC 155ed d 0 static __FrameHandler3::isEHs(_s_FuncInfo const*)
+FUNC 155ed d 0 __FrameHandler3::isEHs(_s_FuncInfo const*)
 155ed 3 494 77
 155f0 8 495 77
 155f8 2 496 77
-FUNC 155fd 10 0 static __FrameHandler3::isNoExcept(_s_FuncInfo const*)
+FUNC 155fd 10 0 __FrameHandler3::isNoExcept(_s_FuncInfo const*)
 155fd 3 499 77
 15600 b 500 77
 1560b 2 501 77
@@ -5475,14 +5475,14 @@ FUNC 15703 1d 0 unexpected()
 15710 8 43 88
 15718 2 43 88
 1571a 6 46 88
-FUNC 15727 1d 0 static __FrameHandler3::GetCurrentState(EHRegistrationNode*, void*, _s_FuncInfo const*)
+FUNC 15727 1d 0 __FrameHandler3::GetCurrentState(EHRegistrationNode*, void*, _s_FuncInfo const*)
 15727 3 202 89
 1572a f 205 89
 15739 4 207 89
 1573d 2 212 89
 1573f 3 210 89
 15742 2 212 89
-FUNC 1574b e 0 static __FrameHandler3::SetState(EHRegistrationNode*, _s_FuncInfo const*, int)
+FUNC 1574b e 0 __FrameHandler3::SetState(EHRegistrationNode*, _s_FuncInfo const*, int)
 1574b 3 219 89
 1574e 9 220 89
 15757 2 221 89
@@ -6259,7 +6259,7 @@ FUNC 16b9b 17 0 __crt_unique_handle_t<__crt_hmodule_traits>::close()
 16ba5 8 1146 214
 16bad 3 1147 214
 16bb0 2 1148 214
-FUNC 16bb7 15 0 static __crt_hmodule_traits::close(HINSTANCE__*)
+FUNC 16bb7 15 0 __crt_hmodule_traits::close(HINSTANCE__*)
 16bb7 5 1061 214
 16bbc e 1062 214
 16bca 2 1063 214
@@ -6285,7 +6285,7 @@ FUNC 16ca0 3 0 __crt_unique_handle_t<__crt_hmodule_traits>::get() const
 FUNC 16ca3 3 0 __crt_unique_handle_t<__crt_hmodule_traits>::get_address_of()
 16ca3 2 1162 214
 16ca5 1 1163 214
-FUNC 16ca6 3 0 static __crt_hmodule_traits::get_invalid_value()
+FUNC 16ca6 3 0 __crt_hmodule_traits::get_invalid_value()
 16ca6 2 1067 214
 16ca8 1 1068 214
 FUNC 16ca9 43 0 is_managed_app()
@@ -6420,9 +6420,9 @@ FUNC 1702a 12f 0 common_configure_argv<wchar_t>(const _crt_argv_mode)
 17136 3 390 332
 17139 1e 391 332
 17157 2 392 332
-FUNC 171a4 1c 0 static __crt_char_traits<char>::get_module_file_name<std::nullptr_t,char (&)[261],int>(void*&&, char[261]&, int&&)
+FUNC 171a4 1c 0 __crt_char_traits<char>::get_module_file_name<std::nullptr_t,char (&)[261],int>(void*&&, char[261]&, int&&)
 171a4 1c 109 336
-FUNC 171c7 1a 0 static __crt_char_traits<wchar_t>::get_module_file_name<std::nullptr_t,wchar_t (&)[261],int>(void*&&, wchar_t[261]&, int&&)
+FUNC 171c7 1a 0 __crt_char_traits<wchar_t>::get_module_file_name<std::nullptr_t,wchar_t (&)[261],int>(void*&&, wchar_t[261]&, int&&)
 171c7 1a 124 336
 FUNC 171e7 177 0 parse_command_line<char>(char*, char**, char*, unsigned int*, unsigned int*)
 171e7 6 102 332
@@ -6554,9 +6554,9 @@ FUNC 173bb 195 0 parse_command_line<wchar_t>(wchar_t*, wchar_t**, wchar_t*, unsi
 17544 3 259 332
 17547 7 261 332
 1754e 2 262 332
-FUNC 175b5 11 0 static __crt_char_traits<char>::set_program_name<char *>(char*&&)
+FUNC 175b5 11 0 __crt_char_traits<char>::set_program_name<char *>(char*&&)
 175b5 11 109 336
-FUNC 175ca 11 0 static __crt_char_traits<wchar_t>::set_program_name<wchar_t *>(wchar_t*&&)
+FUNC 175ca 11 0 __crt_char_traits<wchar_t>::set_program_name<wchar_t *>(wchar_t*&&)
 175ca 11 124 336
 FUNC 175df 10 0 <lambda_a36aafc41185bea294aaaa3896c79ecc>::<lambda_a36aafc41185bea294aaaa3896c79ecc>(__crt_unique_heap_ptr<wchar_t *,__crt_internal_free_policy>&)
 175df 10 388 332
@@ -6846,9 +6846,9 @@ FUNC 17ccd 2f 0 free_environment<wchar_t>(wchar_t** const)
 17ced 4 95 338
 17cf1 9 98 338
 17cfa 2 99 338
-FUNC 17d07 5 0 static __crt_char_traits<char>::get_environment_from_os<>()
+FUNC 17d07 5 0 __crt_char_traits<char>::get_environment_from_os<>()
 17d07 5 109 336
-FUNC 17d0c 5 0 static __crt_char_traits<wchar_t>::get_environment_from_os<>()
+FUNC 17d0c 5 0 __crt_char_traits<wchar_t>::get_environment_from_os<>()
 17d0c 5 124 336
 FUNC 17d11 83 0 initialize_environment_by_cloning_nolock<char>()
 17d11 5 242 338
@@ -6888,17 +6888,17 @@ FUNC 17db4 7d 0 initialize_environment_by_cloning_nolock<wchar_t>()
 17e1f 4 268 338
 17e23 7 262 338
 17e2a 7 269 338
-FUNC 17e50 18 0 static __crt_char_traits<char>::set_variable_in_environment_nolock<char *,int>(char*&&, int&&)
+FUNC 17e50 18 0 __crt_char_traits<char>::set_variable_in_environment_nolock<char *,int>(char*&&, int&&)
 17e50 18 109 336
-FUNC 17e6e 18 0 static __crt_char_traits<wchar_t>::set_variable_in_environment_nolock<wchar_t *,int>(wchar_t*&&, int&&)
+FUNC 17e6e 18 0 __crt_char_traits<wchar_t>::set_variable_in_environment_nolock<wchar_t *,int>(wchar_t*&&, int&&)
 17e6e 18 124 336
-FUNC 17e8c 1e 0 static __crt_char_traits<char>::tcscpy_s<char *,unsigned int const &,char * &>(char*&&, unsigned int const&, char*&)
+FUNC 17e8c 1e 0 __crt_char_traits<char>::tcscpy_s<char *,unsigned int const &,char * &>(char*&&, unsigned int const&, char*&)
 17e8c 1e 109 336
-FUNC 17eb1 1e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t *,unsigned int const &,wchar_t * &>(wchar_t*&&, unsigned int const&, wchar_t*&)
+FUNC 17eb1 1e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t *,unsigned int const &,wchar_t * &>(wchar_t*&&, unsigned int const&, wchar_t*&)
 17eb1 1e 124 336
-FUNC 17ed6 18 0 static __crt_char_traits<char>::tcslen<char * &>(char*&)
+FUNC 17ed6 18 0 __crt_char_traits<char>::tcslen<char * &>(char*&)
 17ed6 18 109 336
-FUNC 17ef4 1e 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t * &>(wchar_t*&)
+FUNC 17ef4 1e 0 __crt_char_traits<wchar_t>::tcslen<wchar_t * &>(wchar_t*&)
 17ef4 1e 124 336
 FUNC 17f19 29 0 __crt_state_management::dual_state_global<char * *>::uninitialize<void (__cdecl&)(char * * &)>(void (&)(char**&))
 17f19 9 177 109
@@ -8635,113 +8635,113 @@ FUNC 1cfab 1c 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::st
 1cfb0 11 1007 366
 1cfc1 2 1009 366
 1cfc3 4 1010 366
-FUNC 1cfce 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<char>(char*)
+FUNC 1cfce 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<char>(char*)
 1cfce 4 1452 366
-FUNC 1cfd2 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<char>(char*)
+FUNC 1cfd2 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<char>(char*)
 1cfd2 4 1452 366
-FUNC 1cfd6 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
+FUNC 1cfd6 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
 1cfd6 4 1452 366
-FUNC 1cfda 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
+FUNC 1cfda 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
 1cfda 4 1452 366
-FUNC 1cfde 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
+FUNC 1cfde 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
 1cfde 4 1452 366
-FUNC 1cfe2 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
+FUNC 1cfe2 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
 1cfe2 4 1452 366
-FUNC 1cfe6 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
+FUNC 1cfe6 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
 1cfe6 4 1452 366
-FUNC 1cfea 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
+FUNC 1cfea 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
 1cfea 4 1452 366
-FUNC 1cfee 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<void>(void*)
+FUNC 1cfee 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<void>(void*)
 1cfee 4 1452 366
-FUNC 1cff2 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<void>(void*)
+FUNC 1cff2 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<void>(void*)
 1cff2 4 1452 366
-FUNC 1cff6 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
+FUNC 1cff6 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
 1cff6 4 1452 366
-FUNC 1cffa 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
+FUNC 1cffa 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
 1cffa 4 1452 366
-FUNC 1cffe 18 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_character_specifier<char>(const char)
+FUNC 1cffe 18 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_character_specifier<char>(const char)
 1cffe 5 1566 366
 1d003 d 1567 366
 1d010 2 1568 366
 1d012 2 1567 366
 1d014 2 1568 366
-FUNC 1d01c 18 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_character_specifier<char>(const char)
+FUNC 1d01c 18 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_character_specifier<char>(const char)
 1d01c 5 1566 366
 1d021 d 1567 366
 1d02e 2 1568 366
 1d030 2 1567 366
 1d032 2 1568 366
-FUNC 1d03a 1b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
+FUNC 1d03a 1b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
 1d03a 5 1566 366
 1d03f 10 1567 366
 1d04f 2 1568 366
 1d051 2 1567 366
 1d053 2 1568 366
-FUNC 1d05b 1b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
+FUNC 1d05b 1b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
 1d05b 5 1566 366
 1d060 10 1567 366
 1d070 2 1568 366
 1d072 2 1567 366
 1d074 2 1568 366
-FUNC 1d07c 2c 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_integral_specifier<char>(const char)
+FUNC 1d07c 2c 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_integral_specifier<char>(const char)
 1d07c 5 1572 366
 1d081 21 1573 366
 1d0a2 2 1576 366
 1d0a4 2 1573 366
 1d0a6 2 1576 366
-FUNC 1d0b3 2c 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_integral_specifier<char>(const char)
+FUNC 1d0b3 2c 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_integral_specifier<char>(const char)
 1d0b3 5 1572 366
 1d0b8 21 1573 366
 1d0d9 2 1576 366
 1d0db 2 1573 366
 1d0dd 2 1576 366
-FUNC 1d0ea 3b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
+FUNC 1d0ea 3b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
 1d0ea 5 1572 366
 1d0ef 30 1573 366
 1d11f 2 1576 366
 1d121 2 1573 366
 1d123 2 1576 366
-FUNC 1d133 3b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
+FUNC 1d133 3b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
 1d133 5 1572 366
 1d138 30 1573 366
 1d168 2 1576 366
 1d16a 2 1573 366
 1d16c 2 1576 366
-FUNC 1d17c e 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_pointer_specifier<char>(const char)
+FUNC 1d17c e 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_pointer_specifier<char>(const char)
 1d17c 5 1554 366
 1d181 7 1555 366
 1d188 2 1556 366
-FUNC 1d18d e 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_pointer_specifier<char>(const char)
+FUNC 1d18d e 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_pointer_specifier<char>(const char)
 1d18d 5 1554 366
 1d192 7 1555 366
 1d199 2 1556 366
-FUNC 1d19e f 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
+FUNC 1d19e f 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
 1d19e 5 1554 366
 1d1a3 8 1555 366
 1d1ab 2 1556 366
-FUNC 1d1b0 f 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
+FUNC 1d1b0 f 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
 1d1b0 5 1554 366
 1d1b5 8 1555 366
 1d1bd 2 1556 366
-FUNC 1d1c2 18 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_string_specifier<char>(const char)
+FUNC 1d1c2 18 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_string_specifier<char>(const char)
 1d1c2 5 1560 366
 1d1c7 d 1561 366
 1d1d4 2 1562 366
 1d1d6 2 1561 366
 1d1d8 2 1562 366
-FUNC 1d1e0 18 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_string_specifier<char>(const char)
+FUNC 1d1e0 18 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_string_specifier<char>(const char)
 1d1e0 5 1560 366
 1d1e5 d 1561 366
 1d1f2 2 1562 366
 1d1f4 2 1561 366
 1d1f6 2 1562 366
-FUNC 1d1fe 1b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
+FUNC 1d1fe 1b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
 1d1fe 5 1560 366
 1d203 10 1561 366
 1d213 2 1562 366
 1d215 2 1561 366
 1d217 2 1562 366
-FUNC 1d21f 1b 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
+FUNC 1d21f 1b 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
 1d21f 5 1560 366
 1d224 10 1561 366
 1d234 2 1562 366
@@ -8829,9 +8829,9 @@ FUNC 1d3ca d 0 __crt_stdio_output::peek_va_arg<wchar_t>(char*)
 1d3ca 5 39 366
 1d3cf 6 40 366
 1d3d5 2 41 366
-FUNC 1d3da 1a 0 static __crt_char_traits<char>::puttc_nolock<char const &,_iobuf *>(char const&, _iobuf*&&)
+FUNC 1d3da 1a 0 __crt_char_traits<char>::puttc_nolock<char const &,_iobuf *>(char const&, _iobuf*&&)
 1d3da 1a 109 336
-FUNC 1d3fa 1a 0 static __crt_char_traits<wchar_t>::puttc_nolock<wchar_t const &,_iobuf *>(wchar_t const&, _iobuf*&&)
+FUNC 1d3fa 1a 0 __crt_char_traits<wchar_t>::puttc_nolock<wchar_t const &,_iobuf *>(wchar_t const&, _iobuf*&&)
 1d3fa 1a 124 336
 FUNC 1d41a 12 0 __crt_stdio_output::read_va_arg<signed char>(char*&)
 1d41a 5 33 366
@@ -8937,13 +8937,13 @@ FUNC 1d63f 1e 0 __crt_stdio_output::formatting_buffer::scratch_data<char>()
 1d654 4 389 366
 1d658 3 391 366
 1d65b 2 392 366
-FUNC 1d664 1e 0 static __crt_char_traits<char>::tcstol<char const * &,char * *,int>(char const*&, char**&&, int&&)
+FUNC 1d664 1e 0 __crt_char_traits<char>::tcstol<char const * &,char * *,int>(char const*&, char**&&, int&&)
 1d664 1e 109 336
-FUNC 1d689 1e 0 static __crt_char_traits<wchar_t>::tcstol<wchar_t const * &,wchar_t * *,int>(wchar_t const*&, wchar_t**&&, int&&)
+FUNC 1d689 1e 0 __crt_char_traits<wchar_t>::tcstol<wchar_t const * &,wchar_t * *,int>(wchar_t const*&, wchar_t**&&, int&&)
 1d689 1e 124 336
-FUNC 1d6ae 1e 0 static __crt_char_traits<char>::tcstol<char const *,char * *,int>(char const*&&, char**&&, int&&)
+FUNC 1d6ae 1e 0 __crt_char_traits<char>::tcstol<char const *,char * *,int>(char const*&&, char**&&, int&&)
 1d6ae 1e 109 336
-FUNC 1d6d3 1e 0 static __crt_char_traits<wchar_t>::tcstol<wchar_t const *,wchar_t * *,int>(wchar_t const*&&, wchar_t**&&, int&&)
+FUNC 1d6d3 1e 0 __crt_char_traits<wchar_t>::tcstol<wchar_t const *,wchar_t * *,int>(wchar_t const*&&, wchar_t**&&, int&&)
 1d6d3 1e 124 336
 FUNC 1d6f8 73 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_integer_parse_into_buffer<unsigned int>(unsigned int, const unsigned int, const bool)
 1d6f8 a 2584 366
@@ -9633,51 +9633,51 @@ FUNC 1f872 9 0 <lambda_dbd837d1c0b7fc6e2d81c287c81c071b>::operator()() const
 FUNC 1f87d 4 0 _LocaleUpdate::GetLocaleT()
 1f87d 3 1844 214
 1f880 1 1845 214
-FUNC 1f881 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f881 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f881 5 2729 366
 1f886 d 2730 366
 1f893 2 2734 366
-FUNC 1f89a 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f89a 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f89a 5 2729 366
 1f89f d 2730 366
 1f8ac 2 2734 366
-FUNC 1f8b3 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f8b3 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f8b3 5 2729 366
 1f8b8 d 2730 366
 1f8c5 2 2734 366
-FUNC 1f8cc 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f8cc 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f8cc 5 2729 366
 1f8d1 d 2730 366
 1f8de 2 2734 366
-FUNC 1f8e5 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f8e5 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f8e5 5 2729 366
 1f8ea d 2730 366
 1f8f7 2 2734 366
-FUNC 1f8fe 14 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 1f8fe 14 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 1f8fe 5 2729 366
 1f903 d 2730 366
 1f910 2 2734 366
-FUNC 1f917 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f917 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f917 5 2729 366
 1f91c d 2730 366
 1f929 2 2734 366
-FUNC 1f930 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f930 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f930 5 2729 366
 1f935 d 2730 366
 1f942 2 2734 366
-FUNC 1f949 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f949 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f949 5 2729 366
 1f94e d 2730 366
 1f95b 2 2734 366
-FUNC 1f962 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f962 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f962 5 2729 366
 1f967 d 2730 366
 1f974 2 2734 366
-FUNC 1f97b 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f97b 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f97b 5 2729 366
 1f980 d 2730 366
 1f98d 2 2734 366
-FUNC 1f994 14 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 1f994 14 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 1f994 5 2729 366
 1f999 d 2730 366
 1f9a6 2 2734 366
@@ -9847,69 +9847,69 @@ FUNC 20024 14 0 __crt_deferred_errno_cache::get()
 FUNC 2003d 7 0 __crt_stdio_stream::get_flags() const
 2003d 6 233 350
 20043 1 234 350
-FUNC 20044 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(short)
+FUNC 20044 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(short)
 20044 4 1453 366
-FUNC 20048 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned short)
+FUNC 20048 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned short)
 20048 4 1454 366
-FUNC 2004c 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(int)
+FUNC 2004c 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(int)
 2004c 4 1456 366
-FUNC 20050 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned int)
+FUNC 20050 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned int)
 20050 4 1457 366
-FUNC 20054 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 20054 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
 20054 4 1460 366
-FUNC 20058 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(long long)
+FUNC 20058 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(long long)
 20058 4 1458 366
-FUNC 2005c 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned long long)
+FUNC 2005c 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned long long)
 2005c 4 1459 366
-FUNC 20060 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(wchar_t)
+FUNC 20060 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(wchar_t)
 20060 4 1455 366
-FUNC 20064 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(short)
+FUNC 20064 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(short)
 20064 4 1453 366
-FUNC 20068 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned short)
+FUNC 20068 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned short)
 20068 4 1454 366
-FUNC 2006c 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(int)
+FUNC 2006c 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(int)
 2006c 4 1456 366
-FUNC 20070 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned int)
+FUNC 20070 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned int)
 20070 4 1457 366
-FUNC 20074 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 20074 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
 20074 4 1460 366
-FUNC 20078 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(long long)
+FUNC 20078 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(long long)
 20078 4 1458 366
-FUNC 2007c 4 8 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned long long)
+FUNC 2007c 4 8 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned long long)
 2007c 4 1459 366
-FUNC 20080 4 4 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(wchar_t)
+FUNC 20080 4 4 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(wchar_t)
 20080 4 1455 366
-FUNC 20084 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(short)
+FUNC 20084 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(short)
 20084 4 1453 366
-FUNC 20088 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
+FUNC 20088 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
 20088 4 1454 366
-FUNC 2008c 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(int)
+FUNC 2008c 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(int)
 2008c 4 1456 366
-FUNC 20090 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
+FUNC 20090 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
 20090 4 1457 366
-FUNC 20094 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 20094 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
 20094 4 1460 366
-FUNC 20098 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(long long)
+FUNC 20098 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(long long)
 20098 4 1458 366
-FUNC 2009c 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
+FUNC 2009c 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
 2009c 4 1459 366
-FUNC 200a0 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
+FUNC 200a0 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
 200a0 4 1455 366
-FUNC 200a4 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(short)
+FUNC 200a4 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(short)
 200a4 4 1453 366
-FUNC 200a8 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
+FUNC 200a8 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
 200a8 4 1454 366
-FUNC 200ac 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(int)
+FUNC 200ac 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(int)
 200ac 4 1456 366
-FUNC 200b0 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
+FUNC 200b0 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
 200b0 4 1457 366
-FUNC 200b4 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 200b4 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
 200b4 4 1460 366
-FUNC 200b8 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(long long)
+FUNC 200b8 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(long long)
 200b8 4 1458 366
-FUNC 200bc 4 8 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
+FUNC 200bc 4 8 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
 200bc 4 1459 366
-FUNC 200c0 4 4 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
+FUNC 200c0 4 4 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
 200c0 4 1455 366
 FUNC 200c4 12 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::has_flag(const unsigned int) const
 200c4 12 2707 366
@@ -10053,29 +10053,29 @@ FUNC 205e6 118 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_std
 206f7 7 1527 366
 FUNC 20744 c 0 __crt_stdio_stream::is_string_backed() const
 20744 c 227 350
-FUNC 20753 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 20753 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 20753 6 2737 366
-FUNC 20759 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 20759 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 20759 6 2737 366
-FUNC 2075f 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 2075f 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 2075f 6 2737 366
-FUNC 20765 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 20765 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 20765 6 2737 366
-FUNC 2076b 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 2076b 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 2076b 6 2737 366
-FUNC 20771 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 20771 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 20771 6 2737 366
-FUNC 20777 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 20777 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 20777 6 2737 366
-FUNC 2077d 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 2077d 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 2077d 6 2737 366
-FUNC 20783 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 20783 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 20783 6 2737 366
-FUNC 20789 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 20789 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 20789 6 2737 366
-FUNC 2078f 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 2078f 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 2078f 6 2737 366
-FUNC 20795 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 20795 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 20795 6 2737 366
 FUNC 2079b 74 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::parse_int_from_format_string(int* const)
 2079b b 1775 366
@@ -12501,52 +12501,52 @@ FUNC 26c51 2c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output:
 26c76 4 1814 366
 26c7a 2 1817 366
 26c7c 1 1818 366
-FUNC 26c88 4 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
+FUNC 26c88 4 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
 26c88 3 1103 366
 26c8b 1 1104 366
-FUNC 26c8c 4 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
+FUNC 26c8c 4 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
 26c8c 3 1103 366
 26c8f 1 1104 366
-FUNC 26c90 4 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
+FUNC 26c90 4 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
 26c90 3 1103 366
 26c93 1 1104 366
-FUNC 26c94 4 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
+FUNC 26c94 4 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
 26c94 3 1103 366
 26c97 1 1104 366
-FUNC 26c98 4 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
+FUNC 26c98 4 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
 26c98 3 1046 366
 26c9b 1 1047 366
-FUNC 26c9c 4 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
+FUNC 26c9c 4 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
 26c9c 3 1046 366
 26c9f 1 1047 366
-FUNC 26ca0 4 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
+FUNC 26ca0 4 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
 26ca0 3 1046 366
 26ca3 1 1047 366
-FUNC 26ca4 4 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
+FUNC 26ca4 4 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
 26ca4 3 1046 366
 26ca7 1 1047 366
-FUNC 26ca8 6 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
+FUNC 26ca8 6 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
 26ca8 5 1108 366
 26cad 1 1109 366
-FUNC 26cae 6 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
+FUNC 26cae 6 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
 26cae 5 1108 366
 26cb3 1 1109 366
-FUNC 26cb4 6 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
+FUNC 26cb4 6 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
 26cb4 5 1108 366
 26cb9 1 1109 366
-FUNC 26cba 6 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
+FUNC 26cba 6 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
 26cba 5 1108 366
 26cbf 1 1109 366
-FUNC 26cc0 6 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
+FUNC 26cc0 6 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
 26cc0 5 1051 366
 26cc5 1 1052 366
-FUNC 26cc6 6 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
+FUNC 26cc6 6 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
 26cc6 5 1051 366
 26ccb 1 1052 366
-FUNC 26ccc 6 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
+FUNC 26ccc 6 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
 26ccc 5 1051 366
 26cd1 1 1052 366
-FUNC 26cd2 6 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
+FUNC 26cd2 6 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
 26cd2 5 1051 366
 26cd7 1 1052 366
 FUNC 26cd8 6 4 __crt_stdio_output::common_data<char>::tchar_string(char)
@@ -14864,39 +14864,39 @@ FUNC 2d432 3 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::str
 FUNC 2d435 3 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::validate_state_for_type_case_a() const
 2d435 2 1026 366
 2d437 1 1027 366
-FUNC 2d438 87 0 static __acrt_stdio_char_traits<char>::validate_stream_is_ansi_if_required(_iobuf* const)
+FUNC 2d438 87 0 __acrt_stdio_char_traits<char>::validate_stream_is_ansi_if_required(_iobuf* const)
 2d438 5 439 350
 2d43d 3 440 350
 2d440 1 439 350
 2d441 79 440 350
 2d4ba 3 441 350
 2d4bd 2 442 350
-FUNC 2d4e0 3 4 static __acrt_stdio_char_traits<wchar_t>::validate_stream_is_ansi_if_required(_iobuf* const)
+FUNC 2d4e0 3 4 __acrt_stdio_char_traits<wchar_t>::validate_stream_is_ansi_if_required(_iobuf* const)
 2d4e0 2 454 350
 2d4e2 1 455 350
-FUNC 2d4e3 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 2d4e3 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 2d4e3 6 2738 366
-FUNC 2d4e9 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 2d4e9 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 2d4e9 6 2738 366
-FUNC 2d4ef 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 2d4ef 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 2d4ef 6 2738 366
-FUNC 2d4f5 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 2d4f5 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 2d4f5 6 2738 366
-FUNC 2d4fb 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 2d4fb 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 2d4fb 6 2738 366
-FUNC 2d501 6 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 2d501 6 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 2d501 6 2738 366
-FUNC 2d507 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2d507 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 2d507 6 2738 366
-FUNC 2d50d 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2d50d 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 2d50d 6 2738 366
-FUNC 2d513 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2d513 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 2d513 6 2738 366
-FUNC 2d519 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2d519 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 2d519 6 2738 366
-FUNC 2d51f 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2d51f 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 2d51f 6 2738 366
-FUNC 2d525 6 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 2d525 6 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 2d525 6 2738 366
 FUNC 2d52b 1f 0 __crt_stdio_output::output_adapter_common<char,__crt_stdio_output::stream_output_adapter<char> >::write_character(const char, int* const) const
 2d52b 5 60 366
@@ -16223,35 +16223,35 @@ FUNC 31a6f 2f 0 get_win_policy<`__acrt_get_process_end_policy'::`2'::process_end
 31a8a 9 23 380
 31a93 9 26 380
 31a9c 2 27 380
-FUNC 31aa9 f 0 static `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_get_policy(AppPolicyThreadInitializationType*)
+FUNC 31aa9 f 0 `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_get_policy(AppPolicyThreadInitializationType*)
 31aa9 5 110 380
 31aae 8 111 380
 31ab6 2 112 380
-FUNC 31abb f 0 static `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_get_policy(AppPolicyShowDeveloperDiagnostic*)
+FUNC 31abb f 0 `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_get_policy(AppPolicyShowDeveloperDiagnostic*)
 31abb 5 141 380
 31ac0 8 142 380
 31ac8 2 143 380
-FUNC 31acd f 0 static `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_get_policy(AppPolicyProcessTerminationMethod*)
+FUNC 31acd f 0 `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_get_policy(AppPolicyProcessTerminationMethod*)
 31acd 5 79 380
 31ad2 8 80 380
 31ada 2 81 380
-FUNC 31adf f 0 static `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_get_policy(AppPolicyWindowingModel*)
+FUNC 31adf f 0 `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_get_policy(AppPolicyWindowingModel*)
 31adf 5 179 380
 31ae4 8 180 380
 31aec 2 181 380
-FUNC 31af1 11 0 static `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 31af1 11 0 `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_policy_to_policy_type(const long)
 31af1 5 98 380
 31af6 a 99 380
 31b00 2 107 380
-FUNC 31b06 11 0 static `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 31b06 11 0 `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_policy_to_policy_type(const long)
 31b06 5 129 380
 31b0b a 130 380
 31b15 2 138 380
-FUNC 31b1b 10 0 static `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_policy_to_policy_type(const AppPolicyProcessTerminationMethod)
+FUNC 31b1b 10 0 `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_policy_to_policy_type(const AppPolicyProcessTerminationMethod)
 31b1b 5 67 380
 31b20 9 68 380
 31b29 2 76 380
-FUNC 31b2f 29 0 static `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 31b2f 29 0 `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_policy_to_policy_type(const long)
 31b2f 5 160 380
 31b34 12 161 380
 31b46 4 174 380
@@ -16348,9 +16348,9 @@ FUNC 31e16 5d 0 _calloc_base(unsigned int, unsigned int)
 31e3a 14 45 382
 31e4e 15 38 382
 31e63 10 53 382
-FUNC 31e8a 18 0 static <lambda_838c7f62c73c983481e27c09e84b0b5d>::<lambda_invoker_cdecl>(void const*, void const*)
+FUNC 31e8a 18 0 <lambda_838c7f62c73c983481e27c09e84b0b5d>::<lambda_invoker_cdecl>(void const*, void const*)
 31e8a 18 301 387
-FUNC 31ea8 18 0 static <lambda_d388dc2bcbe6079ffc891eec49d9b3b2>::<lambda_invoker_cdecl>(void const*, void const*)
+FUNC 31ea8 18 0 <lambda_d388dc2bcbe6079ffc891eec49d9b3b2>::<lambda_invoker_cdecl>(void const*, void const*)
 31ea8 18 301 387
 FUNC 31ec6 b2 0 __acrt_convert_wcs_mbs_cp<char,wchar_t,<lambda_62f6974d9771e494a5ea317cc32e971c>,__crt_win32_buffer_internal_dynamic_resizing>(char const* const, __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>&, __acrt_mbs_to_wcs_cp::__l2::<lambda_62f6974d9771e494a5ea317cc32e971c> const&, const unsigned int)
 31ec6 6 494 337
@@ -16601,25 +16601,25 @@ FUNC 32ab4 172 0 expand_argument_wildcards<wchar_t>(wchar_t* const, wchar_t* con
 32bf4 16 292 387
 32c0a d 303 387
 32c17 f 304 387
-FUNC 32c82 18 0 static __crt_char_traits<char>::tcslen<char const * const &>(char const* const&)
+FUNC 32c82 18 0 __crt_char_traits<char>::tcslen<char const * const &>(char const* const&)
 32c82 18 109 336
-FUNC 32ca0 1e 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t const * const &>(wchar_t const* const&)
+FUNC 32ca0 1e 0 __crt_char_traits<wchar_t>::tcslen<wchar_t const * const &>(wchar_t const* const&)
 32ca0 1e 124 336
-FUNC 32cc5 23 0 static __crt_char_traits<char>::tcsncpy_s<char * &,unsigned int,char * &,unsigned int const &>(char*&, unsigned int&&, char*&, unsigned int const&)
+FUNC 32cc5 23 0 __crt_char_traits<char>::tcsncpy_s<char * &,unsigned int,char * &,unsigned int const &>(char*&, unsigned int&&, char*&, unsigned int const&)
 32cc5 23 109 336
-FUNC 32cf0 23 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t * &,unsigned int,wchar_t * &,unsigned int const &>(wchar_t*&, unsigned int&&, wchar_t*&, unsigned int const&)
+FUNC 32cf0 23 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t * &,unsigned int,wchar_t * &,unsigned int const &>(wchar_t*&, unsigned int&&, wchar_t*&, unsigned int const&)
 32cf0 23 124 336
-FUNC 32d1b 23 0 static __crt_char_traits<char>::tcsncpy_s<char *,unsigned int const &,char const * const &,unsigned int const &>(char*&&, unsigned int const&, char const* const&, unsigned int const&)
+FUNC 32d1b 23 0 __crt_char_traits<char>::tcsncpy_s<char *,unsigned int const &,char const * const &,unsigned int const &>(char*&&, unsigned int const&, char const* const&, unsigned int const&)
 32d1b 23 109 336
-FUNC 32d46 23 0 static __crt_char_traits<char>::tcsncpy_s<char *,unsigned int,char const * const &,unsigned int const &>(char*&&, unsigned int&&, char const* const&, unsigned int const&)
+FUNC 32d46 23 0 __crt_char_traits<char>::tcsncpy_s<char *,unsigned int,char const * const &,unsigned int const &>(char*&&, unsigned int&&, char const* const&, unsigned int const&)
 32d46 23 109 336
-FUNC 32d71 23 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned int const &,wchar_t const * const &,unsigned int const &>(wchar_t*&&, unsigned int const&, wchar_t const* const&, unsigned int const&)
+FUNC 32d71 23 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned int const &,wchar_t const * const &,unsigned int const &>(wchar_t*&&, unsigned int const&, wchar_t const* const&, unsigned int const&)
 32d71 23 124 336
-FUNC 32d9c 23 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned int,wchar_t const * const &,unsigned int const &>(wchar_t*&&, unsigned int&&, wchar_t const* const&, unsigned int const&)
+FUNC 32d9c 23 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned int,wchar_t const * const &,unsigned int const &>(wchar_t*&&, unsigned int&&, wchar_t const* const&, unsigned int const&)
 32d9c 23 124 336
-FUNC 32dc7 16 0 static __crt_char_traits<char>::tcspbrk<char * &,char const (&)[3]>(char*&, const char[3]&)
+FUNC 32dc7 16 0 __crt_char_traits<char>::tcspbrk<char * &,char const (&)[3]>(char*&, const char[3]&)
 32dc7 16 109 336
-FUNC 32de2 16 0 static __crt_char_traits<wchar_t>::tcspbrk<wchar_t * &,wchar_t const (&)[3]>(wchar_t*&, const wchar_t[3]&)
+FUNC 32de2 16 0 __crt_char_traits<wchar_t>::tcspbrk<wchar_t * &,wchar_t const (&)[3]>(wchar_t*&, const wchar_t[3]&)
 32de2 16 124 336
 FUNC 32dfd 10 0 __crt_unique_handle_t<__crt_findfile_traits>::__crt_unique_handle_t<__crt_findfile_traits>(void* const)
 32dfd 5 1098 214
@@ -16732,7 +16732,7 @@ FUNC 330c0 3f 0 __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_r
 330f0 4 360 337
 330f4 5 362 337
 330f9 6 363 337
-FUNC 3310e 1f 0 static __crt_win32_buffer_internal_dynamic_resizing::allocate(void** const, const unsigned int, __crt_win32_buffer_empty_debug_info const&)
+FUNC 3310e 1f 0 __crt_win32_buffer_internal_dynamic_resizing::allocate(void** const, const unsigned int, __crt_win32_buffer_empty_debug_info const&)
 3310e 5 82 337
 33113 9 83 337
 3311c 5 84 337
@@ -16772,7 +16772,7 @@ FUNC 331c6 17 0 __crt_unique_handle_t<__crt_findfile_traits>::close()
 331d0 8 1146 214
 331d8 3 1147 214
 331db 2 1148 214
-FUNC 331e2 15 0 static __crt_findfile_traits::close(void*)
+FUNC 331e2 15 0 __crt_findfile_traits::close(void*)
 331e2 5 1076 214
 331e7 e 1077 214
 331f5 2 1078 214
@@ -16782,7 +16782,7 @@ FUNC 331fc 4 0 __crt_win32_buffer<char,__crt_win32_buffer_internal_dynamic_resiz
 FUNC 33200 4 0 __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>::data()
 33200 3 248 337
 33203 1 249 337
-FUNC 33204 10 0 static __crt_win32_buffer_internal_dynamic_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
+FUNC 33204 10 0 __crt_win32_buffer_internal_dynamic_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
 33204 5 92 337
 33209 9 93 337
 33212 2 94 337
@@ -16854,7 +16854,7 @@ FUNC 333ac a 0 get_file_name(__crt_win32_buffer<wchar_t,__crt_win32_buffer_inter
 333ac 5 207 387
 333b1 3 208 387
 333b4 2 209 387
-FUNC 333b8 4 0 static __crt_findfile_traits::get_invalid_value()
+FUNC 333b8 4 0 __crt_findfile_traits::get_invalid_value()
 333b8 3 1082 214
 333bb 1 1083 214
 FUNC 333bc a 0 get_wide(__crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>*, wchar_t* const)
@@ -16971,7 +16971,7 @@ FUNC 3364e 27 4 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::allocat
 3365d a 348 337
 33667 b 357 337
 33672 3 363 337
-FUNC 3367e d c static __crt_win32_buffer_no_resizing::allocate(void** const, const unsigned int, __crt_win32_buffer_empty_debug_info const&)
+FUNC 3367e d c __crt_win32_buffer_no_resizing::allocate(void** const, const unsigned int, __crt_win32_buffer_empty_debug_info const&)
 3367e a 132 337
 33688 2 133 337
 3368a 1 134 337
@@ -16981,7 +16981,7 @@ FUNC 3368e 4 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::capacity
 FUNC 33692 4 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::data()
 33692 3 248 337
 33695 1 249 337
-FUNC 33696 3 8 static __crt_win32_buffer_no_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
+FUNC 33696 3 8 __crt_win32_buffer_no_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
 33696 3 138 337
 FUNC 33699 3 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::debug_info() const
 33699 2 341 337
@@ -17515,7 +17515,7 @@ FUNC 34b63 17 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings
 34b6d 8 1146 214
 34b75 3 1147 214
 34b78 2 1148 214
-FUNC 34b7f 12 0 static `anonymous namespace'::environment_strings_traits::close(wchar_t*)
+FUNC 34b7f 12 0 `anonymous namespace'::environment_strings_traits::close(wchar_t*)
 34b7f 5 24 401
 34b84 9 25 401
 34b8d 2 26 401
@@ -17529,7 +17529,7 @@ FUNC 34b95 37 0 find_end_of_double_null_terminated_sequence(wchar_t const* const
 FUNC 34bd9 3 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings_traits>::get() const
 34bd9 2 1138 214
 34bdb 1 1139 214
-FUNC 34bdc 3 0 static `anonymous namespace'::environment_strings_traits::get_invalid_value()
+FUNC 34bdc 3 0 `anonymous namespace'::environment_strings_traits::get_invalid_value()
 34bdc 2 31 401
 34bde 1 32 401
 FUNC 34bdf 7 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings_traits>::is_valid() const
@@ -17746,33 +17746,33 @@ FUNC 35516 58 0 find_in_environment_nolock<wchar_t>(wchar_t const* const, const 
 35559 7 125 402
 35560 7 126 402
 35567 7 121 402
-FUNC 35584 5 0 static __crt_char_traits<char>::get_or_create_environment_nolock<>()
+FUNC 35584 5 0 __crt_char_traits<char>::get_or_create_environment_nolock<>()
 35584 5 109 336
-FUNC 35589 5 0 static __crt_char_traits<wchar_t>::get_or_create_environment_nolock<>()
+FUNC 35589 5 0 __crt_char_traits<wchar_t>::get_or_create_environment_nolock<>()
 35589 5 124 336
-FUNC 3558e 18 0 static __crt_char_traits<char>::set_environment_variable<char * const &,char * const>(char* const&, char* const&&)
+FUNC 3558e 18 0 __crt_char_traits<char>::set_environment_variable<char * const &,char * const>(char* const&, char* const&&)
 3558e 18 109 336
-FUNC 355ac 17 0 static __crt_char_traits<wchar_t>::set_environment_variable<wchar_t * const &,wchar_t * const>(wchar_t* const&, wchar_t* const&&)
+FUNC 355ac 17 0 __crt_char_traits<wchar_t>::set_environment_variable<wchar_t * const &,wchar_t * const>(wchar_t* const&, wchar_t* const&&)
 355ac 17 124 336
-FUNC 355c8 1a 0 static __crt_char_traits<char>::tcschr<char * const &,char>(char* const&, char&&)
+FUNC 355c8 1a 0 __crt_char_traits<char>::tcschr<char * const &,char>(char* const&, char&&)
 355c8 1a 109 336
-FUNC 355e8 1e 0 static __crt_char_traits<wchar_t>::tcschr<wchar_t * const &,char>(wchar_t* const&, char&&)
+FUNC 355e8 1e 0 __crt_char_traits<wchar_t>::tcschr<wchar_t * const &,char>(wchar_t* const&, char&&)
 355e8 1e 124 336
-FUNC 3560d 1e 0 static __crt_char_traits<char>::tcscpy_s<char * &,unsigned int const &,char * &>(char*&, unsigned int const&, char*&)
+FUNC 3560d 1e 0 __crt_char_traits<char>::tcscpy_s<char * &,unsigned int const &,char * &>(char*&, unsigned int const&, char*&)
 3560d 1e 109 336
-FUNC 35632 1e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * &,unsigned int const &,wchar_t * &>(wchar_t*&, unsigned int const&, wchar_t*&)
+FUNC 35632 1e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * &,unsigned int const &,wchar_t * &>(wchar_t*&, unsigned int const&, wchar_t*&)
 35632 1e 124 336
-FUNC 35657 1e 0 static __crt_char_traits<char>::tcscpy_s<char * const &,unsigned int const &,char * const &>(char* const&, unsigned int const&, char* const&)
+FUNC 35657 1e 0 __crt_char_traits<char>::tcscpy_s<char * const &,unsigned int const &,char * const &>(char* const&, unsigned int const&, char* const&)
 35657 1e 109 336
-FUNC 3567c 1e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * const &,unsigned int const &,wchar_t * const &>(wchar_t* const&, unsigned int const&, wchar_t* const&)
+FUNC 3567c 1e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * const &,unsigned int const &,wchar_t * const &>(wchar_t* const&, unsigned int const&, wchar_t* const&)
 3567c 1e 124 336
-FUNC 356a1 18 0 static __crt_char_traits<char>::tcslen<char * const &>(char* const&)
+FUNC 356a1 18 0 __crt_char_traits<char>::tcslen<char * const &>(char* const&)
 356a1 18 109 336
-FUNC 356bf 1e 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t * const &>(wchar_t* const&)
+FUNC 356bf 1e 0 __crt_char_traits<wchar_t>::tcslen<wchar_t * const &>(wchar_t* const&)
 356bf 1e 124 336
-FUNC 356e4 1e 0 static __crt_char_traits<char>::tcsnicoll<char const * const &,char * &,unsigned int const &>(char const* const&, char*&, unsigned int const&)
+FUNC 356e4 1e 0 __crt_char_traits<char>::tcsnicoll<char const * const &,char * &,unsigned int const &>(char const* const&, char*&, unsigned int const&)
 356e4 1e 109 336
-FUNC 35709 1e 0 static __crt_char_traits<wchar_t>::tcsnicoll<wchar_t const * const &,wchar_t * &,unsigned int const &>(wchar_t const* const&, wchar_t*&, unsigned int const&)
+FUNC 35709 1e 0 __crt_char_traits<wchar_t>::tcsnicoll<wchar_t const * const &,wchar_t * &,unsigned int const &>(wchar_t const* const&, wchar_t*&, unsigned int const&)
 35709 1e 124 336
 FUNC 3572e 6 4 get_environment(char)
 3572e 6 17 402
@@ -17816,7 +17816,7 @@ FUNC 35793 6d 0 _recalloc_base(void*, unsigned int, unsigned int)
 357e8 11 40 403
 357f9 5 43 403
 357fe 2 44 403
-FUNC 3581b d 0 static <lambda_29d3c280b90b41c2ae070ffca879996a>::<lambda_invoker_stdcall>(wchar_t*)
+FUNC 3581b d 0 <lambda_29d3c280b90b41c2ae070ffca879996a>::<lambda_invoker_stdcall>(wchar_t*)
 3581b d 425 405
 FUNC 3582b 6 0 __crt_fast_encoded_nullptr_t::operator<int __stdcall(wchar_t *,unsigned long,long)> int (__stdcall*)(wchar_t *,unsigned long,long)() const
 3582b 5 536 159
@@ -19461,28 +19461,28 @@ FUNC 39df9 4 0 __crt_simd_cleanup_guard<1>::~__crt_simd_cleanup_guard<1>()
 39dfc 1 116 428
 FUNC 39dfd 3 0 __crt_simd_cleanup_guard<0>::~__crt_simd_cleanup_guard<0>()
 39dfd 3 63 428
-FUNC 39e00 5 0 static __crt_simd_traits<1,unsigned char>::compare_equals(const __m256i, const __m256i)
+FUNC 39e00 5 0 __crt_simd_traits<1,unsigned char>::compare_equals(const __m256i, const __m256i)
 39e00 4 143 428
 39e04 1 144 428
-FUNC 39e05 5 0 static __crt_simd_traits<1,unsigned short>::compare_equals(const __m256i, const __m256i)
+FUNC 39e05 5 0 __crt_simd_traits<1,unsigned short>::compare_equals(const __m256i, const __m256i)
 39e05 4 153 428
 39e09 1 154 428
-FUNC 39e0a 5 0 static __crt_simd_traits<0,unsigned char>::compare_equals(const __m128i, const __m128i)
+FUNC 39e0a 5 0 __crt_simd_traits<0,unsigned char>::compare_equals(const __m128i, const __m128i)
 39e0a 4 90 428
 39e0e 1 91 428
-FUNC 39e0f 5 0 static __crt_simd_traits<0,unsigned short>::compare_equals(const __m128i, const __m128i)
+FUNC 39e0f 5 0 __crt_simd_traits<0,unsigned short>::compare_equals(const __m128i, const __m128i)
 39e0f 4 100 428
 39e13 1 101 428
-FUNC 39e14 5 0 static __crt_simd_pack_traits<1>::compute_byte_mask(const __m256i)
+FUNC 39e14 5 0 __crt_simd_pack_traits<1>::compute_byte_mask(const __m256i)
 39e14 4 133 428
 39e18 1 134 428
-FUNC 39e19 5 0 static __crt_simd_pack_traits<0>::compute_byte_mask(const __m128i)
+FUNC 39e19 5 0 __crt_simd_pack_traits<0>::compute_byte_mask(const __m128i)
 39e19 4 80 428
 39e1d 1 81 428
-FUNC 39e1e 5 0 static __crt_simd_pack_traits<1>::get_zero_pack()
+FUNC 39e1e 5 0 __crt_simd_pack_traits<1>::get_zero_pack()
 39e1e 4 128 428
 39e22 1 129 428
-FUNC 39e23 4 0 static __crt_simd_pack_traits<0>::get_zero_pack()
+FUNC 39e23 4 0 __crt_simd_pack_traits<0>::get_zero_pack()
 39e23 3 75 428
 39e26 1 76 428
 FUNC 39e27 122 8 strnlen(char const*, unsigned int)
@@ -24672,17 +24672,17 @@ FUNC 4cf73 7e 0 common_show_message_box<wchar_t>(wchar_t const* const, wchar_t c
 4cfd8 f 75 514
 4cfe7 6 64 514
 4cfed 4 76 514
-FUNC 4d010 20 0 static __crt_char_traits<char>::message_box<std::nullptr_t,char const * const &,char const * const &,unsigned long>(void*&&, char const* const&, char const* const&, unsigned long&&)
+FUNC 4d010 20 0 __crt_char_traits<char>::message_box<std::nullptr_t,char const * const &,char const * const &,unsigned long>(void*&&, char const* const&, char const* const&, unsigned long&&)
 4d010 20 109 336
-FUNC 4d038 20 0 static __crt_char_traits<wchar_t>::message_box<std::nullptr_t,wchar_t const * const &,wchar_t const * const &,unsigned long>(void*&&, wchar_t const* const&, wchar_t const* const&, unsigned long&&)
+FUNC 4d038 20 0 __crt_char_traits<wchar_t>::message_box<std::nullptr_t,wchar_t const * const &,wchar_t const * const &,unsigned long>(void*&&, wchar_t const* const&, wchar_t const* const&, unsigned long&&)
 4d038 20 124 336
-FUNC 4d060 20 0 static __crt_char_traits<char>::message_box<HWND__ *,char const * const &,char const * const &,unsigned int const &>(HWND__*&&, char const* const&, char const* const&, unsigned int const&)
+FUNC 4d060 20 0 __crt_char_traits<char>::message_box<HWND__ *,char const * const &,char const * const &,unsigned int const &>(HWND__*&&, char const* const&, char const* const&, unsigned int const&)
 4d060 20 109 336
-FUNC 4d088 20 0 static __crt_char_traits<wchar_t>::message_box<HWND__ *,wchar_t const * const &,wchar_t const * const &,unsigned int const &>(HWND__*&&, wchar_t const* const&, wchar_t const* const&, unsigned int const&)
+FUNC 4d088 20 0 __crt_char_traits<wchar_t>::message_box<HWND__ *,wchar_t const * const &,wchar_t const * const &,unsigned int const &>(HWND__*&&, wchar_t const* const&, wchar_t const* const&, unsigned int const&)
 4d088 20 124 336
-FUNC 4d0b0 11 0 static __crt_char_traits<char>::output_debug_string<char const * const &>(char const* const&)
+FUNC 4d0b0 11 0 __crt_char_traits<char>::output_debug_string<char const * const &>(char const* const&)
 4d0b0 11 109 336
-FUNC 4d0c5 12 0 static __crt_char_traits<wchar_t>::output_debug_string<wchar_t const * const &>(wchar_t const* const&)
+FUNC 4d0c5 12 0 __crt_char_traits<wchar_t>::output_debug_string<wchar_t const * const &>(wchar_t const* const&)
 4d0c5 12 124 336
 FUNC 4d0db b 0 __acrt_show_narrow_message_box(char const*, char const*, unsigned int)
 4d0db 5 83 514

--- a/test_data/windows/basic64.sym
+++ b/test_data/windows/basic64.sym
@@ -599,7 +599,7 @@ FUNC 6de0 11 0 A::meth2(int)
 FUNC 6e00 17 0 A::meth2(double)
 6e00 12 74 0
 6e12 5 75 0
-FUNC 6e20 c 0 static A::meth2(short, signed char)
+FUNC 6e20 c 0 A::meth2(short, signed char)
 6e20 a 77 0
 6e2a 2 78 0
 FUNC 6e30 1a 0 A::meth4(A*, A::B&&)
@@ -635,7 +635,7 @@ FUNC 6ff0 1d 0 std::_String_val<std::_Simple_types<char> >::_Large_string_engage
 FUNC 7020 19 0 std::_String_alloc<std::_String_base_types<char,std::allocator<char> > >::_Getal()
 7020 e 2032 1
 702e b 2033 1
-FUNC 7040 12 0 static std::_Default_allocator_traits<std::allocator<char> >::destroy<char *>(std::allocator<char>&, char** const)
+FUNC 7040 12 0 std::_Default_allocator_traits<std::allocator<char> >::destroy<char *>(std::allocator<char>&, char** const)
 7040 d 886 2
 704d 5 888 2
 FUNC 7060 b 0 std::addressof<char *>(char*&)
@@ -645,7 +645,7 @@ FUNC 7070 39 0 std::allocator<char>::deallocate(char* const, const unsigned long
 7070 13 990 2
 7083 20 992 2
 70a3 6 993 2
-FUNC 70c0 1f 0 static std::char_traits<char>::assign(char&, char const&)
+FUNC 70c0 1f 0 std::char_traits<char>::assign(char&, char const&)
 70c0 d 505 4
 70cd d 506 4
 70da 5 507 4
@@ -920,7 +920,7 @@ FUNC a53c 9 0 __crt_rotate_pointer_value(const unsigned long long, const int)
 a53c 3 497 28
 a53f 5 498 28
 a544 1 499 28
-FUNC a548 14 0 static __scrt_narrow_argv_policy::configure_argv()
+FUNC a548 14 0 __scrt_narrow_argv_policy::configure_argv()
 a548 14 400 31
 FUNC a564 49 0 find_pe_section(unsigned char* const, const unsigned long long)
 a564 4 63 44
@@ -932,7 +932,7 @@ a5a6 3 75 44
 a5a9 1 80 44
 a5aa 2 79 44
 a5ac 1 80 44
-FUNC a5c0 5 0 static __scrt_narrow_environment_policy::initialize_environment()
+FUNC a5c0 5 0 __scrt_narrow_environment_policy::initialize_environment()
 a5c0 5 421 31
 FUNC a5c8 2f 0 is_potentially_valid_image_base(void* const)
 a5c8 5 29 44
@@ -1259,9 +1259,9 @@ b331 1a 406 53
 b34b d 344 53
 b358 5 421 53
 b35d 1e 422 53
-FUNC b400 5 0 static <lambda_02a71323d951a238fa4826e9f186893b>::<lambda_invoker_cdecl>(void* const)
+FUNC b400 5 0 <lambda_02a71323d951a238fa4826e9f186893b>::<lambda_invoker_cdecl>(void* const)
 b400 5 84 54
-FUNC b408 5 0 static <lambda_ab747d7d039e86ead2ea2c584b0f6318>::<lambda_invoker_cdecl>(const unsigned long long)
+FUNC b408 5 0 <lambda_ab747d7d039e86ead2ea2c584b0f6318>::<lambda_invoker_cdecl>(const unsigned long long)
 b408 5 83 54
 FUNC b410 8 0 __crt_internal_free_policy::operator()<char>(char const* const) const
 b410 8 335 28
@@ -1951,7 +1951,7 @@ cbde b 134 73
 cbe9 12 136 73
 cbfb 5 132 73
 cc00 6 139 73
-FUNC cc18 20 0 static UnDecorator::UScore(Tokens)
+FUNC cc18 20 0 UnDecorator::UScore(Tokens)
 cc18 1b 4984 73
 cc33 4 4987 73
 cc37 1 4989 73
@@ -1964,7 +1964,7 @@ cc8e 4 617 74
 cc92 2 619 74
 cc94 4 620 74
 cc98 b 621 74
-FUNC ccbc db3 0 static UnDecorator::composeDeclaration(DName const&)
+FUNC ccbc db3 0 UnDecorator::composeDeclaration(DName const&)
 ccbc 1c 2394 73
 ccd8 6 2396 73
 ccde 3 2395 73
@@ -2104,25 +2104,25 @@ da07 6 2701 73
 da0d 35 2703 73
 da42 c 2706 73
 da4e 21 2708 73
-FUNC dddc f 0 static UnDecorator::doAccessSpecifiers()
+FUNC dddc f 0 UnDecorator::doAccessSpecifiers()
 dddc f 4960 73
-FUNC ddf0 f 0 static UnDecorator::doAllocationLanguage()
+FUNC ddf0 f 0 UnDecorator::doAllocationLanguage()
 ddf0 f 4952 73
-FUNC de04 f 0 static UnDecorator::doAllocationModel()
+FUNC de04 f 0 UnDecorator::doAllocationModel()
 de04 f 4951 73
-FUNC de18 f 0 static UnDecorator::doEcsu()
+FUNC de18 f 0 UnDecorator::doEcsu()
 de18 f 4970 73
-FUNC de2c f 0 static UnDecorator::doEllipsis()
+FUNC de2c f 0 UnDecorator::doEllipsis()
 de2c f 4972 73
-FUNC de40 f 0 static UnDecorator::doFunctionReturns()
+FUNC de40 f 0 UnDecorator::doFunctionReturns()
 de40 f 4950 73
-FUNC de54 e 0 static UnDecorator::doMSKeywords()
+FUNC de54 e 0 UnDecorator::doMSKeywords()
 de54 e 4948 73
-FUNC de68 f 0 static UnDecorator::doMemberTypes()
+FUNC de68 f 0 UnDecorator::doMemberTypes()
 de68 f 4962 73
-FUNC de7c c 0 static UnDecorator::doNameOnly()
+FUNC de7c c 0 UnDecorator::doNameOnly()
 de7c c 4967 73
-FUNC de8c c 0 static UnDecorator::doNoIdentCharCheck()
+FUNC de8c c 0 UnDecorator::doNoIdentCharCheck()
 de8c c 4971 73
 FUNC de9c a6 0 DName::doPchar(char const*, int)
 de9c f 828 74
@@ -2135,19 +2135,19 @@ defe 20 842 74
 df1e 10 860 74
 df2e 4 858 74
 df32 10 860 74
-FUNC df6c f 0 static UnDecorator::doPtr64()
+FUNC df6c f 0 UnDecorator::doPtr64()
 df6c f 4949 73
-FUNC df80 f 0 static UnDecorator::doRestrictionSpec()
+FUNC df80 f 0 UnDecorator::doRestrictionSpec()
 df80 f 4975 73
-FUNC df94 12 0 static UnDecorator::doThisTypes()
+FUNC df94 12 0 UnDecorator::doThisTypes()
 df94 12 4959 73
-FUNC dfac f 0 static UnDecorator::doThrowTypes()
+FUNC dfac f 0 UnDecorator::doThrowTypes()
 dfac f 4961 73
-FUNC dfc0 c 0 static UnDecorator::doTypeOnly()
+FUNC dfc0 c 0 UnDecorator::doTypeOnly()
 dfc0 c 4968 73
-FUNC dfd0 c 0 static UnDecorator::doUnderScore()
+FUNC dfd0 c 0 UnDecorator::doUnderScore()
 dfd0 c 4947 73
-FUNC dfe0 12b 0 static UnDecorator::getArgumentList()
+FUNC dfe0 12b 0 UnDecorator::getArgumentList()
 dfe0 f 3544 73
 dfef 4 3546 73
 dff3 3 3544 73
@@ -2176,7 +2176,7 @@ e0cc c 3598 73
 e0d8 13 3549 73
 e0eb d 3605 73
 e0f8 13 3616 73
-FUNC e158 f3 0 static UnDecorator::getArgumentTypes()
+FUNC e158 f3 0 UnDecorator::getArgumentTypes()
 e158 6 3503 73
 e15e 1c 3504 73
 e17a a 3514 73
@@ -2189,7 +2189,7 @@ e1f4 d 3540 73
 e201 2b 3507 73
 e22c 11 3510 73
 e23d e 3540 73
-FUNC e288 253 0 static UnDecorator::getArrayType(DName const&)
+FUNC e288 253 0 UnDecorator::getArrayType(DName const&)
 e288 1e 4647 73
 e2a6 19 4648 73
 e2bf 5 4650 73
@@ -2216,7 +2216,7 @@ e431 1b 4685 73
 e44c 39 4686 73
 e485 20 4688 73
 e4a5 36 4690 73
-FUNC e570 c8 0 static UnDecorator::getBasedType()
+FUNC e570 c8 0 UnDecorator::getBasedType()
 e570 6 3057 73
 e576 6 3058 73
 e57c 3 3057 73
@@ -2232,7 +2232,7 @@ e600 f 3116 73
 e60f 11 3120 73
 e620 f 3124 73
 e62f 9 3126 73
-FUNC e66c 468 0 static UnDecorator::getBasicDataType(DName const&)
+FUNC e66c 468 0 UnDecorator::getBasicDataType(DName const&)
 e66c 1b 3725 73
 e687 19 3726 73
 e6a0 5 3731 73
@@ -2345,9 +2345,9 @@ ecb7 16 973 73
 eccd 16 974 73
 ece3 22 975 73
 ed05 8 979 73
-FUNC ed54 19 0 static UnDecorator::getCallIndex()
+FUNC ed54 19 0 UnDecorator::getCallIndex()
 ed54 19 4734 73
-FUNC ed74 13e 0 static UnDecorator::getCallingConvention()
+FUNC ed74 13e 0 UnDecorator::getCallingConvention()
 ed74 d 3229 73
 ed81 16 3230 73
 ed97 14 3232 73
@@ -2379,7 +2379,7 @@ ee66 23 3307 73
 ee89 d 3311 73
 ee96 e 3315 73
 eea4 e 3317 73
-FUNC ef04 7b8 0 static UnDecorator::getDataIndirectType(DName const&, char const*, DName const&, int)
+FUNC ef04 7b8 0 UnDecorator::getDataIndirectType(DName const&, char const*, DName const&, int)
 ef04 25 4321 73
 ef29 7 4327 73
 ef30 3 4324 73
@@ -2500,13 +2500,13 @@ f686 5 4570 73
 f68b 5 4571 73
 f690 e 4573 73
 f69e 1e 4575 73
-FUNC f8ac 3e 0 static UnDecorator::getDataIndirectType()
+FUNC f8ac 3e 0 UnDecorator::getDataIndirectType()
 f8ac 8 4698 73
 f8b4 1d 4701 73
 f8d1 3 4698 73
 f8d4 10 4701 73
 f8e4 6 4702 73
-FUNC f8fc e6 0 static UnDecorator::getDataType(DName*)
+FUNC f8fc e6 0 UnDecorator::getDataType(DName*)
 f8fc 10 3338 73
 f90c 9 3339 73
 f915 1b 3344 73
@@ -2520,7 +2520,7 @@ f97a 37 3364 73
 f9b1 5 3365 73
 f9b6 12 3347 73
 f9c8 1a 3375 73
-FUNC fa1c 2a8 0 static UnDecorator::getDecoratedName()
+FUNC fa1c 2a8 0 UnDecorator::getDecoratedName()
 fa1c 26 992 73
 fa42 6 1003 73
 fa48 c 1007 73
@@ -2568,7 +2568,7 @@ fc81 e 1121 73
 fc8f 8 1129 73
 fc97 a 1132 73
 fca1 23 1134 73
-FUNC fd70 179 0 static UnDecorator::getDimension(bool)
+FUNC fd70 179 0 UnDecorator::getDimension(bool)
 fd70 17 1871 73
 fd87 19 1873 73
 fda0 11 1876 73
@@ -2592,7 +2592,7 @@ fe8a 21 1910 73
 feab 17 1914 73
 fec2 e 1893 73
 fed0 19 1918 73
-FUNC ff48 4c 0 static UnDecorator::getDispatchTarget()
+FUNC ff48 4c 0 UnDecorator::getDispatchTarget()
 ff48 12 3703 73
 ff5a b 3707 73
 ff65 10 3709 73
@@ -2600,9 +2600,9 @@ ff75 5 3710 73
 ff7a e 3713 73
 ff88 8 3720 73
 ff90 4 3721 73
-FUNC ffa8 19 0 static UnDecorator::getDisplacement()
+FUNC ffa8 19 0 UnDecorator::getDisplacement()
 ffa8 19 4733 73
-FUNC ffc8 160 0 static UnDecorator::getECSUDataType()
+FUNC ffc8 160 0 UnDecorator::getECSUDataType()
 ffc8 17 3967 73
 ffdf d 3970 73
 ffec 3 3967 73
@@ -2628,9 +2628,9 @@ ffef 11 3970 73
 100f5 4 3977 73
 100f9 16 3979 73
 1010f 19 4027 73
-FUNC 10180 17 0 static UnDecorator::getECSUName()
+FUNC 10180 17 0 UnDecorator::getECSUName()
 10180 17 3162 73
-FUNC 1019c fc 0 static UnDecorator::getEnumType()
+FUNC 1019c fc 0 UnDecorator::getEnumType()
 1019c d 3166 73
 101a9 a 3170 73
 101b3 9 3167 73
@@ -2649,7 +2649,7 @@ FUNC 1019c fc 0 static UnDecorator::getEnumType()
 10271 c 3199 73
 1027d d 3222 73
 1028a e 3224 73
-FUNC 102d8 214 0 static UnDecorator::getExtendedDataIndirectType(char const*&, bool&, int)
+FUNC 102d8 214 0 UnDecorator::getExtendedDataIndirectType(char const*&, bool&, int)
 102d8 12 4236 73
 102ea a 4243 73
 102f4 5 4239 73
@@ -2690,7 +2690,7 @@ FUNC 102d8 214 0 static UnDecorator::getExtendedDataIndirectType(char const*&, b
 104c6 4 4254 73
 104ca b 4317 73
 104d5 17 4318 73
-FUNC 10574 c6 0 static UnDecorator::getExternalDataType(DName const&)
+FUNC 10574 c6 0 UnDecorator::getExternalDataType(DName const&)
 10574 12 4932 73
 10586 3 4935 73
 10589 6 4932 73
@@ -2701,7 +2701,7 @@ FUNC 10574 c6 0 static UnDecorator::getExternalDataType(DName const&)
 10622 c 4941 73
 1062e 3 4943 73
 10631 9 4945 73
-FUNC 1066c 556 0 static UnDecorator::getFunctionIndirectType(DName const&)
+FUNC 1066c 556 0 UnDecorator::getFunctionIndirectType(DName const&)
 1066c 26 4036 73
 10692 12 4037 73
 106a4 23 4179 73
@@ -2767,7 +2767,7 @@ FUNC 1066c 556 0 static UnDecorator::getFunctionIndirectType(DName const&)
 10b89 a 4174 73
 10b93 8 4097 73
 10b9b 27 4179 73
-FUNC 10d18 19 0 static UnDecorator::getGuardNumber()
+FUNC 10d18 19 0 UnDecorator::getGuardNumber()
 10d18 19 4735 73
 FUNC 10d38 19 0 DName::getLastChar() const
 10d38 8 512 74
@@ -2793,7 +2793,7 @@ FUNC 10da0 35 0 pairNode::getLastChar() const
 FUNC 10de4 14 0 pcharNode::getLastChar() const
 10de4 13 932 74
 10df7 1 933 74
-FUNC 10e00 71 0 static UnDecorator::getLexicalFrame()
+FUNC 10e00 71 0 UnDecorator::getLexicalFrame()
 10e00 71 4693 73
 FUNC 10e90 a9 0 _HeapManager::getMemory(unsigned long long, int)
 10e90 f 151 74
@@ -2812,14 +2812,14 @@ FUNC 10e90 a9 0 _HeapManager::getMemory(unsigned long long, int)
 10f13 12 202 74
 10f25 10 205 74
 10f35 4 194 74
-FUNC 10f64 45 0 static UnDecorator::getNoexcept()
+FUNC 10f64 45 0 UnDecorator::getNoexcept()
 10f64 6 3636 73
 10f6a 15 3637 73
 10f7f 4 3639 73
 10f83 15 3640 73
 10f98 8 3643 73
 10fa0 9 3644 73
-FUNC 10fbc 73 0 static UnDecorator::getNumberOfDimensions()
+FUNC 10fbc 73 0 UnDecorator::getNumberOfDimensions()
 10fbc d 1923 73
 10fc9 7 1925 73
 10fd0 10 1926 73
@@ -2838,7 +2838,7 @@ FUNC 10fbc 73 0 static UnDecorator::getNumberOfDimensions()
 1102b 1 1955 73
 1102c 2 1937 73
 1102e 1 1955 73
-FUNC 1104c 76d 0 static UnDecorator::getOperatorName(bool, bool*)
+FUNC 1104c 76d 0 UnDecorator::getOperatorName(bool, bool*)
 1104c 19 1267 73
 11065 7 1276 73
 1106c 3 1268 73
@@ -2942,15 +2942,15 @@ FUNC 1104c 76d 0 static UnDecorator::getOperatorName(bool, bool*)
 1179d 8 1645 73
 117a5 f 1646 73
 117b4 5 1647 73
-FUNC 11994 1e 0 static UnDecorator::getPointerType(DName const&, DName const&)
+FUNC 11994 1e 0 UnDecorator::getPointerType(DName const&, DName const&)
 11994 6 4712 73
 1199a 12 4715 73
 119ac 6 4716 73
-FUNC 119bc 1e 0 static UnDecorator::getPointerTypeArray(DName const&, DName const&)
+FUNC 119bc 1e 0 UnDecorator::getPointerTypeArray(DName const&, DName const&)
 119bc 6 4719 73
 119c2 12 4722 73
 119d4 6 4723 73
-FUNC 119e4 24d 0 static UnDecorator::getPrimaryDataType(DName const&)
+FUNC 119e4 24d 0 UnDecorator::getPrimaryDataType(DName const&)
 119e4 17 3380 73
 119fb 2 3381 73
 119fd 3 3380 73
@@ -2990,7 +2990,7 @@ FUNC 119e4 24d 0 static UnDecorator::getPrimaryDataType(DName const&)
 11bf9 1d 3432 73
 11c16 4 3427 73
 11c1a 17 3428 73
-FUNC 11cc4 162 0 static UnDecorator::getPtrRefDataType(DName const&, int)
+FUNC 11cc4 162 0 UnDecorator::getPtrRefDataType(DName const&, int)
 11cc4 12 4579 73
 11cd6 17 4581 73
 11ced 5 4584 73
@@ -3021,7 +3021,7 @@ FUNC 11cc4 162 0 static UnDecorator::getPtrRefDataType(DName const&, int)
 11dee 8 4637 73
 11df6 12 4641 73
 11e08 1e 4643 73
-FUNC 11e80 136 0 static UnDecorator::getPtrRefType(DName const&, DName const&, char const*)
+FUNC 11e80 136 0 UnDecorator::getPtrRefType(DName const&, DName const&, char const*)
 11e80 1b 4183 73
 11e9b 1f 4188 73
 11eba c 4189 73
@@ -3045,11 +3045,11 @@ FUNC 11e80 136 0 static UnDecorator::getPtrRefType(DName const&, DName const&, c
 11f81 c 4225 73
 11f8d d 4229 73
 11f9a 1c 4232 73
-FUNC 12004 17 0 static UnDecorator::getReferenceType(DName const&, DName const&, char const*)
+FUNC 12004 17 0 UnDecorator::getReferenceType(DName const&, DName const&, char const*)
 12004 9 4726 73
 1200d 8 4727 73
 12015 6 4728 73
-FUNC 12020 13d 0 static UnDecorator::getRestrictionSpec()
+FUNC 12020 13d 0 UnDecorator::getRestrictionSpec()
 12020 14 3648 73
 12034 2a 3649 73
 1205e 7 3652 73
@@ -3076,14 +3076,14 @@ FUNC 12020 13d 0 static UnDecorator::getRestrictionSpec()
 12133 c 3693 73
 1213f 6 3697 73
 12145 18 3699 73
-FUNC 121ac 34 0 static UnDecorator::getReturnType(DName*)
+FUNC 121ac 34 0 UnDecorator::getReturnType(DName*)
 121ac 6 3322 73
 121b2 f 3323 73
 121c1 a 3325 73
 121cb 7 3327 73
 121d2 5 3331 73
 121d7 9 3333 73
-FUNC 121f0 478 0 static UnDecorator::getScope()
+FUNC 121f0 478 0 UnDecorator::getScope()
 121f0 1d 1693 73
 1220d 3 1694 73
 12210 3 1693 73
@@ -3143,7 +3143,7 @@ FUNC 121f0 478 0 static UnDecorator::getScope()
 12611 2 1836 73
 12613 3a 1837 73
 1264d 1b 1853 73
-FUNC 12788 103 0 static UnDecorator::getScopedName()
+FUNC 12788 103 0 UnDecorator::getScopedName()
 12788 6 3131 73
 1278e 4 3132 73
 12792 3 3131 73
@@ -3164,7 +3164,7 @@ FUNC 12788 103 0 static UnDecorator::getScopedName()
 12846 3c 3153 73
 12882 3 3157 73
 12885 6 3159 73
-FUNC 128cc 94 0 static UnDecorator::getSignedDimension()
+FUNC 128cc 94 0 UnDecorator::getSignedDimension()
 128cc d 1857 73
 128d9 d 1858 73
 128e6 10 1859 73
@@ -3173,7 +3173,7 @@ FUNC 128cc 94 0 static UnDecorator::getSignedDimension()
 12906 44 1863 73
 1294a 8 1866 73
 12952 e 1867 73
-FUNC 12988 3e 0 static UnDecorator::getStorageConvention()
+FUNC 12988 3e 0 UnDecorator::getStorageConvention()
 12988 3e 4694 73
 FUNC 129d8 1a 0 DName::getString(char*, char*) const
 129d8 8 555 74
@@ -3221,7 +3221,7 @@ FUNC 12b5c 4b 0 pairNode::getString(char*, char*) const
 FUNC 12bbc 36 0 pcharNode::getString(char*, char*) const
 12bbc 35 972 74
 12bf1 1 973 74
-FUNC 12c00 d0 0 static UnDecorator::getStringEncoding(char const*, int)
+FUNC 12c00 d0 0 UnDecorator::getStringEncoding(char const*, int)
 12c00 9 1655 73
 12c09 a 1656 73
 12c13 2d 1659 73
@@ -3246,7 +3246,7 @@ FUNC 12d04 2d 0 getStringHelper(char*, char const*, char const*, int)
 12d0d 1d 212 74
 12d2a 6 213 74
 12d30 1 214 74
-FUNC 12d3c 4c 0 static UnDecorator::getSymbolName()
+FUNC 12d3c 4c 0 UnDecorator::getSymbolName()
 12d3c 6 1139 73
 12d42 f 1140 73
 12d51 8 1142 73
@@ -3254,7 +3254,7 @@ FUNC 12d3c 4c 0 static UnDecorator::getSymbolName()
 12d62 13 1150 73
 12d75 a 1155 73
 12d7f 9 1157 73
-FUNC 12d9c 31a 0 static UnDecorator::getTemplateArgumentList()
+FUNC 12d9c 31a 0 UnDecorator::getTemplateArgumentList()
 12d9c 2d 2039 73
 12dc9 3 2041 73
 12dcc 3 2040 73
@@ -3313,7 +3313,7 @@ FUNC 12d9c 31a 0 static UnDecorator::getTemplateArgumentList()
 13083 7 2192 73
 1308a 3 2194 73
 1308d 29 2196 73
-FUNC 1317c 3a0 0 static UnDecorator::getTemplateConstant()
+FUNC 1317c 3a0 0 UnDecorator::getTemplateConstant()
 1317c 29 2214 73
 131a5 18 2221 73
 131bd 3c 2222 73
@@ -3368,7 +3368,7 @@ FUNC 1317c 3a0 0 static UnDecorator::getTemplateConstant()
 134d9 31 2391 73
 1350a 9 2370 73
 13513 9 2367 73
-FUNC 13604 1fa 0 static UnDecorator::getTemplateName(bool)
+FUNC 13604 1fa 0 UnDecorator::getTemplateName(bool)
 13604 1f 1959 73
 13623 20 1963 73
 13643 7 1973 73
@@ -3403,17 +3403,17 @@ FUNC 13604 1fa 0 static UnDecorator::getTemplateName(bool)
 137cd 5 2033 73
 137d2 c 1964 73
 137de 20 2035 73
-FUNC 1387c 42 0 static UnDecorator::getThisType()
+FUNC 1387c 42 0 UnDecorator::getThisType()
 1387c 8 4705 73
 13884 29 4708 73
 138ad 3 4705 73
 138b0 8 4708 73
 138b8 6 4709 73
-FUNC 138d0 23 0 static UnDecorator::getThrowTypes()
+FUNC 138d0 23 0 UnDecorator::getThrowTypes()
 138d0 18 3629 73
 138e8 a 3630 73
 138f2 1 3633 73
-FUNC 138fc 35e 0 static UnDecorator::getTypeEncoding()
+FUNC 138fc 35e 0 UnDecorator::getTypeEncoding()
 138fc 17 2712 73
 13913 2 2713 73
 13915 6 2718 73
@@ -3532,7 +3532,7 @@ FUNC 13d34 109 0 UnDecorator::getUndecoratedName(char*, int)
 13e2d 2 907 73
 13e2f 3 912 73
 13e32 b 914 73
-FUNC 13e80 58 0 static UnDecorator::getVCallThunkType()
+FUNC 13e80 58 0 UnDecorator::getVCallThunkType()
 13e80 6 4744 73
 13e86 15 4746 73
 13e9b c 4754 73
@@ -3540,11 +3540,11 @@ FUNC 13e80 58 0 static UnDecorator::getVCallThunkType()
 13eaa 18 4750 73
 13ec2 d 4752 73
 13ecf 9 4858 73
-FUNC 13ef0 17 0 static UnDecorator::getVbTableType(DName const&)
+FUNC 13ef0 17 0 UnDecorator::getVbTableType(DName const&)
 13ef0 9 4738 73
 13ef9 8 4739 73
 13f01 6 4740 73
-FUNC 13f0c 5f 0 static UnDecorator::getVdispMapType(DName const&)
+FUNC 13f0c 5f 0 UnDecorator::getVdispMapType(DName const&)
 13f0c 6 4918 73
 13f12 3 4919 73
 13f15 3 4918 73
@@ -3558,7 +3558,7 @@ FUNC 13f0c 5f 0 static UnDecorator::getVdispMapType(DName const&)
 13f58 a 4925 73
 13f62 3 4926 73
 13f65 6 4927 73
-FUNC 13f84 1fd 0 static UnDecorator::getVfTableType(DName const&)
+FUNC 13f84 1fd 0 UnDecorator::getVfTableType(DName const&)
 13f84 15 4862 73
 13f99 3 4863 73
 13f9c 3 4862 73
@@ -3584,7 +3584,7 @@ FUNC 13f84 1fd 0 static UnDecorator::getVfTableType(DName const&)
 1413f 2 4909 73
 14141 28 4910 73
 14169 18 4914 73
-FUNC 14200 2d9 0 static UnDecorator::getZName(bool, bool)
+FUNC 14200 2d9 0 UnDecorator::getZName(bool, bool)
 14200 28 1161 73
 14228 18 1162 73
 14240 6 1167 73
@@ -3628,7 +3628,7 @@ FUNC 14200 2d9 0 static UnDecorator::getZName(bool, bool)
 1449c 9 1256 73
 144a5 d 1259 73
 144b2 27 1262 73
-FUNC 14590 c 0 static UnDecorator::haveTemplateParameters()
+FUNC 14590 c 0 UnDecorator::haveTemplateParameters()
 14590 c 4969 73
 FUNC 145a0 a 0 DName::isArray() const
 145a0 9 467 74
@@ -3686,13 +3686,13 @@ FUNC 146a4 53 0 pairNode::length() const
 FUNC 1470c 4 0 pcharNode::length() const
 1470c 3 927 74
 1470f 1 928 74
-FUNC 14710 1f 0 static DNameStatusNode::make(DNameStatus)
+FUNC 14710 1f 0 DNameStatusNode::make(DNameStatus)
 14710 5 1028 74
 14715 11 1029 74
 14726 1 1032 74
 14727 7 1031 74
 1472e 1 1032 74
-FUNC 14738 f5 0 static UnDecorator::parseDecoratedName()
+FUNC 14738 f5 0 UnDecorator::parseDecoratedName()
 14738 a 808 73
 14742 7 814 73
 14749 5 809 73
@@ -4174,7 +4174,7 @@ FUNC 16020 a8 0 __FrameHandler4::TryBlockMap::iterator::operator++()
 160bf 4 835 64
 160c3 4 836 64
 160c7 1 838 64
-FUNC 160f4 56 0 static __FrameHandler3::CatchTryBlock(_s_FuncInfo const*, int)
+FUNC 160f4 56 0 __FrameHandler3::CatchTryBlock(_s_FuncInfo const*, int)
 160f4 f 162 81
 16103 8 167 81
 1610b 1e 168 81
@@ -4205,27 +4205,27 @@ FUNC 1621c 9e 0 __FrameHandler4::TryBlockMap::DecompTryBlock()
 1627c 2b 913 64
 162a7 12 914 64
 162b9 1 915 64
-FUNC 162e4 2a 0 static __FrameHandler3::ExecutionInCatch(_xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 162e4 2a 0 __FrameHandler3::ExecutionInCatch(_xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 162e4 9 193 81
 162ed b 194 81
 162f8 10 195 81
 16308 6 196 81
-FUNC 16318 a 0 static __FrameHandler4::ExecutionInCatch(_xDISPATCHER_CONTEXT*, FuncInfo4*)
+FUNC 16318 a 0 __FrameHandler4::ExecutionInCatch(_xDISPATCHER_CONTEXT*, FuncInfo4*)
 16318 9 186 81
 16321 1 187 81
-FUNC 16324 64 0 static __FrameHandler3::FrameUnwindToEmptyState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 16324 64 0 __FrameHandler3::FrameUnwindToEmptyState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 16324 f 231 81
 16333 10 236 81
 16343 e 241 81
 16351 a 242 81
 1635b 1d 244 81
 16378 10 246 81
-FUNC 163a4 35 0 static __FrameHandler4::FrameUnwindToEmptyState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*)
+FUNC 163a4 35 0 __FrameHandler4::FrameUnwindToEmptyState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*)
 163a4 4 218 81
 163a8 1e 221 81
 163c6 e 223 81
 163d4 5 224 81
-FUNC 163e8 c9 0 static __FrameHandler3::GetEstablisherFrame(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, unsigned long long*)
+FUNC 163e8 c9 0 __FrameHandler3::GetEstablisherFrame(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, unsigned long long*)
 163e8 16 110 81
 163fe 7 114 81
 16405 11 118 81
@@ -4240,13 +4240,13 @@ FUNC 163e8 c9 0 static __FrameHandler3::GetEstablisherFrame(unsigned long long*,
 1647e 5 132 81
 16483 14 136 81
 16497 1a 153 81
-FUNC 164e4 24 0 static __FrameHandler4::GetEstablisherFrame(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*, unsigned long long*)
+FUNC 164e4 24 0 __FrameHandler4::GetEstablisherFrame(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*, unsigned long long*)
 164e4 9 77 81
 164ed 9 79 81
 164f6 e 84 81
 16504 3 97 81
 16507 1 98 81
-FUNC 16514 159 0 static __FrameHandler3::GetRangeOfTrysToCheck(__FrameHandler3::TryBlockMap&, int, int)
+FUNC 16514 159 0 __FrameHandler3::GetRangeOfTrysToCheck(__FrameHandler3::TryBlockMap&, int, int)
 16514 1e 483 81
 16532 3 485 81
 16535 3 483 81
@@ -4283,7 +4283,7 @@ FUNC 16514 159 0 static __FrameHandler3::GetRangeOfTrysToCheck(__FrameHandler3::
 16651 6 530 81
 16657 10 531 81
 16667 6 491 81
-FUNC 166c4 d3 0 static __FrameHandler4::GetRangeOfTrysToCheck(__FrameHandler4::TryBlockMap&, int, int)
+FUNC 166c4 d3 0 __FrameHandler4::GetRangeOfTrysToCheck(__FrameHandler4::TryBlockMap&, int, int)
 166c4 1e 456 81
 166e2 8 457 81
 166ea 3 456 81
@@ -4319,13 +4319,13 @@ FUNC 167dc 30 0 ReadUnsigned(unsigned char**)
 16800 8 198 64
 16808 3 199 64
 1680b 1 202 64
-FUNC 16818 121 0 static __FrameHandler3::UnwindNestedFrames(unsigned long long*, EHExceptionRecord*, _CONTEXT*, unsigned long long*, void*, _s_FuncInfo const*, int, int, _s_HandlerType const*, _xDISPATCHER_CONTEXT*, unsigned char)
+FUNC 16818 121 0 __FrameHandler3::UnwindNestedFrames(unsigned long long*, EHExceptionRecord*, _CONTEXT*, unsigned long long*, void*, _s_FuncInfo const*, int, int, _s_HandlerType const*, _xDISPATCHER_CONTEXT*, unsigned char)
 16818 29 674 81
 16841 69 705 81
 168aa 7 706 81
 168b1 70 738 81
 16921 18 744 81
-FUNC 16984 170 0 static __FrameHandler4::UnwindNestedFrames(unsigned long long*, EHExceptionRecord*, _CONTEXT*, unsigned long long*, void*, FuncInfo4*, int, int, HandlerType4*, _xDISPATCHER_CONTEXT*, unsigned char)
+FUNC 16984 170 0 __FrameHandler4::UnwindNestedFrames(unsigned long long*, EHExceptionRecord*, _CONTEXT*, unsigned long long*, void*, FuncInfo4*, int, int, HandlerType4*, _xDISPATCHER_CONTEXT*, unsigned char)
 16984 2d 582 81
 169b1 68 613 81
 16a19 c 614 81
@@ -4690,30 +4690,30 @@ FUNC 17030 435 0 memcpy()
 1745e 3 671 82
 17461 3 672 82
 17464 1 673 82
-FUNC 17580 27 0 static __FrameHandler3::GetCurrentState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 17580 27 0 __FrameHandler3::GetCurrentState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 17580 4 179 83
 17584 13 180 83
 17597 b 181 83
 175a2 5 186 83
-FUNC 175b0 29 0 static __FrameHandler3::GetUnwindTryBlock(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 175b0 29 0 __FrameHandler3::GetUnwindTryBlock(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 175b0 6 168 83
 175b6 10 170 83
 175c6 d 171 83
 175d3 6 172 83
-FUNC 175e4 c 0 static __FrameHandler3::SetState(unsigned long long*, _s_FuncInfo const*, int)
+FUNC 175e4 c 0 __FrameHandler3::SetState(unsigned long long*, _s_FuncInfo const*, int)
 175e4 b 194 83
 175ef 1 195 83
-FUNC 175f4 3b 0 static __FrameHandler3::SetUnwindTryBlock(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, int)
+FUNC 175f4 3b 0 __FrameHandler3::SetUnwindTryBlock(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, int)
 175f4 10 155 83
 17604 d 157 83
 17611 f 158 83
 17620 4 159 83
 17624 b 161 83
-FUNC 17640 8 0 static __FrameHandler3::StateFromControlPc(_s_FuncInfo const*, _xDISPATCHER_CONTEXT*)
+FUNC 17640 8 0 __FrameHandler3::StateFromControlPc(_s_FuncInfo const*, _xDISPATCHER_CONTEXT*)
 17640 8 136 83
-FUNC 1764c 8 0 static __FrameHandler4::StateFromControlPc(FuncInfo4*, _xDISPATCHER_CONTEXT*)
+FUNC 1764c 8 0 __FrameHandler4::StateFromControlPc(FuncInfo4*, _xDISPATCHER_CONTEXT*)
 1764c 8 146 83
-FUNC 17658 66 0 static __FrameHandler3::StateFromIp(_s_FuncInfo const*, _xDISPATCHER_CONTEXT*, unsigned long long)
+FUNC 17658 66 0 __FrameHandler3::StateFromIp(_s_FuncInfo const*, _xDISPATCHER_CONTEXT*, unsigned long long)
 17658 9 98 83
 17661 5 105 83
 17666 11 108 83
@@ -4725,7 +4725,7 @@ FUNC 17658 66 0 static __FrameHandler3::StateFromIp(_s_FuncInfo const*, _xDISPAT
 176ad 6 127 83
 176b3 5 120 83
 176b8 6 105 83
-FUNC 176d8 ed 0 static __FrameHandler4::StateFromIp(FuncInfo4*, _xDISPATCHER_CONTEXT*, unsigned long long)
+FUNC 176d8 ed 0 __FrameHandler4::StateFromIp(FuncInfo4*, _xDISPATCHER_CONTEXT*, unsigned long long)
 176d8 1c 60 83
 176f4 10 66 83
 17704 4 68 83
@@ -5209,15 +5209,15 @@ FUNC 19f6c c 0 UWMap::iterator::operator>=(UWMap::iterator const&) const
 19f77 1 283 64
 FUNC 19f7c 42 0 std::bad_exception::`scalar deleting destructor'(unsigned int)
 FUNC 19fd0 42 0 std::exception::`scalar deleting destructor'(unsigned int)
-FUNC 1a024 5 0 static __FrameHandler3::BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 1a024 5 0 __FrameHandler3::BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 1a024 5 2027 84
-FUNC 1a02c 5 0 static __FrameHandler4::BuildCatchObject(EHExceptionRecord*, void*, HandlerType4*, _s_CatchableType const*)
+FUNC 1a02c 5 0 __FrameHandler4::BuildCatchObject(EHExceptionRecord*, void*, HandlerType4*, _s_CatchableType const*)
 1a02c 5 2038 84
-FUNC 1a034 5 0 static __FrameHandler3::BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 1a034 5 0 __FrameHandler3::BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 1a034 5 1916 84
-FUNC 1a03c 5 0 static __FrameHandler4::BuildCatchObjectHelper(EHExceptionRecord*, void*, HandlerType4*, _s_CatchableType const*)
+FUNC 1a03c 5 0 __FrameHandler4::BuildCatchObjectHelper(EHExceptionRecord*, void*, HandlerType4*, _s_CatchableType const*)
 1a03c 5 1927 84
-FUNC 1a044 1ea 0 static __FrameHandler3::CxxCallCatchBlock(_EXCEPTION_RECORD*)
+FUNC 1a044 1ea 0 __FrameHandler3::CxxCallCatchBlock(_EXCEPTION_RECORD*)
 1a044 13 1489 84
 1a057 10 1490 84
 1a067 5 1492 84
@@ -5253,7 +5253,7 @@ FUNC 1a044 1ea 0 static __FrameHandler3::CxxCallCatchBlock(_EXCEPTION_RECORD*)
 1a207 14 1563 84
 1a21b 3 1565 84
 1a21e 10 1566 84
-FUNC 1a2a8 240 0 static __FrameHandler4::CxxCallCatchBlock(_EXCEPTION_RECORD*)
+FUNC 1a2a8 240 0 __FrameHandler4::CxxCallCatchBlock(_EXCEPTION_RECORD*)
 1a2a8 16 1382 84
 1a2be 10 1383 84
 1a2ce 5 1385 84
@@ -5334,7 +5334,7 @@ FUNC 1a710 87 0 ExFilterRethrow(_EXCEPTION_POINTERS*, EHExceptionRecord*, int*)
 1a782 d 1595 84
 1a78f 2 1597 84
 1a791 6 1598 84
-FUNC 1a7b8 193 0 static __FrameHandler3::FrameUnwindToState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, int)
+FUNC 1a7b8 193 0 __FrameHandler3::FrameUnwindToState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, int)
 1a7b8 2a 1167 84
 1a7e2 d 1173 84
 1a7ef 10 1176 84
@@ -5357,7 +5357,7 @@ FUNC 1a7b8 193 0 static __FrameHandler3::FrameUnwindToState(unsigned long long*,
 1a92f 10 1240 84
 1a93f 6 1185 84
 1a945 6 1230 84
-FUNC 1a9b0 2d9 0 static __FrameHandler4::FrameUnwindToState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*, int)
+FUNC 1a9b0 2d9 0 __FrameHandler4::FrameUnwindToState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*, int)
 1a9b0 41 1017 84
 1a9f1 a 1023 84
 1a9fb 3 1027 84
@@ -5399,7 +5399,7 @@ FUNC 1a9b0 2d9 0 static __FrameHandler4::FrameUnwindToState(unsigned long long*,
 1ac46 8 1142 84
 1ac4e 10 1149 84
 1ac5e 2b 1156 84
-FUNC 1ad40 96 0 static __FrameHandler3::GetHandlerSearchState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 1ad40 96 0 __FrameHandler3::GetHandlerSearchState(unsigned long long*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 1ad40 1a 444 84
 1ad5a b 446 84
 1ad65 15 448 84
@@ -5409,7 +5409,7 @@ FUNC 1ad40 96 0 static __FrameHandler3::GetHandlerSearchState(unsigned long long
 1adad 2 453 84
 1adaf 10 454 84
 1adbf 17 458 84
-FUNC 1adfc 37 0 static __FrameHandler4::GetHandlerSearchState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*)
+FUNC 1adfc 37 0 __FrameHandler4::GetHandlerSearchState(unsigned long long*, _xDISPATCHER_CONTEXT*, FuncInfo4*)
 1adfc 6 465 84
 1ae02 a 466 84
 1ae0c b 468 84
@@ -5417,10 +5417,10 @@ FUNC 1adfc 37 0 static __FrameHandler4::GetHandlerSearchState(unsigned long long
 1ae1f c 471 84
 1ae2b 2 474 84
 1ae2d 6 475 84
-FUNC 1ae40 4 0 static __FrameHandler3::GetMaxState(_xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
+FUNC 1ae40 4 0 __FrameHandler3::GetMaxState(_xDISPATCHER_CONTEXT*, _s_FuncInfo const*)
 1ae40 3 449 64
 1ae43 1 450 64
-FUNC 1ae44 38 0 static __FrameHandler4::GetMaxState(_xDISPATCHER_CONTEXT*, FuncInfo4*)
+FUNC 1ae44 38 0 __FrameHandler4::GetMaxState(_xDISPATCHER_CONTEXT*, FuncInfo4*)
 1ae44 6 731 64
 1ae4a 4 733 64
 1ae4e 7 734 64
@@ -5468,9 +5468,9 @@ FUNC 1b050 99 0 UWMap::ReadEntry()
 1b0af e 375 64
 1b0bd 2b 376 64
 1b0e8 1 382 64
-FUNC 1b110 5 0 static __FrameHandler3::TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
+FUNC 1b110 5 0 __FrameHandler3::TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
 1b110 5 977 84
-FUNC 1b118 5 0 static __FrameHandler4::TypeMatch(HandlerType4*, _s_CatchableType const*, _s_ThrowInfo const*)
+FUNC 1b118 5 0 __FrameHandler4::TypeMatch(HandlerType4*, _s_CatchableType const*, _s_ThrowInfo const*)
 1b118 5 987 84
 FUNC 1b120 2e 0 UWMap::WalkBack()
 1b120 a 385 64
@@ -5511,11 +5511,11 @@ FUNC 1b1e4 c 0 __FrameHandler3::HandlerMap::end()
 FUNC 1b1f4 c 0 __FrameHandler4::HandlerMap::end()
 1b1f4 b 984 64
 1b1ff 1 985 64
-FUNC 1b204 28 0 static __FrameHandler3::getESTypes(_s_FuncInfo const*)
+FUNC 1b204 28 0 __FrameHandler3::getESTypes(_s_FuncInfo const*)
 1b204 6 196 84
 1b20a 1c 197 84
 1b226 6 198 84
-FUNC 1b238 3 0 static __FrameHandler4::getESTypes(FuncInfo4*)
+FUNC 1b238 3 0 __FrameHandler4::getESTypes(FuncInfo4*)
 1b238 2 801 64
 1b23a 1 802 64
 FUNC 1b23c 13 0 __FrameHandler3::HandlerMap::getLastEntry()
@@ -5529,10 +5529,10 @@ FUNC 1b254 4e 0 __FrameHandler4::HandlerMap::getLastEntry()
 1b26e 25 1009 64
 1b293 4 1010 64
 1b297 b 1011 64
-FUNC 1b2b8 8 0 static __FrameHandler3::getMagicNum(_s_FuncInfo const*)
+FUNC 1b2b8 8 0 __FrameHandler3::getMagicNum(_s_FuncInfo const*)
 1b2b8 7 505 64
 1b2bf 1 506 64
-FUNC 1b2c4 6 0 static __FrameHandler4::getMagicNum(FuncInfo4*)
+FUNC 1b2c4 6 0 __FrameHandler4::getMagicNum(FuncInfo4*)
 1b2c4 5 795 64
 1b2c9 1 796 64
 FUNC 1b2cc 7 0 __FrameHandler3::TryBlockMap::getNumTryBlocks()
@@ -5577,16 +5577,16 @@ FUNC 1b3bc 86 0 UWMap::getStateIter(int)
 1b415 8 346 64
 1b41d 7 347 64
 1b424 1e 348 64
-FUNC 1b464 6 0 static __FrameHandler3::isEHs(_s_FuncInfo const*)
+FUNC 1b464 6 0 __FrameHandler3::isEHs(_s_FuncInfo const*)
 1b464 5 495 64
 1b469 1 496 64
-FUNC 1b46c 8 0 static __FrameHandler4::isEHs(FuncInfo4*)
+FUNC 1b46c 8 0 __FrameHandler4::isEHs(FuncInfo4*)
 1b46c 7 784 64
 1b473 1 785 64
-FUNC 1b478 9 0 static __FrameHandler3::isNoExcept(_s_FuncInfo const*)
+FUNC 1b478 9 0 __FrameHandler3::isNoExcept(_s_FuncInfo const*)
 1b478 8 500 64
 1b480 1 501 64
-FUNC 1b484 8 0 static __FrameHandler4::isNoExcept(FuncInfo4*)
+FUNC 1b484 8 0 __FrameHandler4::isNoExcept(FuncInfo4*)
 1b484 7 789 64
 1b48b 1 790 64
 FUNC 1b490 11 0 HandlerType4::reset()
@@ -5963,7 +5963,7 @@ FUNC 1c2a4 21 0 __crt_unique_handle_t<__crt_hmodule_traits>::close()
 1c2b5 6 1146 205
 1c2bb 4 1147 205
 1c2bf 6 1148 205
-FUNC 1c2d0 14 0 static __crt_hmodule_traits::close(HINSTANCE__*)
+FUNC 1c2d0 14 0 __crt_hmodule_traits::close(HINSTANCE__*)
 1c2d0 4 1061 205
 1c2d4 b 1062 205
 1c2df 5 1063 205
@@ -5989,7 +5989,7 @@ FUNC 1c434 4 0 __crt_unique_handle_t<__crt_hmodule_traits>::get() const
 FUNC 1c438 4 0 __crt_unique_handle_t<__crt_hmodule_traits>::get_address_of()
 1c438 3 1162 205
 1c43b 1 1163 205
-FUNC 1c43c 3 0 static __crt_hmodule_traits::get_invalid_value()
+FUNC 1c43c 3 0 __crt_hmodule_traits::get_invalid_value()
 1c43c 2 1067 205
 1c43e 1 1068 205
 FUNC 1c440 52 0 is_managed_app()
@@ -6106,9 +6106,9 @@ FUNC 1c810 171 0 common_configure_argv<wchar_t>(const _crt_argv_mode)
 1c94f e 390 325
 1c95d 13 391 325
 1c970 11 392 325
-FUNC 1c9e0 b 0 static __crt_char_traits<char>::get_module_file_name<std::nullptr_t,char (&)[261],int>(void*&&, char[261]&, int&&)
+FUNC 1c9e0 b 0 __crt_char_traits<char>::get_module_file_name<std::nullptr_t,char (&)[261],int>(void*&&, char[261]&, int&&)
 1c9e0 b 109 326
-FUNC 1c9f0 d 0 static __crt_char_traits<wchar_t>::get_module_file_name<std::nullptr_t,wchar_t (&)[261],int>(void*&&, wchar_t[261]&, int&&)
+FUNC 1c9f0 d 0 __crt_char_traits<wchar_t>::get_module_file_name<std::nullptr_t,wchar_t (&)[261],int>(void*&&, wchar_t[261]&, int&&)
 1c9f0 d 124 326
 FUNC 1ca00 1c3 0 parse_command_line<char>(char*, char**, char*, unsigned long long*, unsigned long long*)
 1ca00 1d 102 325
@@ -6240,9 +6240,9 @@ FUNC 1cc34 1a2 0 parse_command_line<wchar_t>(wchar_t*, wchar_t**, wchar_t*, unsi
 1cdb9 3 259 325
 1cdbc 3 261 325
 1cdbf 17 262 325
-FUNC 1ce40 b 0 static __crt_char_traits<char>::set_program_name<char *>(char*&&)
+FUNC 1ce40 b 0 __crt_char_traits<char>::set_program_name<char *>(char*&&)
 1ce40 b 109 326
-FUNC 1ce50 b 0 static __crt_char_traits<wchar_t>::set_program_name<wchar_t *>(wchar_t*&&)
+FUNC 1ce50 b 0 __crt_char_traits<wchar_t>::set_program_name<wchar_t *>(wchar_t*&&)
 1ce50 b 124 326
 FUNC 1ce60 7 0 <lambda_a36aafc41185bea294aaaa3896c79ecc>::<lambda_a36aafc41185bea294aaaa3896c79ecc>(__crt_unique_heap_ptr<wchar_t *,__crt_internal_free_policy>&)
 1ce60 7 388 325
@@ -6501,9 +6501,9 @@ FUNC 1dab0 41 0 free_environment<wchar_t>(wchar_t** const)
 1dad9 5 95 333
 1dade 8 98 333
 1dae6 b 99 333
-FUNC 1db04 5 0 static __crt_char_traits<char>::get_environment_from_os<>()
+FUNC 1db04 5 0 __crt_char_traits<char>::get_environment_from_os<>()
 1db04 5 109 326
-FUNC 1db0c 5 0 static __crt_char_traits<wchar_t>::get_environment_from_os<>()
+FUNC 1db0c 5 0 __crt_char_traits<wchar_t>::get_environment_from_os<>()
 1db0c 5 124 326
 FUNC 1db14 d1 0 initialize_environment_by_cloning_nolock<char>()
 1db14 f 242 333
@@ -6537,17 +6537,17 @@ FUNC 1dc1c b1 0 initialize_environment_by_cloning_nolock<wchar_t>()
 1dcaf c 250 333
 1dcbb 5 268 333
 1dcc0 d 262 333
-FUNC 1dcfc a 0 static __crt_char_traits<char>::set_variable_in_environment_nolock<char *,int>(char*&&, int&&)
+FUNC 1dcfc a 0 __crt_char_traits<char>::set_variable_in_environment_nolock<char *,int>(char*&&, int&&)
 1dcfc a 109 326
-FUNC 1dd08 a 0 static __crt_char_traits<wchar_t>::set_variable_in_environment_nolock<wchar_t *,int>(wchar_t*&&, int&&)
+FUNC 1dd08 a 0 __crt_char_traits<wchar_t>::set_variable_in_environment_nolock<wchar_t *,int>(wchar_t*&&, int&&)
 1dd08 a 124 326
-FUNC 1dd14 e 0 static __crt_char_traits<char>::tcscpy_s<char *,unsigned __int64 const &,char * &>(char*&&, unsigned long long const&, char*&)
+FUNC 1dd14 e 0 __crt_char_traits<char>::tcscpy_s<char *,unsigned __int64 const &,char * &>(char*&&, unsigned long long const&, char*&)
 1dd14 e 109 326
-FUNC 1dd28 e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t *,unsigned __int64 const &,wchar_t * &>(wchar_t*&&, unsigned long long const&, wchar_t*&)
+FUNC 1dd28 e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t *,unsigned __int64 const &,wchar_t * &>(wchar_t*&&, unsigned long long const&, wchar_t*&)
 1dd28 e 124 326
-FUNC 1dd3c 11 0 static __crt_char_traits<char>::tcslen<char * &>(char*&)
+FUNC 1dd3c 11 0 __crt_char_traits<char>::tcslen<char * &>(char*&)
 1dd3c 11 109 326
-FUNC 1dd54 12 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t * &>(wchar_t*&)
+FUNC 1dd54 12 0 __crt_char_traits<wchar_t>::tcslen<wchar_t * &>(wchar_t*&)
 1dd54 12 124 326
 FUNC 1dd6c 43 0 __crt_state_management::dual_state_global<char * *>::uninitialize<void (__cdecl&)(char * * &)>(void (&)(char**&))
 1dd6c f 177 184
@@ -8217,84 +8217,84 @@ FUNC 24874 13 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::st
 24874 d 1007 357
 24881 5 1009 357
 24886 1 1010 357
-FUNC 2488c 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<char>(char*)
+FUNC 2488c 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<char>(char*)
 2488c 6 1452 357
-FUNC 24894 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<char>(char*)
+FUNC 24894 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<char>(char*)
 24894 6 1452 357
-FUNC 2489c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
+FUNC 2489c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
 2489c 6 1452 357
-FUNC 248a4 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
+FUNC 248a4 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<char>(char*)
 248a4 6 1452 357
-FUNC 248ac 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
+FUNC 248ac 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
 248ac 6 1452 357
-FUNC 248b4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
+FUNC 248b4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<`__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::type_case_Z::__l2::ansi_string*)
 248b4 6 1452 357
-FUNC 248bc 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
+FUNC 248bc 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
 248bc 6 1452 357
-FUNC 248c4 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
+FUNC 248c4 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<`__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z'::`2'::ansi_string>(__crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::type_case_Z::__l2::ansi_string*)
 248c4 6 1452 357
-FUNC 248cc 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<void>(void*)
+FUNC 248cc 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type<void>(void*)
 248cc 6 1452 357
-FUNC 248d4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<void>(void*)
+FUNC 248d4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type<void>(void*)
 248d4 6 1452 357
-FUNC 248dc 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
+FUNC 248dc 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
 248dc 6 1452 357
-FUNC 248e4 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
+FUNC 248e4 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type<void>(void*)
 248e4 6 1452 357
-FUNC 248ec a 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_character_specifier<char>(const char)
+FUNC 248ec a 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_character_specifier<char>(const char)
 248ec 9 1567 357
 248f5 1 1568 357
-FUNC 248f8 a 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_character_specifier<char>(const char)
+FUNC 248f8 a 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_character_specifier<char>(const char)
 248f8 9 1567 357
 24901 1 1568 357
-FUNC 24904 10 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
+FUNC 24904 10 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
 24904 f 1567 357
 24913 1 1568 357
-FUNC 24918 10 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
+FUNC 24918 10 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_character_specifier<wchar_t>(const wchar_t)
 24918 f 1567 357
 24927 1 1568 357
-FUNC 2492c 26 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_integral_specifier<char>(const char)
+FUNC 2492c 26 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_integral_specifier<char>(const char)
 2492c 22 1573 357
 2494e 1 1576 357
 2494f 2 1573 357
 24951 1 1576 357
-FUNC 2495c 26 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_integral_specifier<char>(const char)
+FUNC 2495c 26 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_integral_specifier<char>(const char)
 2495c 22 1573 357
 2497e 1 1576 357
 2497f 2 1573 357
 24981 1 1576 357
-FUNC 2498c 28 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
+FUNC 2498c 28 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
 2498c 24 1573 357
 249b0 1 1576 357
 249b1 2 1573 357
 249b3 1 1576 357
-FUNC 249c0 28 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
+FUNC 249c0 28 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_integral_specifier<wchar_t>(const wchar_t)
 249c0 24 1573 357
 249e4 1 1576 357
 249e5 2 1573 357
 249e7 1 1576 357
-FUNC 249f4 7 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_pointer_specifier<char>(const char)
+FUNC 249f4 7 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_pointer_specifier<char>(const char)
 249f4 6 1555 357
 249fa 1 1556 357
-FUNC 249fc 7 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_pointer_specifier<char>(const char)
+FUNC 249fc 7 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_pointer_specifier<char>(const char)
 249fc 6 1555 357
 24a02 1 1556 357
-FUNC 24a04 8 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
+FUNC 24a04 8 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
 24a04 7 1555 357
 24a0b 1 1556 357
-FUNC 24a10 8 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
+FUNC 24a10 8 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_pointer_specifier<wchar_t>(const wchar_t)
 24a10 7 1555 357
 24a17 1 1556 357
-FUNC 24a1c a 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_string_specifier<char>(const char)
+FUNC 24a1c a 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::is_string_specifier<char>(const char)
 24a1c 9 1561 357
 24a25 1 1562 357
-FUNC 24a28 a 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_string_specifier<char>(const char)
+FUNC 24a28 a 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::is_string_specifier<char>(const char)
 24a28 9 1561 357
 24a31 1 1562 357
-FUNC 24a34 10 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
+FUNC 24a34 10 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
 24a34 f 1561 357
 24a43 1 1562 357
-FUNC 24a48 10 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
+FUNC 24a48 10 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::is_string_specifier<wchar_t>(const wchar_t)
 24a48 f 1561 357
 24a57 1 1562 357
 FUNC 24a5c 28 0 __crt_stdio_output::is_wide_character_specifier<char>(const unsigned long long, const char, const __crt_stdio_output::length_modifier)
@@ -8364,9 +8364,9 @@ FUNC 24b18 4 0 __crt_stdio_output::peek_va_arg<unsigned __int64>(char*)
 FUNC 24b1c 4 0 __crt_stdio_output::peek_va_arg<wchar_t>(char*)
 24b1c 3 40 357
 24b1f 1 41 357
-FUNC 24b20 b 0 static __crt_char_traits<char>::puttc_nolock<char const &,_iobuf *>(char const&, _iobuf*&&)
+FUNC 24b20 b 0 __crt_char_traits<char>::puttc_nolock<char const &,_iobuf *>(char const&, _iobuf*&&)
 24b20 b 109 326
-FUNC 24b30 b 0 static __crt_char_traits<wchar_t>::puttc_nolock<wchar_t const &,_iobuf *>(wchar_t const&, _iobuf*&&)
+FUNC 24b30 b 0 __crt_char_traits<wchar_t>::puttc_nolock<wchar_t const &,_iobuf *>(wchar_t const&, _iobuf*&&)
 24b30 b 124 326
 FUNC 24b40 b 0 __crt_stdio_output::read_va_arg<signed char>(char*&)
 24b40 a 34 357
@@ -8451,13 +8451,13 @@ FUNC 24ce4 22 0 __crt_stdio_output::formatting_buffer::scratch_data<char>()
 24cf7 1 392 357
 24cf8 d 391 357
 24d05 1 392 357
-FUNC 24d10 e 0 static __crt_char_traits<char>::tcstol<char const * &,char * *,int>(char const*&, char**&&, int&&)
+FUNC 24d10 e 0 __crt_char_traits<char>::tcstol<char const * &,char * *,int>(char const*&, char**&&, int&&)
 24d10 e 109 326
-FUNC 24d24 e 0 static __crt_char_traits<wchar_t>::tcstol<wchar_t const * &,wchar_t * *,int>(wchar_t const*&, wchar_t**&&, int&&)
+FUNC 24d24 e 0 __crt_char_traits<wchar_t>::tcstol<wchar_t const * &,wchar_t * *,int>(wchar_t const*&, wchar_t**&&, int&&)
 24d24 e 124 326
-FUNC 24d38 e 0 static __crt_char_traits<char>::tcstol<char const *,char * *,int>(char const*&&, char**&&, int&&)
+FUNC 24d38 e 0 __crt_char_traits<char>::tcstol<char const *,char * *,int>(char const*&&, char**&&, int&&)
 24d38 e 109 326
-FUNC 24d4c e 0 static __crt_char_traits<wchar_t>::tcstol<wchar_t const *,wchar_t * *,int>(wchar_t const*&&, wchar_t**&&, int&&)
+FUNC 24d4c e 0 __crt_char_traits<wchar_t>::tcstol<wchar_t const *,wchar_t * *,int>(wchar_t const*&&, wchar_t**&&, int&&)
 24d4c e 124 326
 FUNC 24d60 87 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::type_case_integer_parse_into_buffer<unsigned int>(unsigned int, const unsigned int, const bool)
 24d60 5 2584 357
@@ -9164,40 +9164,40 @@ FUNC 27db0 8 0 <lambda_fe5404e9642edbb7c8ae71e1dcfa4018>::operator()() const
 FUNC 27dbc 5 0 _LocaleUpdate::GetLocaleT()
 27dbc 4 1844 205
 27dc0 1 1845 205
-FUNC 27dc4 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 27dc4 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 27dc4 b 2730 357
 27dcf 1 2734 357
-FUNC 27dd4 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 27dd4 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 27dd4 b 2730 357
 27ddf 1 2734 357
-FUNC 27de4 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 27de4 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::adjust_hexit(const int, const bool)
 27de4 b 2730 357
 27def 1 2734 357
-FUNC 27df4 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 27df4 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 27df4 b 2730 357
 27dff 1 2734 357
-FUNC 27e04 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 27e04 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 27e04 b 2730 357
 27e0f 1 2734 357
-FUNC 27e14 c 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
+FUNC 27e14 c 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::adjust_hexit(const int, const bool)
 27e14 b 2730 357
 27e1f 1 2734 357
-FUNC 27e24 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 27e24 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 27e24 b 2730 357
 27e2f 1 2734 357
-FUNC 27e34 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 27e34 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 27e34 b 2730 357
 27e3f 1 2734 357
-FUNC 27e44 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 27e44 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 27e44 b 2730 357
 27e4f 1 2734 357
-FUNC 27e54 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 27e54 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 27e54 b 2730 357
 27e5f 1 2734 357
-FUNC 27e64 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 27e64 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 27e64 b 2730 357
 27e6f 1 2734 357
-FUNC 27e74 c 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
+FUNC 27e74 c 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::adjust_hexit(const int, const bool)
 27e74 b 2730 357
 27e7f 1 2734 357
 FUNC 27e84 50 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::advance_to_next_pass()
@@ -9343,69 +9343,69 @@ FUNC 2846c 1f 0 __crt_deferred_errno_cache::get()
 FUNC 28494 7 0 __crt_stdio_stream::get_flags() const
 28494 6 233 341
 2849a 1 234 341
-FUNC 2849c 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(short)
+FUNC 2849c 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(short)
 2849c 6 1453 357
-FUNC 284a4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned short)
+FUNC 284a4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned short)
 284a4 6 1454 357
-FUNC 284ac 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(int)
+FUNC 284ac 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(int)
 284ac 6 1456 357
-FUNC 284b4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned int)
+FUNC 284b4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned int)
 284b4 6 1457 357
-FUNC 284bc 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 284bc 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
 284bc 6 1460 357
-FUNC 284c4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(long long)
+FUNC 284c4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(long long)
 284c4 6 1458 357
-FUNC 284cc 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned long long)
+FUNC 284cc 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(unsigned long long)
 284cc 6 1459 357
-FUNC 284d4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(wchar_t)
+FUNC 284d4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> >::get_parameter_type(wchar_t)
 284d4 6 1455 357
-FUNC 284dc 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(short)
+FUNC 284dc 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(short)
 284dc 6 1453 357
-FUNC 284e4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned short)
+FUNC 284e4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned short)
 284e4 6 1454 357
-FUNC 284ec 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(int)
+FUNC 284ec 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(int)
 284ec 6 1456 357
-FUNC 284f4 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned int)
+FUNC 284f4 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned int)
 284f4 6 1457 357
-FUNC 284fc 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 284fc 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(_CRT_DOUBLE)
 284fc 6 1460 357
-FUNC 28504 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(long long)
+FUNC 28504 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(long long)
 28504 6 1458 357
-FUNC 2850c 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned long long)
+FUNC 2850c 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(unsigned long long)
 2850c 6 1459 357
-FUNC 28514 6 0 static __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(wchar_t)
+FUNC 28514 6 0 __crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> >::get_parameter_type(wchar_t)
 28514 6 1455 357
-FUNC 2851c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(short)
+FUNC 2851c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(short)
 2851c 6 1453 357
-FUNC 28524 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
+FUNC 28524 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
 28524 6 1454 357
-FUNC 2852c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(int)
+FUNC 2852c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(int)
 2852c 6 1456 357
-FUNC 28534 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
+FUNC 28534 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
 28534 6 1457 357
-FUNC 2853c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 2853c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
 2853c 6 1460 357
-FUNC 28544 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(long long)
+FUNC 28544 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(long long)
 28544 6 1458 357
-FUNC 2854c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
+FUNC 2854c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
 2854c 6 1459 357
-FUNC 28554 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
+FUNC 28554 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
 28554 6 1455 357
-FUNC 2855c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(short)
+FUNC 2855c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(short)
 2855c 6 1453 357
-FUNC 28564 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
+FUNC 28564 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned short)
 28564 6 1454 357
-FUNC 2856c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(int)
+FUNC 2856c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(int)
 2856c 6 1456 357
-FUNC 28574 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
+FUNC 28574 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned int)
 28574 6 1457 357
-FUNC 2857c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
+FUNC 2857c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(_CRT_DOUBLE)
 2857c 6 1460 357
-FUNC 28584 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(long long)
+FUNC 28584 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(long long)
 28584 6 1458 357
-FUNC 2858c 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
+FUNC 2858c 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(unsigned long long)
 2858c 6 1459 357
-FUNC 28594 6 0 static __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
+FUNC 28594 6 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::get_parameter_type(wchar_t)
 28594 6 1455 357
 FUNC 2859c 7 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::has_flag(const unsigned int) const
 2859c 7 2707 357
@@ -9569,29 +9569,29 @@ FUNC 28df4 200 0 __crt_stdio_output::positional_parameter_base<wchar_t,__crt_std
 28fe4 10 1527 357
 FUNC 29074 c 0 __crt_stdio_stream::is_string_backed() const
 29074 c 227 341
-FUNC 29084 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 29084 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 29084 8 2737 357
-FUNC 29090 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 29090 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 29090 8 2737 357
-FUNC 2909c 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
+FUNC 2909c 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::narrow_null_string()
 2909c 8 2737 357
-FUNC 290a8 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 290a8 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 290a8 8 2737 357
-FUNC 290b4 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 290b4 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 290b4 8 2737 357
-FUNC 290c0 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
+FUNC 290c0 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::narrow_null_string()
 290c0 8 2737 357
-FUNC 290cc 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 290cc 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 290cc 8 2737 357
-FUNC 290d8 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 290d8 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 290d8 8 2737 357
-FUNC 290e4 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 290e4 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::narrow_null_string()
 290e4 8 2737 357
-FUNC 290f0 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 290f0 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 290f0 8 2737 357
-FUNC 290fc 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 290fc 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 290fc 8 2737 357
-FUNC 29108 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
+FUNC 29108 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::narrow_null_string()
 29108 8 2737 357
 FUNC 29114 a1 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::parse_int_from_format_string(int* const)
 29114 12 1775 357
@@ -12030,52 +12030,52 @@ FUNC 31ca0 32 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output:
 31cca 5 1814 357
 31ccf 2 1817 357
 31cd1 1 1818 357
-FUNC 31ce0 6 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
+FUNC 31ce0 6 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
 31ce0 5 1103 357
 31ce5 1 1104 357
-FUNC 31ce8 6 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
+FUNC 31ce8 6 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
 31ce8 5 1103 357
 31ced 1 1104 357
-FUNC 31cf0 6 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
+FUNC 31cf0 6 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
 31cf0 5 1103 357
 31cf5 1 1104 357
-FUNC 31cf8 6 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
+FUNC 31cf8 6 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
 31cf8 5 1103 357
 31cfd 1 1104 357
-FUNC 31d00 6 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
+FUNC 31d00 6 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_count()
 31d00 5 1046 357
 31d05 1 1047 357
-FUNC 31d08 6 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
+FUNC 31d08 6 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_count()
 31d08 5 1046 357
 31d0d 1 1047 357
-FUNC 31d10 6 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
+FUNC 31d10 6 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_count()
 31d10 5 1046 357
 31d15 1 1047 357
-FUNC 31d18 6 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
+FUNC 31d18 6 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_count()
 31d18 5 1046 357
 31d1d 1 1047 357
-FUNC 31d20 8 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
+FUNC 31d20 8 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
 31d20 7 1108 357
 31d27 1 1109 357
-FUNC 31d2c 8 0 static __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
+FUNC 31d2c 8 0 __crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
 31d2c 7 1108 357
 31d33 1 1109 357
-FUNC 31d38 8 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
+FUNC 31d38 8 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
 31d38 7 1108 357
 31d3f 1 1109 357
-FUNC 31d44 8 0 static __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
+FUNC 31d44 8 0 __crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
 31d44 7 1108 357
 31d4b 1 1109 357
-FUNC 31d50 8 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
+FUNC 31d50 8 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> >::state_transition_table()
 31d50 7 1051 357
 31d57 1 1052 357
-FUNC 31d5c 8 0 static __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
+FUNC 31d5c 8 0 __crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> >::state_transition_table()
 31d5c 7 1051 357
 31d63 1 1052 357
-FUNC 31d68 8 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
+FUNC 31d68 8 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> >::state_transition_table()
 31d68 7 1051 357
 31d6f 1 1052 357
-FUNC 31d74 8 0 static __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
+FUNC 31d74 8 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::state_transition_table()
 31d74 7 1051 357
 31d7b 1 1052 357
 FUNC 31d80 5 0 __crt_stdio_output::common_data<char>::tchar_string(char)
@@ -14479,37 +14479,37 @@ FUNC 3aee4 3 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::str
 FUNC 3aee8 3 0 __crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> >::validate_state_for_type_case_a() const
 3aee8 2 1026 357
 3aeea 1 1027 357
-FUNC 3aeec 9a 0 static __acrt_stdio_char_traits<char>::validate_stream_is_ansi_if_required(_iobuf* const)
+FUNC 3aeec 9a 0 __acrt_stdio_char_traits<char>::validate_stream_is_ansi_if_required(_iobuf* const)
 3aeec 4 439 341
 3aef0 8f 440 341
 3af7f 2 441 341
 3af81 5 442 341
-FUNC 3afac 3 0 static __acrt_stdio_char_traits<wchar_t>::validate_stream_is_ansi_if_required(_iobuf* const)
+FUNC 3afac 3 0 __acrt_stdio_char_traits<wchar_t>::validate_stream_is_ansi_if_required(_iobuf* const)
 3afac 2 454 341
 3afae 1 455 341
-FUNC 3afb0 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 3afb0 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 3afb0 8 2738 357
-FUNC 3afbc 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 3afbc 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 3afbc 8 2738 357
-FUNC 3afc8 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
+FUNC 3afc8 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::stream_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::stream_output_adapter<char> > >::wide_null_string()
 3afc8 8 2738 357
-FUNC 3afd4 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 3afd4 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::format_validation_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 3afd4 8 2738 357
-FUNC 3afe0 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 3afe0 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::positional_parameter_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 3afe0 8 2738 357
-FUNC 3afec 8 0 static __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
+FUNC 3afec 8 0 __crt_stdio_output::output_processor<char,__crt_stdio_output::string_output_adapter<char>,__crt_stdio_output::standard_base<char,__crt_stdio_output::string_output_adapter<char> > >::wide_null_string()
 3afec 8 2738 357
-FUNC 3aff8 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3aff8 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 3aff8 8 2738 357
-FUNC 3b004 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3b004 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 3b004 8 2738 357
-FUNC 3b010 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3b010 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::stream_output_adapter<wchar_t> > >::wide_null_string()
 3b010 8 2738 357
-FUNC 3b01c 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3b01c 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::format_validation_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 3b01c 8 2738 357
-FUNC 3b028 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3b028 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::positional_parameter_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 3b028 8 2738 357
-FUNC 3b034 8 0 static __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
+FUNC 3b034 8 0 __crt_stdio_output::output_processor<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t>,__crt_stdio_output::standard_base<wchar_t,__crt_stdio_output::string_output_adapter<wchar_t> > >::wide_null_string()
 3b034 8 2738 357
 FUNC 3b040 48 0 __crt_stdio_output::output_adapter_common<char,__crt_stdio_output::stream_output_adapter<char> >::write_character(const char, int* const) const
 3b040 6 60 357
@@ -15801,24 +15801,24 @@ FUNC 40748 38 0 get_win_policy<`__acrt_get_process_end_policy'::`2'::process_end
 40766 a 23 373
 40770 a 26 373
 4077a 6 27 373
-FUNC 40790 5 0 static `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_get_policy(AppPolicyThreadInitializationType*)
+FUNC 40790 5 0 `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_get_policy(AppPolicyThreadInitializationType*)
 40790 5 111 373
-FUNC 40798 5 0 static `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_get_policy(AppPolicyShowDeveloperDiagnostic*)
+FUNC 40798 5 0 `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_get_policy(AppPolicyShowDeveloperDiagnostic*)
 40798 5 142 373
-FUNC 407a0 5 0 static `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_get_policy(AppPolicyProcessTerminationMethod*)
+FUNC 407a0 5 0 `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_get_policy(AppPolicyProcessTerminationMethod*)
 407a0 5 80 373
-FUNC 407a8 5 0 static `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_get_policy(AppPolicyWindowingModel*)
+FUNC 407a8 5 0 `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_get_policy(AppPolicyWindowingModel*)
 407a8 5 180 373
-FUNC 407b0 b 0 static `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 407b0 b 0 `__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties::appmodel_policy_to_policy_type(const long)
 407b0 a 99 373
 407ba 1 107 373
-FUNC 407c0 b 0 static `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 407c0 b 0 `__acrt_get_developer_information_policy'::`2'::developer_information_policy_properties::appmodel_policy_to_policy_type(const long)
 407c0 a 130 373
 407ca 1 138 373
-FUNC 407d0 9 0 static `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_policy_to_policy_type(const AppPolicyProcessTerminationMethod)
+FUNC 407d0 9 0 `__acrt_get_process_end_policy'::`2'::process_end_policy_properties::appmodel_policy_to_policy_type(const AppPolicyProcessTerminationMethod)
 407d0 8 68 373
 407d8 1 76 373
-FUNC 407dc 27 0 static `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_policy_to_policy_type(const long)
+FUNC 407dc 27 0 `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy_properties::appmodel_policy_to_policy_type(const long)
 407dc f 161 373
 407eb 5 174 373
 407f0 1 176 373
@@ -15911,9 +15911,9 @@ FUNC 40be4 75 0 calloc_base(unsigned long long, unsigned long long)
 40c15 15 45 375
 40c2a 1c 38 375
 40c46 13 53 375
-FUNC 40c78 12 0 static <lambda_861af8918f661c876f88da8747958ced>::<lambda_invoker_cdecl>(void const*, void const*)
+FUNC 40c78 12 0 <lambda_861af8918f661c876f88da8747958ced>::<lambda_invoker_cdecl>(void const*, void const*)
 40c78 12 301 379
-FUNC 40c90 12 0 static <lambda_a1ce4c8ae42411fd470c77163914f50e>::<lambda_invoker_cdecl>(void const*, void const*)
+FUNC 40c90 12 0 <lambda_a1ce4c8ae42411fd470c77163914f50e>::<lambda_invoker_cdecl>(void const*, void const*)
 40c90 12 301 379
 FUNC 40ca8 179 0 __acrt_convert_wcs_mbs_cp<char,wchar_t,<lambda_7c9dea7b4ca7285d2cdb541a38da6275>,__crt_win32_buffer_internal_dynamic_resizing>(char const* const, __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>&, __acrt_mbs_to_wcs_cp::__l2::<lambda_7c9dea7b4ca7285d2cdb541a38da6275> const&, const unsigned int)
 40ca8 19 494 327
@@ -16170,25 +16170,25 @@ FUNC 42320 19b 0 expand_argument_wildcards<wchar_t>(wchar_t* const, wchar_t* con
 4246c 19 292 379
 42485 f 303 379
 42494 27 304 379
-FUNC 42524 11 0 static __crt_char_traits<char>::tcslen<char const * const &>(char const* const&)
+FUNC 42524 11 0 __crt_char_traits<char>::tcslen<char const * const &>(char const* const&)
 42524 11 109 326
-FUNC 4253c 12 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t const * const &>(wchar_t const* const&)
+FUNC 4253c 12 0 __crt_char_traits<wchar_t>::tcslen<wchar_t const * const &>(wchar_t const* const&)
 4253c 12 124 326
-FUNC 42554 11 0 static __crt_char_traits<char>::tcsncpy_s<char * &,unsigned __int64,char * &,unsigned __int64 const &>(char*&, unsigned long long&&, char*&, unsigned long long const&)
+FUNC 42554 11 0 __crt_char_traits<char>::tcsncpy_s<char * &,unsigned __int64,char * &,unsigned __int64 const &>(char*&, unsigned long long&&, char*&, unsigned long long const&)
 42554 11 109 326
-FUNC 4256c 11 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t * &,unsigned __int64,wchar_t * &,unsigned __int64 const &>(wchar_t*&, unsigned long long&&, wchar_t*&, unsigned long long const&)
+FUNC 4256c 11 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t * &,unsigned __int64,wchar_t * &,unsigned __int64 const &>(wchar_t*&, unsigned long long&&, wchar_t*&, unsigned long long const&)
 4256c 11 124 326
-FUNC 42584 11 0 static __crt_char_traits<char>::tcsncpy_s<char *,unsigned __int64 const &,char const * const &,unsigned __int64 const &>(char*&&, unsigned long long const&, char const* const&, unsigned long long const&)
+FUNC 42584 11 0 __crt_char_traits<char>::tcsncpy_s<char *,unsigned __int64 const &,char const * const &,unsigned __int64 const &>(char*&&, unsigned long long const&, char const* const&, unsigned long long const&)
 42584 11 109 326
-FUNC 4259c 11 0 static __crt_char_traits<char>::tcsncpy_s<char *,unsigned __int64,char const * const &,unsigned __int64 const &>(char*&&, unsigned long long&&, char const* const&, unsigned long long const&)
+FUNC 4259c 11 0 __crt_char_traits<char>::tcsncpy_s<char *,unsigned __int64,char const * const &,unsigned __int64 const &>(char*&&, unsigned long long&&, char const* const&, unsigned long long const&)
 4259c 11 109 326
-FUNC 425b4 11 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned __int64 const &,wchar_t const * const &,unsigned __int64 const &>(wchar_t*&&, unsigned long long const&, wchar_t const* const&, unsigned long long const&)
+FUNC 425b4 11 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned __int64 const &,wchar_t const * const &,unsigned __int64 const &>(wchar_t*&&, unsigned long long const&, wchar_t const* const&, unsigned long long const&)
 425b4 11 124 326
-FUNC 425cc 11 0 static __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned __int64,wchar_t const * const &,unsigned __int64 const &>(wchar_t*&&, unsigned long long&&, wchar_t const* const&, unsigned long long const&)
+FUNC 425cc 11 0 __crt_char_traits<wchar_t>::tcsncpy_s<wchar_t *,unsigned __int64,wchar_t const * const &,unsigned __int64 const &>(wchar_t*&&, unsigned long long&&, wchar_t const* const&, unsigned long long const&)
 425cc 11 124 326
-FUNC 425e4 8 0 static __crt_char_traits<char>::tcspbrk<char * &,char const (&)[3]>(char*&, const char[3]&)
+FUNC 425e4 8 0 __crt_char_traits<char>::tcspbrk<char * &,char const (&)[3]>(char*&, const char[3]&)
 425e4 8 109 326
-FUNC 425f0 8 0 static __crt_char_traits<wchar_t>::tcspbrk<wchar_t * &,wchar_t const (&)[3]>(wchar_t*&, const wchar_t[3]&)
+FUNC 425f0 8 0 __crt_char_traits<wchar_t>::tcspbrk<wchar_t * &,wchar_t const (&)[3]>(wchar_t*&, const wchar_t[3]&)
 425f0 8 124 326
 FUNC 425fc 7 0 __crt_unique_handle_t<__crt_findfile_traits>::__crt_unique_handle_t<__crt_findfile_traits>(void* const)
 425fc 3 1097 205
@@ -16316,7 +16316,7 @@ FUNC 429cc 5c 0 __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_r
 42a13 4 360 327
 42a17 6 362 327
 42a1d b 363 327
-FUNC 42a40 24 0 static __crt_win32_buffer_internal_dynamic_resizing::allocate(void** const, const unsigned long long, __crt_win32_buffer_empty_debug_info const&)
+FUNC 42a40 24 0 __crt_win32_buffer_internal_dynamic_resizing::allocate(void** const, const unsigned long long, __crt_win32_buffer_empty_debug_info const&)
 42a40 9 82 327
 42a49 8 83 327
 42a51 3 84 327
@@ -16356,7 +16356,7 @@ FUNC 42cb8 22 0 __crt_unique_handle_t<__crt_findfile_traits>::close()
 42cc7 9 1146 205
 42cd0 4 1147 205
 42cd4 6 1148 205
-FUNC 42ce4 14 0 static __crt_findfile_traits::close(void*)
+FUNC 42ce4 14 0 __crt_findfile_traits::close(void*)
 42ce4 4 1076 205
 42ce8 b 1077 205
 42cf3 5 1078 205
@@ -16366,7 +16366,7 @@ FUNC 42d00 5 0 __crt_win32_buffer<char,__crt_win32_buffer_internal_dynamic_resiz
 FUNC 42d08 5 0 __crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>::data()
 42d08 4 248 327
 42d0c 1 249 327
-FUNC 42d10 5 0 static __crt_win32_buffer_internal_dynamic_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
+FUNC 42d10 5 0 __crt_win32_buffer_internal_dynamic_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
 42d10 5 93 327
 FUNC 42d18 4 0 __crt_win32_buffer<char,__crt_win32_buffer_internal_dynamic_resizing>::debug_info() const
 42d18 3 341 327
@@ -16429,7 +16429,7 @@ FUNC 42f24 9d 0 get_file_name(__crt_win32_buffer<char,__crt_win32_buffer_interna
 FUNC 42fe8 4 0 get_file_name(__crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>*, wchar_t* const)
 42fe8 3 208 379
 42feb 1 209 379
-FUNC 42fec 5 0 static __crt_findfile_traits::get_invalid_value()
+FUNC 42fec 5 0 __crt_findfile_traits::get_invalid_value()
 42fec 4 1082 205
 42ff0 1 1083 205
 FUNC 42ff4 4 0 get_wide(__crt_win32_buffer<wchar_t,__crt_win32_buffer_internal_dynamic_resizing>*, wchar_t* const)
@@ -16532,7 +16532,7 @@ FUNC 434d4 30 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::allocat
 434e7 c 348 327
 434f3 b 357 327
 434fe 6 363 327
-FUNC 43510 17 0 static __crt_win32_buffer_no_resizing::allocate(void** const, const unsigned long long, __crt_win32_buffer_empty_debug_info const&)
+FUNC 43510 17 0 __crt_win32_buffer_no_resizing::allocate(void** const, const unsigned long long, __crt_win32_buffer_empty_debug_info const&)
 43510 4 131 327
 43514 c 132 327
 43520 2 133 327
@@ -16543,7 +16543,7 @@ FUNC 4352c 5 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::capacity
 FUNC 43534 5 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::data()
 43534 4 248 327
 43538 1 249 327
-FUNC 4353c 3 0 static __crt_win32_buffer_no_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
+FUNC 4353c 3 0 __crt_win32_buffer_no_resizing::deallocate(void* const, __crt_win32_buffer_empty_debug_info const&)
 4353c 3 138 327
 FUNC 43540 4 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::debug_info() const
 43540 3 341 327
@@ -17024,7 +17024,7 @@ FUNC 45060 21 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings
 45071 6 1146 205
 45077 4 1147 205
 4507b 6 1148 205
-FUNC 4508c 11 0 static `anonymous namespace'::environment_strings_traits::close(wchar_t*)
+FUNC 4508c 11 0 `anonymous namespace'::environment_strings_traits::close(wchar_t*)
 4508c 4 24 394
 45090 6 25 394
 45096 2 26 394
@@ -17036,7 +17036,7 @@ FUNC 450a4 23 0 find_end_of_double_null_terminated_sequence(wchar_t const* const
 FUNC 450d0 4 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings_traits>::get() const
 450d0 3 1138 205
 450d3 1 1139 205
-FUNC 450d4 3 0 static `anonymous namespace'::environment_strings_traits::get_invalid_value()
+FUNC 450d4 3 0 `anonymous namespace'::environment_strings_traits::get_invalid_value()
 450d4 2 31 394
 450d6 1 32 394
 FUNC 450d8 8 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings_traits>::is_valid() const
@@ -17256,33 +17256,33 @@ FUNC 45e14 91 0 find_in_environment_nolock<wchar_t>(wchar_t const* const, const 
 45e74 9 121 395
 45e7d a 125 395
 45e87 1e 126 395
-FUNC 45ecc 5 0 static __crt_char_traits<char>::get_or_create_environment_nolock<>()
+FUNC 45ecc 5 0 __crt_char_traits<char>::get_or_create_environment_nolock<>()
 45ecc 5 109 326
-FUNC 45ed4 5 0 static __crt_char_traits<wchar_t>::get_or_create_environment_nolock<>()
+FUNC 45ed4 5 0 __crt_char_traits<wchar_t>::get_or_create_environment_nolock<>()
 45ed4 5 124 326
-FUNC 45edc b 0 static __crt_char_traits<char>::set_environment_variable<char * const &,char * const>(char* const&, char* const&&)
+FUNC 45edc b 0 __crt_char_traits<char>::set_environment_variable<char * const &,char * const>(char* const&, char* const&&)
 45edc b 109 326
-FUNC 45eec d 0 static __crt_char_traits<wchar_t>::set_environment_variable<wchar_t * const &,wchar_t * const>(wchar_t* const&, wchar_t* const&&)
+FUNC 45eec d 0 __crt_char_traits<wchar_t>::set_environment_variable<wchar_t * const &,wchar_t * const>(wchar_t* const&, wchar_t* const&&)
 45eec d 124 326
-FUNC 45efc b 0 static __crt_char_traits<char>::tcschr<char * const &,char>(char* const&, char&&)
+FUNC 45efc b 0 __crt_char_traits<char>::tcschr<char * const &,char>(char* const&, char&&)
 45efc b 109 326
-FUNC 45f0c b 0 static __crt_char_traits<wchar_t>::tcschr<wchar_t * const &,char>(wchar_t* const&, char&&)
+FUNC 45f0c b 0 __crt_char_traits<wchar_t>::tcschr<wchar_t * const &,char>(wchar_t* const&, char&&)
 45f0c b 124 326
-FUNC 45f1c e 0 static __crt_char_traits<char>::tcscpy_s<char * &,unsigned __int64 const &,char * &>(char*&, unsigned long long const&, char*&)
+FUNC 45f1c e 0 __crt_char_traits<char>::tcscpy_s<char * &,unsigned __int64 const &,char * &>(char*&, unsigned long long const&, char*&)
 45f1c e 109 326
-FUNC 45f30 e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * &,unsigned __int64 const &,wchar_t * &>(wchar_t*&, unsigned long long const&, wchar_t*&)
+FUNC 45f30 e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * &,unsigned __int64 const &,wchar_t * &>(wchar_t*&, unsigned long long const&, wchar_t*&)
 45f30 e 124 326
-FUNC 45f44 e 0 static __crt_char_traits<char>::tcscpy_s<char * const &,unsigned __int64 const &,char * const &>(char* const&, unsigned long long const&, char* const&)
+FUNC 45f44 e 0 __crt_char_traits<char>::tcscpy_s<char * const &,unsigned __int64 const &,char * const &>(char* const&, unsigned long long const&, char* const&)
 45f44 e 109 326
-FUNC 45f58 e 0 static __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * const &,unsigned __int64 const &,wchar_t * const &>(wchar_t* const&, unsigned long long const&, wchar_t* const&)
+FUNC 45f58 e 0 __crt_char_traits<wchar_t>::tcscpy_s<wchar_t * const &,unsigned __int64 const &,wchar_t * const &>(wchar_t* const&, unsigned long long const&, wchar_t* const&)
 45f58 e 124 326
-FUNC 45f6c 11 0 static __crt_char_traits<char>::tcslen<char * const &>(char* const&)
+FUNC 45f6c 11 0 __crt_char_traits<char>::tcslen<char * const &>(char* const&)
 45f6c 11 109 326
-FUNC 45f84 12 0 static __crt_char_traits<wchar_t>::tcslen<wchar_t * const &>(wchar_t* const&)
+FUNC 45f84 12 0 __crt_char_traits<wchar_t>::tcslen<wchar_t * const &>(wchar_t* const&)
 45f84 12 124 326
-FUNC 45f9c e 0 static __crt_char_traits<char>::tcsnicoll<char const * const &,char * &,unsigned __int64 const &>(char const* const&, char*&, unsigned long long const&)
+FUNC 45f9c e 0 __crt_char_traits<char>::tcsnicoll<char const * const &,char * &,unsigned __int64 const &>(char const* const&, char*&, unsigned long long const&)
 45f9c e 109 326
-FUNC 45fb0 e 0 static __crt_char_traits<wchar_t>::tcsnicoll<wchar_t const * const &,wchar_t * &,unsigned __int64 const &>(wchar_t const* const&, wchar_t*&, unsigned long long const&)
+FUNC 45fb0 e 0 __crt_char_traits<wchar_t>::tcsnicoll<wchar_t const * const &,wchar_t * &,unsigned __int64 const &>(wchar_t const* const&, wchar_t*&, unsigned long long const&)
 45fb0 e 124 326
 FUNC 45fc4 8 0 get_environment(char)
 45fc4 8 17 395
@@ -17316,7 +17316,7 @@ FUNC 46034 95 0 recalloc_base(void*, unsigned long long, unsigned long long)
 460a0 11 40 396
 460b1 3 43 396
 460b4 15 44 396
-FUNC 460f0 28 0 static <lambda_795c6bd18aed400428efeb9a5f0e1479>::<lambda_invoker_cdecl>(wchar_t*)
+FUNC 460f0 28 0 <lambda_795c6bd18aed400428efeb9a5f0e1479>::<lambda_invoker_cdecl>(wchar_t*)
 460f0 28 425 397
 FUNC 46124 8 0 __crt_fast_encoded_nullptr_t::operator<int __cdecl(wchar_t *,unsigned long,__int64)> int (__cdecl*)(wchar_t *,unsigned long,__int64)() const
 46124 7 536 103
@@ -18937,28 +18937,28 @@ FUNC 4b938 4 0 __crt_simd_cleanup_guard<1>::~__crt_simd_cleanup_guard<1>()
 4b93b 1 116 421
 FUNC 4b93c 3 0 __crt_simd_cleanup_guard<0>::~__crt_simd_cleanup_guard<0>()
 4b93c 3 63 421
-FUNC 4b940 9 0 static __crt_simd_traits<1,unsigned char>::compare_equals(const __m256i, const __m256i)
+FUNC 4b940 9 0 __crt_simd_traits<1,unsigned char>::compare_equals(const __m256i, const __m256i)
 4b940 8 143 421
 4b948 1 144 421
-FUNC 4b94c 9 0 static __crt_simd_traits<1,unsigned short>::compare_equals(const __m256i, const __m256i)
+FUNC 4b94c 9 0 __crt_simd_traits<1,unsigned short>::compare_equals(const __m256i, const __m256i)
 4b94c 8 153 421
 4b954 1 154 421
-FUNC 4b958 9 0 static __crt_simd_traits<0,unsigned char>::compare_equals(const __m128i, const __m128i)
+FUNC 4b958 9 0 __crt_simd_traits<0,unsigned char>::compare_equals(const __m128i, const __m128i)
 4b958 8 90 421
 4b960 1 91 421
-FUNC 4b964 9 0 static __crt_simd_traits<0,unsigned short>::compare_equals(const __m128i, const __m128i)
+FUNC 4b964 9 0 __crt_simd_traits<0,unsigned short>::compare_equals(const __m128i, const __m128i)
 4b964 8 100 421
 4b96c 1 101 421
-FUNC 4b970 c 0 static __crt_simd_pack_traits<1>::compute_byte_mask(const __m256i)
+FUNC 4b970 c 0 __crt_simd_pack_traits<1>::compute_byte_mask(const __m256i)
 4b970 b 133 421
 4b97b 1 134 421
-FUNC 4b980 9 0 static __crt_simd_pack_traits<0>::compute_byte_mask(const __m128i)
+FUNC 4b980 9 0 __crt_simd_pack_traits<0>::compute_byte_mask(const __m128i)
 4b980 8 80 421
 4b988 1 81 421
-FUNC 4b98c 5 0 static __crt_simd_pack_traits<1>::get_zero_pack()
+FUNC 4b98c 5 0 __crt_simd_pack_traits<1>::get_zero_pack()
 4b98c 4 127 421
 4b990 1 129 421
-FUNC 4b994 4 0 static __crt_simd_pack_traits<0>::get_zero_pack()
+FUNC 4b994 4 0 __crt_simd_pack_traits<0>::get_zero_pack()
 4b994 3 74 421
 4b997 1 76 421
 FUNC 4b998 150 0 strnlen(char const*, unsigned long long)
@@ -24076,17 +24076,17 @@ FUNC 623e8 a4 0 common_show_message_box<wchar_t>(wchar_t const* const, wchar_t c
 62466 a 75 508
 62470 7 64 508
 62477 15 76 508
-FUNC 624b8 11 0 static __crt_char_traits<char>::message_box<std::nullptr_t,char const * const &,char const * const &,unsigned long>(void*&&, char const* const&, char const* const&, unsigned long&&)
+FUNC 624b8 11 0 __crt_char_traits<char>::message_box<std::nullptr_t,char const * const &,char const * const &,unsigned long>(void*&&, char const* const&, char const* const&, unsigned long&&)
 624b8 11 109 326
-FUNC 624d0 11 0 static __crt_char_traits<wchar_t>::message_box<std::nullptr_t,wchar_t const * const &,wchar_t const * const &,unsigned long>(void*&&, wchar_t const* const&, wchar_t const* const&, unsigned long&&)
+FUNC 624d0 11 0 __crt_char_traits<wchar_t>::message_box<std::nullptr_t,wchar_t const * const &,wchar_t const * const &,unsigned long>(void*&&, wchar_t const* const&, wchar_t const* const&, unsigned long&&)
 624d0 11 124 326
-FUNC 624e8 11 0 static __crt_char_traits<char>::message_box<HWND__ *,char const * const &,char const * const &,unsigned int const &>(HWND__*&&, char const* const&, char const* const&, unsigned int const&)
+FUNC 624e8 11 0 __crt_char_traits<char>::message_box<HWND__ *,char const * const &,char const * const &,unsigned int const &>(HWND__*&&, char const* const&, char const* const&, unsigned int const&)
 624e8 11 109 326
-FUNC 62500 11 0 static __crt_char_traits<wchar_t>::message_box<HWND__ *,wchar_t const * const &,wchar_t const * const &,unsigned int const &>(HWND__*&&, wchar_t const* const&, wchar_t const* const&, unsigned int const&)
+FUNC 62500 11 0 __crt_char_traits<wchar_t>::message_box<HWND__ *,wchar_t const * const &,wchar_t const * const &,unsigned int const &>(HWND__*&&, wchar_t const* const&, wchar_t const* const&, unsigned int const&)
 62500 11 124 326
-FUNC 62518 8 0 static __crt_char_traits<char>::output_debug_string<char const * const &>(char const* const&)
+FUNC 62518 8 0 __crt_char_traits<char>::output_debug_string<char const * const &>(char const* const&)
 62518 8 109 326
-FUNC 62524 a 0 static __crt_char_traits<wchar_t>::output_debug_string<wchar_t const * const &>(wchar_t const* const&)
+FUNC 62524 a 0 __crt_char_traits<wchar_t>::output_debug_string<wchar_t const * const &>(wchar_t const* const&)
 62524 a 124 326
 FUNC 62530 a3 0 _acrt_show_narrow_message_box(char const*, char const*, unsigned int)
 62530 1d 83 508

--- a/test_data/windows/dump_syms_regtest64.sym
+++ b/test_data/windows/dump_syms_regtest64.sym
@@ -343,7 +343,7 @@ FUNC 1110 26 0 google_breakpad::C::f()
 1110 26 43 0
 FUNC 1140 b 0 google_breakpad::C::g()
 1140 b 44 0
-FUNC 1150 8 0 static google_breakpad::C::h(google_breakpad::C const&)
+FUNC 1150 8 0 google_breakpad::C::h(google_breakpad::C const&)
 1150 8 45 0
 FUNC 1160 16 0 google_breakpad::C::set_member(int)
 1160 16 40 0
@@ -433,7 +433,7 @@ FUNC 13d0 67 0 strcmp()
 142f 3 125 236
 1432 4 126 236
 1436 1 127 236
-FUNC 1438 6c 0 static type_info::_Type_info_dtor(type_info*)
+FUNC 1438 6c 0 type_info::_Type_info_dtor(type_info*)
 1438 9 31 307
 1441 b 32 307
 144c 9 34 307


### PR DESCRIPTION
Fixes #77.

The default flags in pdb-addr2line are equal to the flags we were using previously plus NO_MEMBER_FUNCTION_STATIC.

In #77, willkg said:

> Socorro's signature generation drops the prefix and return type.

So this change probably won't affect signatures.

But it will make the results of the Tecken symbolication API nicer.