### PR TITLE
Don't strip underscores from pdb FUNC names.

### DIFF
--- a/src/windows/symbol.rs
+++ b/src/windows/symbol.rs
@@ -254,7 +254,6 @@ impl SelectedSymbol {
             // The public name may contain parameter_size info so get it
             if let FuncName::Unknown((name, sps)) = FuncName::get_unknown(fun_name.clone()) {
                 if name == self.name || fun_name == self.name {
-                    self.name = name;
                     self.parameter_size = sps;
                 }
             }

--- a/test_data/windows/basic-opt32.sym
+++ b/test_data/windows/basic-opt32.sym
@@ -1023,7 +1023,7 @@ a0e4 8 59 40
 a0ec 2 59 40
 a0ee 9 55 40
 a0f7 2 62 40
-FUNC a110 46 0 _SEH_prolog4()
+FUNC a110 46 0 __SEH_prolog4()
 a110 5 71 41
 a115 7 72 41
 a11c 4 73 41
@@ -1045,7 +1045,7 @@ a148 3 88 41
 a14b 3 89 41
 a14e 6 90 41
 a154 2 91 41
-FUNC a156 15 0 _SEH_epilog4()
+FUNC a156 15 0 __SEH_epilog4()
 a156 3 113 41
 a159 7 114 41
 a160 1 115 41
@@ -1618,7 +1618,7 @@ afe4 5 346 53
 afe9 3 347 53
 afec 1 348 53
 afed 3 349 53
-FUNC aff0 17 0 _EH4_CallFilterFunc()
+FUNC aff0 17 0 @_EH4_CallFilterFunc@8()
 aff0 1 387 53
 aff1 1 388 53
 aff2 1 389 53
@@ -1635,7 +1635,7 @@ b003 1 399 53
 b004 1 400 53
 b005 1 401 53
 b006 1 402 53
-FUNC b008 19 0 _EH4_TransferToHandler()
+FUNC b008 19 0 @_EH4_TransferToHandler@8()
 b008 2 431 53
 b00a 2 432 53
 b00c 2 433 53
@@ -1647,7 +1647,7 @@ b019 2 438 53
 b01b 2 439 53
 b01d 2 440 53
 b01f 2 441 53
-FUNC b024 1a 0 _EH4_GlobalUnwind2()
+FUNC b024 1a 0 @_EH4_GlobalUnwind2@8()
 b024 1 467 53
 b025 2 468 53
 b027 1 469 53
@@ -1663,7 +1663,7 @@ b03a 1 479 53
 b03b 1 480 53
 b03c 1 481 53
 b03d 1 482 53
-FUNC b040 17 8 _EH4_LocalUnwind()
+FUNC b040 17 8 @_EH4_LocalUnwind@16()
 b040 1 513 53
 b041 4 514 53
 b045 1 515 53
@@ -4215,7 +4215,7 @@ FUNC 12d3a 1d 0 __crt_fast_encode_pointer<void (__cdecl*)(void)>(void (* const)(
 FUNC 12d5e b 0 __vcrt_initialize_pure_virtual_call_handler()
 12d5e a 21 62
 12d68 1 22 62
-FUNC 12d70 21 0 _global_unwind2()
+FUNC 12d70 21 0 __global_unwind2()
 12d70 7 92 63
 12d77 2 93 63
 12d79 2 94 63
@@ -4246,7 +4246,7 @@ FUNC 12d91 45 0 __unwind_handler()
 12dce 2 169 63
 12dd0 5 171 63
 12dd5 1 173 63
-FUNC 12dd6 84 0 _local_unwind2()
+FUNC 12dd6 84 0 __local_unwind2()
 12dd6 1 205 63
 12dd7 1 206 63
 12dd8 1 207 63
@@ -4289,7 +4289,7 @@ FUNC 12dd6 84 0 _local_unwind2()
 12e57 1 260 63
 12e58 1 261 63
 12e59 1 262 63
-FUNC 12e5a 23 0 _abnormal_termination()
+FUNC 12e5a 23 0 __abnormal_termination()
 12e5a 2 275 63
 12e5c 7 277 63
 12e63 7 278 63

--- a/test_data/windows/basic-opt64.sym
+++ b/test_data/windows/basic-opt64.sym
@@ -669,9 +669,9 @@ FUNC 9790 19 0 dllmain_raw(HINSTANCE__* const, const unsigned long, void* const)
 979c 5 164 24
 97a1 1 167 24
 97a2 7 166 24
-FUNC 97b0 5 0 CRT_INIT(HINSTANCE__* const, const unsigned long, void* const)
+FUNC 97b0 5 0 _CRT_INIT(HINSTANCE__* const, const unsigned long, void* const)
 97b0 5 154 24
-FUNC 97b8 3d 0 DllMainCRTStartup(HINSTANCE__* const, const unsigned long, void* const)
+FUNC 97b8 3d 0 _DllMainCRTStartup(HINSTANCE__* const, const unsigned long, void* const)
 97b8 17 243 24
 97cf 5 244 24
 97d4 5 250 24
@@ -691,7 +691,7 @@ FUNC 980c 6b 0 __get_entropy()
 984e 3 115 28
 9851 20 132 28
 9871 6 136 28
-FUNC 9894 ac 0 _security_init_cookie()
+FUNC 9894 ac 0 __security_init_cookie()
 9894 d 158 28
 98a1 16 169 28
 98b7 5c 184 28
@@ -705,13 +705,13 @@ FUNC 9974 e 0 __scrt_initialize_type_info()
 9974 e 17 30
 FUNC 9988 c 0 __scrt_uninitialize_type_info()
 9988 c 25 30
-FUNC 9998 8 0 _local_stdio_printf_options()
+FUNC 9998 8 0 __local_stdio_printf_options()
 9998 7 83 36
 999f 1 84 36
-FUNC 99a4 8 0 _local_stdio_scanf_options()
+FUNC 99a4 8 0 __local_stdio_scanf_options()
 99a4 7 93 36
 99ab 1 94 36
-FUNC 99b0 1b 0 _scrt_initialize_default_local_stdio_options()
+FUNC 99b0 1b 0 __scrt_initialize_default_local_stdio_options()
 99b0 4 17 33
 99b4 9 18 33
 99bd 9 19 33
@@ -753,7 +753,7 @@ FUNC 9aa4 2f 0 is_potentially_valid_image_base(void* const)
 FUNC 9ae0 a 0 NtCurrentTeb()
 9ae0 9 21341 15
 9ae9 1 21342 15
-FUNC 9aec 39 0 _scrt_acquire_startup_lock()
+FUNC 9aec 39 0 __scrt_acquire_startup_lock()
 9aec 4 139 37
 9af0 9 140 37
 9af9 d 146 37
@@ -763,7 +763,7 @@ FUNC 9aec 39 0 _scrt_acquire_startup_lock()
 9b1a 2 156 37
 9b1c 5 157 37
 9b21 4 152 37
-FUNC 9b34 34 0 _scrt_dllmain_after_initialize_c()
+FUNC 9b34 34 0 __scrt_dllmain_after_initialize_c()
 9b34 4 376 37
 9b38 9 377 37
 9b41 5 379 37
@@ -773,11 +773,11 @@ FUNC 9b34 34 0 _scrt_dllmain_after_initialize_c()
 9b5c 5 388 37
 9b61 2 391 37
 9b63 5 392 37
-FUNC 9b78 15 0 _scrt_dllmain_before_initialize_c()
+FUNC 9b78 15 0 __scrt_dllmain_before_initialize_c()
 9b78 4 366 37
 9b7c c 367 37
 9b88 5 373 37
-FUNC 9b94 28 0 _scrt_dllmain_crt_thread_attach()
+FUNC 9b94 28 0 __scrt_dllmain_crt_thread_attach()
 9b94 4 434 37
 9b98 9 436 37
 9ba1 4 448 37
@@ -786,20 +786,20 @@ FUNC 9b94 28 0 _scrt_dllmain_crt_thread_attach()
 9bb3 2 444 37
 9bb5 2 447 37
 9bb7 5 448 37
-FUNC 9bc8 15 0 _scrt_dllmain_crt_thread_detach()
+FUNC 9bc8 15 0 __scrt_dllmain_crt_thread_detach()
 9bc8 4 451 37
 9bcc 5 453 37
 9bd1 5 454 37
 9bd6 2 455 37
 9bd8 5 456 37
-FUNC 9be4 60 0 _scrt_dllmain_exception_filter(HINSTANCE__*, unsigned long, void*, int (*)(HINSTANCE__*, unsigned long, void*), unsigned long, _EXCEPTION_POINTERS*)
+FUNC 9be4 60 0 __scrt_dllmain_exception_filter(HINSTANCE__*, unsigned long, void*, int (*)(HINSTANCE__*, unsigned long, void*), unsigned long, _EXCEPTION_POINTERS*)
 9be4 1f 350 37
 9c03 e 351 37
 9c11 11 359 37
 9c22 9 362 37
 9c2b 14 363 37
 9c3f 5 362 37
-FUNC 9c5c 30 0 _scrt_dllmain_uninitialize_c()
+FUNC 9c5c 30 0 __scrt_dllmain_uninitialize_c()
 9c5c 4 395 37
 9c60 9 396 37
 9c69 7 398 37
@@ -808,12 +808,12 @@ FUNC 9c5c 30 0 _scrt_dllmain_uninitialize_c()
 9c79 9 402 37
 9c82 5 404 37
 9c87 5 407 37
-FUNC 9c98 14 0 _scrt_dllmain_uninitialize_critical()
+FUNC 9c98 14 0 __scrt_dllmain_uninitialize_critical()
 9c98 4 410 37
 9c9c 7 429 37
 9ca3 4 431 37
 9ca7 5 430 37
-FUNC 9cb4 49 0 _scrt_initialize_crt(__scrt_module_type)
+FUNC 9cb4 49 0 __scrt_initialize_crt(__scrt_module_type)
 9cb4 6 185 37
 9cba 17 186 37
 9cd1 5 191 37
@@ -824,7 +824,7 @@ FUNC 9cb4 49 0 _scrt_initialize_crt(__scrt_module_type)
 9cf3 2 202 37
 9cf5 2 205 37
 9cf7 6 206 37
-FUNC 9d10 d8 0 _scrt_initialize_onexit_tables(__scrt_module_type)
+FUNC 9d10 d8 0 __scrt_initialize_onexit_tables(__scrt_module_type)
 9d10 6 296 37
 9d16 f 297 37
 9d25 9 302 37
@@ -838,7 +838,7 @@ FUNC 9d10 d8 0 _scrt_initialize_onexit_tables(__scrt_module_type)
 9dce 7 331 37
 9dd5 8 333 37
 9ddd b 304 37
-FUNC 9e20 99 0 _scrt_is_nonwritable_in_current_image(void const*)
+FUNC 9e20 99 0 __scrt_is_nonwritable_in_current_image(void const*)
 9e20 7 88 37
 9e27 33 99 37
 9e5a 3 107 37
@@ -851,19 +851,19 @@ FUNC 9e20 99 0 _scrt_is_nonwritable_in_current_image(void const*)
 9eae 4 101 37
 9eb2 2 127 37
 9eb4 5 129 37
-FUNC 9ee0 24 0 _scrt_release_startup_lock(bool)
+FUNC 9ee0 24 0 __scrt_release_startup_lock(bool)
 9ee0 8 160 37
 9ee8 b 161 37
 9ef3 4 167 37
 9ef7 7 172 37
 9efe 6 173 37
-FUNC 9f10 2b 0 _scrt_uninitialize_crt(bool, bool)
+FUNC 9f10 2b 0 __scrt_uninitialize_crt(bool, bool)
 9f10 6 209 37
 9f16 f 214 37
 9f25 7 220 37
 9f2c 7 221 37
 9f33 8 224 37
-FUNC 9f48 4f 0 onexit(int (*)())
+FUNC 9f48 4f 0 _onexit(int (*)())
 9f48 6 256 37
 9f4e 7 257 37
 9f55 3 256 37
@@ -883,13 +883,13 @@ FUNC 9ff0 17 0 atexit(void (*)())
 9ff0 4 274 37
 9ff4 e 275 37
 a002 5 278 37
-FUNC a00c 8 0 _scrt_get_dyn_tls_init_callback(<NoType>)
+FUNC a00c 8 0 __scrt_get_dyn_tls_init_callback(<NoType>)
 a00c 7 20 38
 a013 1 21 38
-FUNC a018 8 0 _crt_debugger_hook(int)
+FUNC a018 8 0 __crt_debugger_hook(int)
 a018 7 131 39
 a01f 1 132 39
-FUNC a024 14a 0 _scrt_fastfail(unsigned int)
+FUNC a024 14a 0 __scrt_fastfail(unsigned int)
 a024 17 147 39
 a03b e 150 39
 a049 4 151 39
@@ -910,18 +910,18 @@ a142 b 227 39
 a14d 8 231 39
 a155 8 232 39
 a15d 11 233 39
-FUNC a1c0 3a 0 _scrt_get_show_window_mode()
+FUNC a1c0 3a 0 __scrt_get_show_window_mode()
 a1c0 7 22 39
 a1c7 10 23 39
 a1d7 b 24 39
 a1e2 10 26 39
 a1f2 8 29 39
-FUNC a208 5 0 _scrt_initialize_mta()
+FUNC a208 5 0 __scrt_initialize_mta()
 a208 5 83 39
-FUNC a210 3 0 _scrt_initialize_winrt()
+FUNC a210 3 0 __scrt_initialize_winrt()
 a210 2 67 39
 a212 1 68 39
-FUNC a214 52 0 _scrt_is_managed_app()
+FUNC a214 52 0 __scrt_is_managed_app()
 a214 4 32 39
 a218 8 33 39
 a220 5 34 39
@@ -934,33 +934,33 @@ a252 9 58 39
 a25b 4 61 39
 a25f 2 59 39
 a261 5 62 39
-FUNC a27c e 0 _scrt_set_unhandled_exception_filter()
+FUNC a27c e 0 __scrt_set_unhandled_exception_filter()
 a27c e 99 39
-FUNC a290 3 0 _scrt_stub_for_initialize_mta()
+FUNC a290 3 0 __scrt_stub_for_initialize_mta()
 a290 2 76 39
 a292 1 77 39
-FUNC a294 38 0 _scrt_unhandled_exception_filter(_EXCEPTION_POINTERS* const)
+FUNC a294 38 0 __scrt_unhandled_exception_filter(_EXCEPTION_POINTERS* const)
 a294 4 87 39
 a298 3 88 39
 a29b 24 89 39
 a2bf 2 94 39
 a2c1 5 95 39
 a2c6 6 91 39
-FUNC a2dc 3c 0 RTC_Initialize()
+FUNC a2dc 3c 0 _RTC_Initialize()
 a2dc a 38 40
 a2e6 10 41 40
 a2f6 8 43 40
 a2fe 6 45 40
 a304 9 41 40
 a30d b 48 40
-FUNC a328 3c 0 RTC_Terminate()
+FUNC a328 3c 0 _RTC_Terminate()
 a328 a 52 40
 a332 10 55 40
 a342 8 57 40
 a34a 6 59 40
 a350 9 55 40
 a359 b 62 40
-FUNC a374 3 0 guard_check_icall_nop(unsigned long long)
+FUNC a374 3 0 _guard_check_icall_nop(unsigned long long)
 a374 3 82 41
 FUNC a378 4 0 ReadNoFence64(long long const*)
 a378 3 7716 15
@@ -968,13 +968,13 @@ a37b 1 7718 15
 FUNC a37c 4 0 ReadPointerNoFence(void* const*)
 a37c 3 8335 15
 a37f 1 8336 15
-FUNC a380 17 0 guard_icall_checks_enforced()
+FUNC a380 17 0 _guard_icall_checks_enforced()
 a380 16 130 41
 a396 1 131 41
-FUNC a39c 3 0 guard_rf_checks_enforced()
+FUNC a39c 3 0 _guard_rf_checks_enforced()
 a39c 2 162 41
 a39e 1 163 41
-FUNC a3a0 1b9 0 _isa_available_init(<NoType>)
+FUNC a3a0 1b9 0 __isa_available_init(<NoType>)
 a3a0 12 70 42
 a3b2 1a 82 42
 a3cc 6 86 42
@@ -1003,10 +1003,10 @@ a52b 6 158 42
 a531 d 160 42
 a53e 6 161 42
 a544 15 168 42
-FUNC a5c8 6 0 get_startup_argv_mode()
+FUNC a5c8 6 0 _get_startup_argv_mode()
 a5c8 5 15 43
 a5cd 1 16 43
-FUNC a5d0 c 0 _scrt_is_ucrt_dll_in_use(<NoType>)
+FUNC a5d0 c 0 __scrt_is_ucrt_dll_in_use(<NoType>)
 a5d0 b 23 44
 a5db 1 24 44
 PUBLIC a5e0 0 QueryPerformanceCounter
@@ -1023,7 +1023,7 @@ PUBLIC a61c 0 SetUnhandledExceptionFilter
 PUBLIC a622 0 GetStartupInfoW
 PUBLIC a628 0 IsProcessorFeaturePresent
 PUBLIC a62e 0 GetModuleHandleW
-FUNC a634 20b 0 _C_specific_handler(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
+FUNC a634 20b 0 __C_specific_handler(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
 a634 22 175 49
 a656 e 196 49
 a664 4 205 49
@@ -1134,13 +1134,13 @@ a9f0 9 394 22
 a9f9 8 395 22
 aa01 4 396 22
 aa05 6 397 22
-FUNC aa14 27 0 _std_type_info_compare(__std_type_info_data const*, __std_type_info_data const*)
+FUNC aa14 27 0 __std_type_info_compare(__std_type_info_data const*, __std_type_info_data const*)
 aa14 5 23 50
 aa19 19 28 50
 aa32 3 29 50
 aa35 5 28 50
 aa3a 1 29 50
-FUNC aa44 2a 0 _std_type_info_destroy_list(__type_info_node*)
+FUNC aa44 2a 0 __std_type_info_destroy_list(__type_info_node*)
 aa44 6 139 50
 aa4a 6 140 50
 aa50 5 141 50
@@ -1148,7 +1148,7 @@ aa55 3 143 50
 aa58 8 144 50
 aa60 8 145 50
 aa68 6 147 50
-FUNC aa78 3b 0 _std_type_info_hash(__std_type_info_data const*)
+FUNC aa78 3b 0 __std_type_info_hash(__std_type_info_data const*)
 aa78 a 47 50
 aa82 6 48 50
 aa88 3 50 50
@@ -1156,7 +1156,7 @@ aa8b 17 51 50
 aaa2 6 48 50
 aaa8 a 56 50
 aab2 1 62 50
-FUNC aac4 11c 0 _std_type_info_name(__std_type_info_data*, __type_info_node*)
+FUNC aac4 11c 0 __std_type_info_name(__std_type_info_data*, __type_info_node*)
 aac4 1c 68 50
 aae0 3 72 50
 aae3 6 68 50
@@ -1183,7 +1183,7 @@ aba3 3 129 50
 aba6 6 130 50
 abac 16 131 50
 abc2 1e 132 50
-FUNC ac28 32 0 _vcrt_initialize()
+FUNC ac28 32 0 __vcrt_initialize()
 ac28 4 54 51
 ac2c 5 61 51
 ac31 5 62 51
@@ -1194,16 +1194,16 @@ ac4c 5 71 51
 ac51 2 72 51
 ac53 2 75 51
 ac55 5 76 51
-FUNC ac68 14 0 _vcrt_thread_attach()
+FUNC ac68 14 0 __vcrt_thread_attach()
 ac68 4 104 51
 ac6c b 108 51
 ac77 5 112 51
-FUNC ac84 12 0 _vcrt_thread_detach()
+FUNC ac84 12 0 __vcrt_thread_detach()
 ac84 4 115 51
 ac88 7 117 51
 ac8f 2 118 51
 ac91 5 119 51
-FUNC ac9c 20 0 _vcrt_uninitialize(bool)
+FUNC ac9c 20 0 __vcrt_uninitialize(bool)
 ac9c 4 79 51
 aca0 4 85 51
 aca4 5 88 51
@@ -1211,7 +1211,7 @@ aca9 5 89 51
 acae 7 90 51
 acb5 2 93 51
 acb7 5 94 51
-FUNC acc4 10 0 _vcrt_uninitialize_critical()
+FUNC acc4 10 0 __vcrt_uninitialize_critical()
 acc4 4 97 51
 acc8 5 98 51
 accd 2 100 51
@@ -1313,32 +1313,32 @@ ae97 1 305 52
 ae98 3 308 52
 ae9b 4 309 52
 ae9f 1 310 52
-FUNC af20 18 0 NLG_Notify()
+FUNC af20 18 0 _NLG_Notify()
 af20 5 51 53
 af25 5 52 53
 af2a 5 53 53
 af2f 7 54 53
 af36 2 55 53
-FUNC af40 1 0 _NLG_Dispatch2()
+FUNC af40 1 0 __NLG_Dispatch2()
 af40 1 60 53
-FUNC af50 1 0 _NLG_Return2()
+FUNC af50 1 0 __NLG_Return2()
 af50 1 84 53
 FUNC af64 5 0 __except_get_jumpbuf_sp(_SETJMP_FLOAT128*)
 af64 4 159 54
 af68 1 160 54
-FUNC af6c 37 0 _except_validate_context_record(_CONTEXT*)
+FUNC af6c 37 0 __except_validate_context_record(_CONTEXT*)
 af6c 13 83 54
 af7f 9 84 54
 af88 7 90 54
 af8f c 91 54
 af9b 7 94 54
 afa2 1 97 54
-FUNC afb0 3f 0 _except_validate_jump_buffer(_SETJMP_FLOAT128*)
+FUNC afb0 3f 0 __except_validate_jump_buffer(_SETJMP_FLOAT128*)
 afb0 7 167 54
 afb7 3 166 54
 afba 34 167 54
 afee 1 168 54
-FUNC b000 5b 0 _except_validate_jump_buffer_common(_SETJMP_FLOAT128*, void* (*)(_SETJMP_FLOAT128*))
+FUNC b000 5b 0 __except_validate_jump_buffer_common(_SETJMP_FLOAT128*, void* (*)(_SETJMP_FLOAT128*))
 b000 a 123 54
 b00a 7 135 54
 b011 3 123 54
@@ -1350,7 +1350,7 @@ b046 2 143 54
 b048 6 147 54
 b04e 2 149 54
 b050 b 153 54
-FUNC b074 71 0 _DestructExceptionObject(EHExceptionRecord*, unsigned char)
+FUNC b074 71 0 __DestructExceptionObject(EHExceptionRecord*, unsigned char)
 b074 5 223 61
 b079 8 220 61
 b081 1b 223 61
@@ -1368,7 +1368,7 @@ b104 3 149 65
 FUNC b108 5 0 type_info::raw_name() const
 b108 4 103 31
 b10c 1 104 31
-FUNC b110 2f 0 IsExceptionObjectToBeDestroyed(void*)
+FUNC b110 2f 0 _IsExceptionObjectToBeDestroyed(void*)
 b110 9 276 61
 b119 b 279 61
 b124 5 280 61
@@ -1376,16 +1376,16 @@ b129 9 279 61
 b132 3 284 61
 b135 6 285 61
 b13b 4 281 61
-FUNC b14c 8 0 SetWinRTOutOfMemoryExceptionCallback(void* (*)())
+FUNC b14c 8 0 _SetWinRTOutOfMemoryExceptionCallback(void* (*)())
 b14c 7 185 61
 b153 1 186 61
-FUNC b158 23 0 _AdjustPointer(void*, PMD const&)
+FUNC b158 23 0 __AdjustPointer(void*, PMD const&)
 b158 6 48 61
 b15e 6 50 61
 b164 10 51 61
 b174 6 58 61
 b17a 1 62 61
-FUNC b184 4a 0 _FrameUnwindFilter(_EXCEPTION_POINTERS*)
+FUNC b184 4a 0 __FrameUnwindFilter(_EXCEPTION_POINTERS*)
 b184 4 134 61
 b188 1d 139 61
 b1a5 b 168 61
@@ -1394,7 +1394,7 @@ b1b8 2 172 61
 b1ba 5 178 61
 b1bf 9 141 61
 b1c8 6 142 61
-FUNC b1e0 5b 0 _GetPlatformExceptionInfo(int*)
+FUNC b1e0 5b 0 __GetPlatformExceptionInfo(int*)
 b1e0 6 75 61
 b1e6 6 76 61
 b1ec 9 77 61
@@ -1408,22 +1408,22 @@ b215 6 93 61
 b21b 18 95 61
 b233 2 100 61
 b235 6 101 61
-FUNC b254 12 0 _current_exception()
+FUNC b254 12 0 __current_exception()
 b254 4 112 61
 b258 9 113 61
 b261 5 114 61
-FUNC b26c 12 0 _current_exception_context()
+FUNC b26c 12 0 __current_exception_context()
 b26c 4 117 61
 b270 9 118 61
 b279 5 119 61
-FUNC b284 12 0 _processing_throw()
+FUNC b284 12 0 __processing_throw()
 b284 4 122 61
 b288 9 123 61
 b291 5 124 61
-FUNC b29c a 0 _std_terminate()
+FUNC b29c a 0 __std_terminate()
 b29c 4 197 61
 b2a0 6 198 61
-FUNC b2a8 a5 0 is_exception_typeof(type_info const&, _EXCEPTION_POINTERS*)
+FUNC b2a8 a5 0 _is_exception_typeof(type_info const&, _EXCEPTION_POINTERS*)
 b2a8 9 292 61
 b2b1 9 293 61
 b2ba 3 295 61
@@ -3559,11 +3559,11 @@ FUNC 13db0 2c 0 und_strncmp(char const*, char const*, unsigned int)
 13dce 5 1084 70
 13dd3 8 1090 70
 13ddb 1 1091 70
-FUNC 13de8 27 0 _unDName(char*, char const*, int, void* (*)(unsigned long long), void (*)(void*), unsigned short)
+FUNC 13de8 27 0 __unDName(char*, char const*, int, void* (*)(unsigned long long), void (*)(void*), unsigned short)
 13de8 4 707 69
 13dec 1e 708 69
 13e0a 5 710 69
-FUNC 13e18 132 0 _unDNameEx(char*, char const*, int, void* (*)(unsigned long long), void (*)(void*), char* (*)(long), unsigned long)
+FUNC 13e18 132 0 __unDNameEx(char*, char const*, int, void* (*)(unsigned long long), void (*)(void*), char* (*)(long), unsigned long)
 13e18 24 746 69
 13e3c 5 749 69
 13e41 2 750 69
@@ -3575,7 +3575,7 @@ FUNC 13e18 132 0 _unDNameEx(char*, char const*, int, void* (*)(unsigned long lon
 13f03 38 770 69
 13f3b 7 776 69
 13f42 8 782 69
-FUNC 13f98 62 0 vsprintf_s_l(char* const, const unsigned long long, char const* const, __crt_locale_pointers* const, char*)
+FUNC 13f98 62 0 _vsprintf_s_l(char* const, const unsigned long long, char const* const, __crt_locale_pointers* const, char*)
 13f98 20 1493 34
 13fb8 25 1494 34
 13fdd 1d 1499 34
@@ -3641,25 +3641,25 @@ FUNC 14274 34 0 store_and_initialize_ptd(__vcrt_ptd* const)
 14299 7 59 71
 142a0 2 61 71
 142a2 6 62 71
-FUNC 142b8 1f 0 _vcrt_freefls(void*)
+FUNC 142b8 1f 0 __vcrt_freefls(void*)
 142b8 4 194 71
 142bc 11 195 71
 142cd 5 198 71
 142d2 5 199 71
-FUNC 142e0 4d 0 _vcrt_freeptd(__vcrt_ptd*)
+FUNC 142e0 4d 0 __vcrt_freeptd(__vcrt_ptd*)
 142e0 9 175 71
 142e9 b 177 71
 142f4 13 183 71
 14307 7 187 71
 1430e 19 188 71
 14327 6 189 71
-FUNC 14340 19 0 _vcrt_getptd()
+FUNC 14340 19 0 __vcrt_getptd()
 14340 4 164 71
 14344 5 165 71
 14349 5 166 71
 1434e 5 172 71
 14353 6 168 71
-FUNC 14360 cb 0 _vcrt_getptd_noexit()
+FUNC 14360 cb 0 __vcrt_getptd_noexit()
 14360 f 95 71
 1436f 9 106 71
 14378 7 108 71
@@ -3678,7 +3678,7 @@ FUNC 14360 cb 0 _vcrt_getptd_noexit()
 143fb 6 139 71
 14401 1a 143 71
 1441b 10 144 71
-FUNC 14460 4d 0 _vcrt_getptd_noinit()
+FUNC 14460 4d 0 __vcrt_getptd_noinit()
 14460 a 148 71
 1446a 9 150 71
 14473 4 151 71
@@ -3687,7 +3687,7 @@ FUNC 14460 4d 0 _vcrt_getptd_noinit()
 1448a b 157 71
 14495 d 159 71
 144a2 b 160 71
-FUNC 144c0 51 0 _vcrt_initialize_ptd()
+FUNC 144c0 51 0 __vcrt_initialize_ptd()
 144c0 4 67 71
 144c4 12 68 71
 144d6 5 69 71
@@ -3695,14 +3695,14 @@ FUNC 144c0 51 0 _vcrt_initialize_ptd()
 14501 4 80 71
 14505 5 76 71
 1450a 7 81 71
-FUNC 14528 22 0 _vcrt_uninitialize_ptd()
+FUNC 14528 22 0 __vcrt_uninitialize_ptd()
 14528 4 84 71
 1452c b 85 71
 14537 5 87 71
 1453c 7 88 71
 14543 2 91 71
 14545 5 92 71
-FUNC 14554 46 0 _vcrt_initialize_locks()
+FUNC 14554 46 0 __vcrt_initialize_locks()
 14554 6 25 72
 1455a 2 26 72
 1455c 20 28 72
@@ -3711,9 +3711,9 @@ FUNC 14554 46 0 _vcrt_initialize_locks()
 1458d 5 30 72
 14592 2 31 72
 14594 6 38 72
-FUNC 145ac 19 0 _vcrt_lock(__vcrt_lock_id)
+FUNC 145ac 19 0 __vcrt_lock(__vcrt_lock_id)
 145ac 19 53 72
-FUNC 145cc 37 0 _vcrt_uninitialize_locks()
+FUNC 145cc 37 0 __vcrt_uninitialize_locks()
 145cc 6 41 72
 145d2 8 42 72
 145da 17 44 72
@@ -3721,7 +3721,7 @@ FUNC 145cc 37 0 _vcrt_uninitialize_locks()
 145f7 4 42 72
 145fb 2 48 72
 145fd 6 49 72
-FUNC 14610 19 0 _vcrt_unlock(__vcrt_lock_id)
+FUNC 14610 19 0 __vcrt_unlock(__vcrt_lock_id)
 14610 19 58 72
 FUNC 14630 8 0 __crt_fast_encoded_nullptr_t::operator<void> void *() const
 14630 7 536 22
@@ -3818,7 +3818,7 @@ FUNC 14de4 73 0 try_load_library_from_system_directory(wchar_t const* const)
 14e48 7 143 73
 14e4f 2 146 73
 14e51 6 147 73
-FUNC 14e74 45 0 _vcrt_FlsAlloc(void (*)(void*))
+FUNC 14e74 45 0 __vcrt_FlsAlloc(void (*)(void*))
 14e74 9 312 73
 14e7d 21 313 73
 14e9e 3 315 73
@@ -3826,21 +3826,21 @@ FUNC 14e74 45 0 _vcrt_FlsAlloc(void (*)(void*))
 14ea6 7 315 73
 14ead 5 319 73
 14eb2 7 318 73
-FUNC 14ecc 46 0 _vcrt_FlsFree(unsigned long)
+FUNC 14ecc 46 0 __vcrt_FlsFree(unsigned long)
 14ecc 8 322 73
 14ed4 26 323 73
 14efa 5 329 73
 14eff 7 325 73
 14f06 5 329 73
 14f0b 7 328 73
-FUNC 14f24 46 0 _vcrt_FlsGetValue(unsigned long)
+FUNC 14f24 46 0 __vcrt_FlsGetValue(unsigned long)
 14f24 8 332 73
 14f2c 26 333 73
 14f52 5 339 73
 14f57 7 335 73
 14f5e 5 339 73
 14f63 7 338 73
-FUNC 14f7c 51 0 _vcrt_FlsSetValue(unsigned long, void*)
+FUNC 14f7c 51 0 __vcrt_FlsSetValue(unsigned long, void*)
 14f7c d 342 73
 14f89 7 343 73
 14f90 2 342 73
@@ -3848,7 +3848,7 @@ FUNC 14f7c 51 0 _vcrt_FlsSetValue(unsigned long, void*)
 14fb4 8 345 73
 14fbc 6 348 73
 14fc2 b 349 73
-FUNC 14fe4 61 0 _vcrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsigned long, unsigned long)
+FUNC 14fe4 61 0 __vcrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsigned long, unsigned long)
 14fe4 12 356 73
 14ff6 7 357 73
 14ffd 2 356 73
@@ -3858,11 +3858,11 @@ FUNC 14fe4 61 0 _vcrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsign
 15024 b 359 73
 1502f 6 362 73
 15035 10 363 73
-FUNC 15060 2f 0 _vcrt_initialize_winapi_thunks()
+FUNC 15060 2f 0 __vcrt_initialize_winapi_thunks()
 15060 5 86 73
 15065 24 87 73
 15089 6 93 73
-FUNC 1509c 3e 0 _vcrt_uninitialize_winapi_thunks(bool)
+FUNC 1509c 3e 0 __vcrt_uninitialize_winapi_thunks(bool)
 1509c 9 98 73
 150a5 7 103 73
 150ac 8 105 73
@@ -3877,7 +3877,7 @@ FUNC 150ec 8 0 __crt_fast_encoded_nullptr_t::operator<void __cdecl(void)> void (
 FUNC 150f8 1e 0 __crt_fast_encode_pointer<void (__cdecl*)(void)>(void (* const)())
 150f8 1d 517 22
 15115 1 523 22
-FUNC 15120 f 0 _vcrt_initialize_pure_virtual_call_handler()
+FUNC 15120 f 0 __vcrt_initialize_pure_virtual_call_handler()
 15120 e 21 74
 1512e 1 22 74
 FUNC 15134 16 0 __crt_fast_decode_pointer<void (__cdecl*)(void)>(void (* const)())
@@ -3889,16 +3889,16 @@ FUNC 15150 7 0 __crt_interlocked_exchange_pointer<void __cdecl(void),void (__cde
 FUNC 15158 4 0 __crt_interlocked_read_pointer<void __cdecl(void)>(void (* const*)())
 15158 3 638 22
 1515b 1 642 22
-FUNC 1515c 1a 0 get_purecall_handler()
+FUNC 1515c 1a 0 _get_purecall_handler()
 1515c 19 44 75
 15175 1 45 75
-FUNC 1517c 2e 0 purecall()
+FUNC 1517c 2e 0 _purecall()
 1517c 4 19 75
 15180 19 20 75
 15199 5 21 75
 1519e 6 23 75
 151a4 6 29 75
-FUNC 151b8 37 0 set_purecall_handler(void (*)())
+FUNC 151b8 37 0 _set_purecall_handler(void (*)())
 151b8 7 36 75
 151bf 3 35 75
 151c2 2c 36 75
@@ -4171,14 +4171,14 @@ FUNC 16054 175 0 __FrameHandler4::TryBlockMap::setBuffer(__FrameHandler4::TryBlo
 16116 8c 897 60
 161a2 17 895 60
 161b9 10 899 60
-FUNC 16228 3a 0 CreateFrameInfo(FrameInfo*, void*)
+FUNC 16228 3a 0 _CreateFrameInfo(FrameInfo*, void*)
 16228 9 536 77
 16231 3 537 77
 16234 1c 538 77
 16250 9 539 77
 16259 3 540 77
 1625c 6 541 77
-FUNC 16270 53 0 FindAndUnlinkFrame(FrameInfo*)
+FUNC 16270 53 0 _FindAndUnlinkFrame(FrameInfo*)
 16270 d 552 77
 1627d b 553 77
 16288 b 555 77
@@ -4188,27 +4188,27 @@ FUNC 16270 53 0 FindAndUnlinkFrame(FrameInfo*)
 162a6 8 560 77
 162ae f 567 77
 162bd 6 553 77
-FUNC 162d8 12 0 GetImageBase()
+FUNC 162d8 12 0 _GetImageBase()
 162d8 4 29 77
 162dc 9 30 77
 162e5 5 31 77
-FUNC 162f0 12 0 GetThrowImageBase()
+FUNC 162f0 12 0 _GetThrowImageBase()
 162f0 4 45 77
 162f4 9 46 77
 162fd 5 47 77
-FUNC 16308 18 0 SetImageBase(unsigned long long)
+FUNC 16308 18 0 _SetImageBase(unsigned long long)
 16308 9 34 77
 16311 9 35 77
 1631a 6 36 77
-FUNC 16328 18 0 SetThrowImageBase(unsigned long long)
+FUNC 16328 18 0 _SetThrowImageBase(unsigned long long)
 16328 9 50 77
 16331 9 51 77
 1633a 6 52 77
-FUNC 16348 5 0 _CxxFrameHandler(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
+FUNC 16348 5 0 __CxxFrameHandler(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
 16348 5 318 77
-FUNC 16350 5 0 _CxxFrameHandler2(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
+FUNC 16350 5 0 __CxxFrameHandler2(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
 16350 5 308 77
-FUNC 16358 7d 0 _CxxFrameHandler3(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
+FUNC 16358 7d 0 __CxxFrameHandler3(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
 16358 12 260 77
 1636a b 263 77
 16375 d 265 77
@@ -4216,7 +4216,7 @@ FUNC 16358 7d 0 _CxxFrameHandler3(EHExceptionRecord*, unsigned long long, _CONTE
 1638f 9 269 77
 16398 2d 270 77
 163c5 10 272 77
-FUNC 163f4 a1 0 _CxxFrameHandler4(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
+FUNC 163f4 a1 0 __CxxFrameHandler4(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
 163f4 10 279 77
 16404 4 280 77
 16408 3 279 77
@@ -5411,15 +5411,15 @@ FUNC 1a978 39 0 __FrameHandler4::HandlerMap::setBuffer(unsigned int)
 FUNC 1a9c0 12 0 std::exception::what() const
 1a9c0 11 91 32
 1a9d1 1 92 32
-FUNC 1a9d8 5 0 _BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 1a9d8 5 0 __BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 1a9d8 5 2017 80
-FUNC 1a9e0 5 0 _BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 1a9e0 5 0 __BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 1a9e0 5 1906 80
-FUNC 1a9e8 5 0 _TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
+FUNC 1a9e8 5 0 __TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
 1a9e8 5 968 80
-FUNC 1a9f0 7 0 _vcrt_EncodePointer(void* const)
+FUNC 1a9f0 7 0 __vcrt_EncodePointer(void* const)
 1a9f0 7 332 11
-FUNC 1aa10 40 0 CallSettingFrame()
+FUNC 1aa10 40 0 _CallSettingFrame()
 1aa10 4 38 81
 1aa14 5 42 81
 1aa19 5 43 81
@@ -5436,7 +5436,7 @@ FUNC 1aa10 40 0 CallSettingFrame()
 1aa46 5 56 81
 1aa4b 4 57 81
 1aa4f 1 58 81
-FUNC 1aa60 47 0 CallSettingFrameEncoded()
+FUNC 1aa60 47 0 _CallSettingFrameEncoded()
 1aa60 4 88 81
 1aa64 5 92 81
 1aa69 5 93 81
@@ -5481,7 +5481,7 @@ FUNC 1ab30 1b 0 __crt_unique_heap_ptr<char,__crt_public_free_policy>::release()
 1ab39 8 395 22
 1ab41 4 396 22
 1ab45 6 397 22
-FUNC 1ab54 8d 0 _std_exception_copy(__std_exception_data const*, __std_exception_data*)
+FUNC 1ab54 8d 0 __std_exception_copy(__std_exception_data const*, __std_exception_data*)
 1ab54 15 17 82
 1ab69 14 20 82
 1ab7d d 27 82
@@ -5495,13 +5495,13 @@ FUNC 1ab54 8d 0 _std_exception_copy(__std_exception_data const*, __std_exception
 1abc1 6 22 82
 1abc7 4 23 82
 1abcb 16 38 82
-FUNC 1ac04 25 0 _std_exception_destroy(__std_exception_data*)
+FUNC 1ac04 25 0 __std_exception_destroy(__std_exception_data*)
 1ac04 6 43 82
 1ac0a 9 44 82
 1ac13 8 46 82
 1ac1b 8 50 82
 1ac23 6 51 82
-FUNC 1ac34 bf 0 CxxThrowException(void*, _s__ThrowInfo const*)
+FUNC 1ac34 bf 0 _CxxThrowException(void*, _s__ThrowInfo const*)
 1ac34 12 59 83
 1ac46 32 76 83
 1ac78 a 79 83
@@ -5542,7 +5542,7 @@ FUNC 1adfc 3 0 __crt_state_management::get_current_state_index()
 FUNC 1ae00 4 0 __crt_state_management::dual_state_global<void (__cdecl*)(wchar_t const *,wchar_t const *,wchar_t const *,unsigned int,unsigned __int64)>::value()
 1ae00 3 147 180
 1ae03 1 148 180
-FUNC 1ae04 15b 0 _acrt_call_reportfault(int, unsigned long, unsigned long)
+FUNC 1ae04 15b 0 __acrt_call_reportfault(int, unsigned long, unsigned long)
 1ae04 35 143 122
 1ae39 5 145 122
 1ae3e 5 147 122
@@ -5562,19 +5562,19 @@ FUNC 1ae04 15b 0 _acrt_call_reportfault(int, unsigned long, unsigned long)
 1af24 d 202 122
 1af31 7 204 122
 1af38 27 206 122
-FUNC 1afb8 8 0 _acrt_initialize_invalid_parameter_handler(void*)
+FUNC 1afb8 8 0 __acrt_initialize_invalid_parameter_handler(void*)
 1afb8 7 80 122
 1afbf 1 81 122
-FUNC 1afc4 17 0 get_invalid_parameter_handler()
+FUNC 1afc4 17 0 _get_invalid_parameter_handler()
 1afc4 16 273 122
 1afda 1 274 122
-FUNC 1afe0 1a 0 get_thread_local_invalid_parameter_handler()
+FUNC 1afe0 1a 0 _get_thread_local_invalid_parameter_handler()
 1afe0 4 288 122
 1afe4 5 289 122
 1afe9 5 290 122
 1afee 7 295 122
 1aff5 5 296 122
-FUNC 1b000 ae 0 invalid_parameter(wchar_t const* const, wchar_t const* const, wchar_t const* const, const unsigned int, const unsigned long long)
+FUNC 1b000 ae 0 _invalid_parameter(wchar_t const* const, wchar_t const* const, wchar_t const* const, const unsigned int, const unsigned long long)
 1b000 20 97 122
 1b020 5 98 122
 1b025 11 99 122
@@ -5589,15 +5589,15 @@ FUNC 1b000 ae 0 invalid_parameter(wchar_t const* const, wchar_t const* const, wc
 1b08c d 108 122
 1b099 2 109 122
 1b09b 13 112 122
-FUNC 1b0dc 1e 0 invalid_parameter_noinfo()
+FUNC 1b0dc 1e 0 _invalid_parameter_noinfo()
 1b0dc 4 116 122
 1b0e0 15 117 122
 1b0f5 5 118 122
-FUNC 1b104 2f 0 invalid_parameter_noinfo_noreturn()
+FUNC 1b104 2f 0 _invalid_parameter_noinfo_noreturn()
 1b104 4 124 122
 1b108 15 125 122
 1b11d 16 126 122
-FUNC 1b140 47 0 invoke_watson(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
+FUNC 1b140 47 0 _invoke_watson(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
 1b140 4 215 122
 1b144 f 222 122
 1b153 7 224 122
@@ -5605,7 +5605,7 @@ FUNC 1b140 47 0 invoke_watson(wchar_t const*, wchar_t const*, wchar_t const*, un
 1b16e e 233 122
 1b17c 4 234 122
 1b180 7 233 122
-FUNC 1b198 34 0 set_invalid_parameter_handler(void (*)(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long))
+FUNC 1b198 34 0 _set_invalid_parameter_handler(void (*)(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long))
 1b198 a 265 122
 1b1a2 b 267 122
 1b1ad a 266 122
@@ -5615,20 +5615,20 @@ FUNC 1b198 34 0 set_invalid_parameter_handler(void (*)(wchar_t const*, wchar_t c
 1b1c1 3 266 122
 1b1c4 7 267 122
 1b1cb 1 269 122
-FUNC 1b1dc 25 0 set_thread_local_invalid_parameter_handler(void (*)(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long))
+FUNC 1b1dc 25 0 _set_thread_local_invalid_parameter_handler(void (*)(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long))
 1b1dc 9 279 122
 1b1e5 8 280 122
 1b1ed 7 282 122
 1b1f4 7 283 122
 1b1fb 6 285 122
-FUNC 1b20c 64 0 initterm(void (**)(), void (**)())
+FUNC 1b20c 64 0 _initterm(void (**)(), void (**)())
 1b20c 14 15 255
 1b220 21 16 255
 1b241 8 18 255
 1b249 6 21 255
 1b24f c 16 255
 1b25b 15 23 255
-FUNC 1b28c 3d 0 initterm_e(int (**)(), int (**)())
+FUNC 1b28c 3d 0 _initterm_e(int (**)(), int (**)())
 1b28c 10 34 255
 1b29c 3 35 255
 1b29f a 37 255
@@ -5649,12 +5649,12 @@ FUNC 1b2f0 1d 0 xcptlookup(const unsigned long, __crt_signal_action_t* const)
 1b308 1 70 257
 1b309 3 66 257
 1b30c 1 70 257
-FUNC 1b314 13 0 seh_filter_dll(unsigned long, _EXCEPTION_POINTERS*)
+FUNC 1b314 13 0 _seh_filter_dll(unsigned long, _EXCEPTION_POINTERS*)
 1b314 9 80 257
 1b31d 2 81 257
 1b31f 1 84 257
 1b320 7 83 257
-FUNC 1b32c 182 0 seh_filter_exe(unsigned long, _EXCEPTION_POINTERS*)
+FUNC 1b32c 182 0 _seh_filter_exe(unsigned long, _EXCEPTION_POINTERS*)
 1b32c 19 124 257
 1b345 5 127 257
 1b34a f 128 257
@@ -5825,21 +5825,21 @@ FUNC 1b9a4 5b 0 try_cor_exit_process(const unsigned int)
 1b9dc 5 94 275
 1b9e1 8 97 275
 1b9e9 16 98 275
-FUNC 1ba18 c 0 Exit(int)
+FUNC 1ba18 c 0 _Exit(int)
 1ba18 c 303 275
-FUNC 1ba28 8 0 _acrt_initialize_thread_local_exit_callback(void*)
+FUNC 1ba28 8 0 __acrt_initialize_thread_local_exit_callback(void*)
 1ba28 7 163 275
 1ba2f 1 164 275
-FUNC 1ba34 10 0 c_exit()
+FUNC 1ba34 10 0 _c_exit()
 1ba34 10 318 275
-FUNC 1ba48 d 0 cexit()
+FUNC 1ba48 d 0 _cexit()
 1ba48 d 313 275
-FUNC 1ba58 c 0 exit(int)
+FUNC 1ba58 c 0 _exit(int)
 1ba58 c 298 275
-FUNC 1ba68 7 0 is_c_termination_complete()
+FUNC 1ba68 7 0 _is_c_termination_complete()
 1ba68 6 286 275
 1ba6e 1 287 275
-FUNC 1ba70 3c 0 register_thread_local_exe_atexit_callback(void (*)(void*, unsigned long, void*))
+FUNC 1ba70 3c 0 _register_thread_local_exe_atexit_callback(void (*)(void*, unsigned long, void*))
 1ba70 4 169 275
 1ba74 7 171 275
 1ba7b 3 169 275
@@ -6154,7 +6154,7 @@ FUNC 1c504 16 0 should_copy_another_character(const char)
 FUNC 1c520 3 0 should_copy_another_character(wchar_t)
 1c520 2 91 321
 1c522 1 92 321
-FUNC 1c524 5d 0 _acrt_allocate_buffer_for_argv(unsigned long long, unsigned long long, unsigned long long)
+FUNC 1c524 5d 0 __acrt_allocate_buffer_for_argv(unsigned long long, unsigned long long, unsigned long long)
 1c524 6 271 321
 1c52a 12 272 321
 1c53c e 275 321
@@ -6168,21 +6168,21 @@ FUNC 1c524 5d 0 _acrt_allocate_buffer_for_argv(unsigned long long, unsigned long
 1c56f a 289 321
 1c579 2 282 321
 1c57b 6 290 321
-FUNC 1c598 186 0 configure_narrow_argv(_crt_argv_mode)
+FUNC 1c598 186 0 _configure_narrow_argv(_crt_argv_mode)
 1c598 13 397 321
 1c5ab 2 398 321
 1c5ad 3 397 321
 1c5b0 15b 398 321
 1c70b 13 399 321
-FUNC 1c780 182 0 configure_wide_argv(_crt_argv_mode)
+FUNC 1c780 182 0 _configure_wide_argv(_crt_argv_mode)
 1c780 13 402 321
 1c793 2 403 321
 1c795 3 402 321
 1c798 157 403 321
 1c8ef 13 404 321
-FUNC 1c964 8 0 set_pgmptr(char*)
+FUNC 1c964 8 0 _set_pgmptr(char*)
 1c964 8 229 201
-FUNC 1c970 8 0 set_wpgmptr(wchar_t*)
+FUNC 1c970 8 0 _set_wpgmptr(wchar_t*)
 1c970 8 230 201
 FUNC 1c97c 8 0 __crt_internal_free_policy::operator()<wchar_t>(wchar_t const* const) const
 1c97c 8 335 99
@@ -6460,19 +6460,19 @@ FUNC 1d550 4 0 __crt_state_management::dual_state_global<char * *>::value()
 FUNC 1d554 4 0 __crt_state_management::dual_state_global<wchar_t * *>::value()
 1d554 3 147 180
 1d557 1 148 180
-FUNC 1d558 3b 0 _dcrt_get_or_create_narrow_environment_nolock()
+FUNC 1d558 3b 0 __dcrt_get_or_create_narrow_environment_nolock()
 1d558 4 307 329
 1d55c 15 308 329
 1d571 4 309 329
 1d575 19 308 329
 1d58e 5 309 329
-FUNC 1d5a4 3b 0 _dcrt_get_or_create_wide_environment_nolock()
+FUNC 1d5a4 3b 0 __dcrt_get_or_create_wide_environment_nolock()
 1d5a4 4 312 329
 1d5a8 15 313 329
 1d5bd 4 314 329
 1d5c1 19 313 329
 1d5da 5 314 329
-FUNC 1d5f0 38 0 _dcrt_uninitialize_environments_nolock()
+FUNC 1d5f0 38 0 __dcrt_uninitialize_environments_nolock()
 1d5f0 4 217 329
 1d5f4 c 218 329
 1d600 c 219 329
@@ -6480,23 +6480,23 @@ FUNC 1d5f0 38 0 _dcrt_uninitialize_environments_nolock()
 1d618 7 222 329
 1d61f 4 223 329
 1d623 5 222 329
-FUNC 1d638 8 0 _p__environ()
+FUNC 1d638 8 0 __p__environ()
 1d638 8 30 329
-FUNC 1d644 8 0 _p__wenviron()
+FUNC 1d644 8 0 __p__wenviron()
 1d644 8 31 329
-FUNC 1d650 4e 0 get_initial_narrow_environment()
+FUNC 1d650 4e 0 _get_initial_narrow_environment()
 1d650 4 329 329
 1d654 45 330 329
 1d699 5 331 329
-FUNC 1d6b4 4e 0 get_initial_wide_environment()
+FUNC 1d6b4 4e 0 _get_initial_wide_environment()
 1d6b4 4 334 329
 1d6b8 45 335 329
 1d6fd 5 336 329
-FUNC 1d718 5 0 initialize_narrow_environment()
+FUNC 1d718 5 0 _initialize_narrow_environment()
 1d718 5 194 329
-FUNC 1d720 5 0 initialize_wide_environment()
+FUNC 1d720 5 0 _initialize_wide_environment()
 1d720 5 199 329
-FUNC 1d728 31 0 invoke_watson_if_error(int, wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
+FUNC 1d728 31 0 _invoke_watson_if_error(int, wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
 1d728 4 1586 201
 1d72c 6 1592 201
 1d732 27 1591 201
@@ -6637,15 +6637,15 @@ FUNC 1dcbc 1b 0 __crt_unique_heap_ptr<void (__cdecl*)(void),__crt_internal_free_
 1dcc5 8 395 99
 1dccd 4 396 99
 1dcd1 6 397 99
-FUNC 1dce0 f 0 crt_at_quick_exit(void (*)())
+FUNC 1dce0 f 0 _crt_at_quick_exit(void (*)())
 1dce0 f 48 333
-FUNC 1dcf4 f 0 crt_atexit(void (*)())
+FUNC 1dcf4 f 0 _crt_atexit(void (*)())
 1dcf4 f 43 333
-FUNC 1dd08 3a 0 execute_onexit_table(_onexit_table_t*)
+FUNC 1dd08 3a 0 _execute_onexit_table(_onexit_table_t*)
 1dd08 b 159 333
 1dd13 2a 160 333
 1dd3d 5 231 333
-FUNC 1dd50 27 0 initialize_onexit_table(_onexit_table_t*)
+FUNC 1dd50 27 0 _initialize_onexit_table(_onexit_table_t*)
 1dd50 5 55 333
 1dd55 3 57 333
 1dd58 1 75 333
@@ -6655,7 +6655,7 @@ FUNC 1dd50 27 0 initialize_onexit_table(_onexit_table_t*)
 1dd6c 4 71 333
 1dd70 4 72 333
 1dd74 3 75 333
-FUNC 1dd80 48 0 register_onexit_function(_onexit_table_t*, int (*)())
+FUNC 1dd80 48 0 _register_onexit_function(_onexit_table_t*, int (*)())
 1dd80 12 83 333
 1dd92 30 84 333
 1ddc2 6 149 333
@@ -6734,18 +6734,18 @@ FUNC 1e04c 27 0 __crt_state_management::dual_state_global<__crt_locale_data *>::
 1e04c 5 156 180
 1e051 1c 157 180
 1e06d 6 161 180
-FUNC 1e07c 13 0 _acrt_initialize()
+FUNC 1e07c 13 0 __acrt_initialize()
 1e07c 13 287 336
-FUNC 1e094 14 0 _acrt_thread_attach()
+FUNC 1e094 14 0 __acrt_thread_attach()
 1e094 4 328 336
 1e098 b 332 336
 1e0a3 5 336 336
-FUNC 1e0b0 10 0 _acrt_thread_detach()
+FUNC 1e0b0 10 0 __acrt_thread_detach()
 1e0b0 4 339 336
 1e0b4 5 341 336
 1e0b9 2 342 336
 1e0bb 5 343 336
-FUNC 1e0c4 35 0 _acrt_uninitialize(bool)
+FUNC 1e0c4 35 0 __acrt_uninitialize(bool)
 1e0c4 4 294 336
 1e0c8 4 300 336
 1e0cc a 302 336
@@ -6755,7 +6755,7 @@ FUNC 1e0c4 35 0 _acrt_uninitialize(bool)
 1e0e2 e 310 336
 1e0f0 4 314 336
 1e0f4 5 310 336
-FUNC 1e108 10 0 _acrt_uninitialize_critical(bool)
+FUNC 1e108 10 0 __acrt_uninitialize_critical(bool)
 1e108 4 317 336
 1e10c 5 318 336
 1e111 2 324 336
@@ -6763,7 +6763,7 @@ FUNC 1e108 10 0 _acrt_uninitialize_critical(bool)
 FUNC 1e11c 12 0 get_terminate_or_default(__acrt_ptd const* const)
 1e11c 11 17 344
 1e12d 1 18 344
-FUNC 1e134 22 0 get_terminate()
+FUNC 1e134 22 0 _get_terminate()
 1e134 4 21 344
 1e138 19 22 344
 1e151 5 23 344
@@ -14622,93 +14622,93 @@ FUNC 3b8fc 103 0 __crt_stdio_output::output_adapter_common<wchar_t,__crt_stdio_o
 3b9d0 2 94 353
 3b9d2 3 98 353
 3b9d5 2a 105 353
-FUNC 3ba40 21 0 _acrt_isleadbyte_l_noupdate(const int, __crt_locale_pointers* const)
+FUNC 3ba40 21 0 __acrt_isleadbyte_l_noupdate(const int, __crt_locale_pointers* const)
 3ba40 1d 810 201
 3ba5d 1 811 201
 3ba5e 2 810 201
 3ba60 1 811 201
-FUNC 3ba6c b 0 _acrt_locale_changed()
+FUNC 3ba6c b 0 __acrt_locale_changed()
 3ba6c a 746 201
 3ba76 1 747 201
-FUNC 3ba7c 18 0 _acrt_locale_get_ctype_array_value(unsigned short const* const, const int, const int)
+FUNC 3ba7c 18 0 __acrt_locale_get_ctype_array_value(unsigned short const* const, const int, const int)
 3ba7c a 91 218
 3ba86 a 93 218
 3ba90 1 97 218
 3ba91 2 96 218
 3ba93 1 97 218
-FUNC 3ba9c 8b 0 _stdio_common_vfprintf(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
+FUNC 3ba9c 8b 0 __stdio_common_vfprintf(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
 3ba9c 9 60 350
 3baa5 1d 61 350
 3bac2 15 62 350
 3bad7 4a 61 350
 3bb21 6 62 350
-FUNC 3bb4c 8b 0 _stdio_common_vfprintf_p(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
+FUNC 3bb4c 8b 0 __stdio_common_vfprintf_p(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
 3bb4c 9 104 350
 3bb55 1d 105 350
 3bb72 15 106 350
 3bb87 4a 105 350
 3bbd1 6 106 350
-FUNC 3bbfc 8b 0 _stdio_common_vfprintf_s(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
+FUNC 3bbfc 8b 0 __stdio_common_vfprintf_s(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
 3bbfc 9 82 350
 3bc05 1d 83 350
 3bc22 15 84 350
 3bc37 4a 83 350
 3bc81 6 84 350
-FUNC 3bcac 8b 0 _stdio_common_vfwprintf(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3bcac 8b 0 __stdio_common_vfwprintf(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
 3bcac 9 71 350
 3bcb5 1d 72 350
 3bcd2 15 73 350
 3bce7 4a 72 350
 3bd31 6 73 350
-FUNC 3bd5c 8b 0 _stdio_common_vfwprintf_p(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3bd5c 8b 0 __stdio_common_vfwprintf_p(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
 3bd5c 9 115 350
 3bd65 1d 116 350
 3bd82 15 117 350
 3bd97 4a 116 350
 3bde1 6 117 350
-FUNC 3be0c 8b 0 _stdio_common_vfwprintf_s(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3be0c 8b 0 __stdio_common_vfwprintf_s(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
 3be0c 9 93 350
 3be15 1d 94 350
 3be32 15 95 350
 3be47 4a 94 350
 3be91 6 95 350
-FUNC 3bebc 134 0 _stdio_common_vsnprintf_s(unsigned long long, char*, unsigned long long, unsigned long long, char const*, __crt_locale_pointers*, char*)
+FUNC 3bebc 134 0 __stdio_common_vsnprintf_s(unsigned long long, char*, unsigned long long, unsigned long long, char const*, __crt_locale_pointers*, char*)
 3bebc 18 390 350
 3bed4 6 391 350
 3beda c 390 350
 3bee6 ef 391 350
 3bfd5 1b 392 350
-FUNC 3c040 143 0 _stdio_common_vsnwprintf_s(unsigned long long, wchar_t*, unsigned long long, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3c040 143 0 __stdio_common_vsnwprintf_s(unsigned long long, wchar_t*, unsigned long long, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
 3c040 1d 403 350
 3c05d 3 404 350
 3c060 c 403 350
 3c06c f6 404 350
 3c162 21 405 350
-FUNC 3c1d4 5 0 _stdio_common_vsprintf(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
+FUNC 3c1d4 5 0 __stdio_common_vsprintf(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
 3c1d4 5 239 350
-FUNC 3c1dc 5 0 _stdio_common_vsprintf_p(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
+FUNC 3c1dc 5 0 __stdio_common_vsprintf_p(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
 3c1dc 5 416 350
-FUNC 3c1e4 63 0 _stdio_common_vsprintf_s(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
+FUNC 3c1e4 63 0 __stdio_common_vsprintf_s(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
 3c1e4 9 295 350
 3c1ed 41 296 350
 3c22e 19 297 350
-FUNC 3c260 5 0 _stdio_common_vswprintf(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3c260 5 0 __stdio_common_vswprintf(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
 3c260 5 251 350
-FUNC 3c268 5 0 _stdio_common_vswprintf_p(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3c268 5 0 __stdio_common_vswprintf_p(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
 3c268 5 428 350
-FUNC 3c270 6e 0 _stdio_common_vswprintf_s(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3c270 6e 0 __stdio_common_vswprintf_s(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
 3c270 a 307 350
 3c27a 2 308 350
 3c27c 3 307 350
 3c27f 41 308 350
 3c2c0 1e 309 350
-FUNC 3c2fc 13 0 ctype_fast_check_internal(const unsigned char, const int, __crt_locale_pointers* const)
+FUNC 3c2fc 13 0 _ctype_fast_check_internal(const unsigned char, const int, __crt_locale_pointers* const)
 3c2fc 12 1549 201
 3c30e 1 1550 201
-FUNC 3c314 14 0 isdigit_fast_internal(const unsigned char, __crt_locale_pointers* const)
+FUNC 3c314 14 0 _isdigit_fast_internal(const unsigned char, __crt_locale_pointers* const)
 3c314 13 1557 201
 3c327 1 1558 201
-FUNC 3c330 11 0 tolower_fast_internal(const unsigned char, __crt_locale_pointers* const)
+FUNC 3c330 11 0 _tolower_fast_internal(const unsigned char, __crt_locale_pointers* const)
 3c330 10 1479 201
 3c340 1 1480 201
 FUNC 3c348 24 0 __crt_strtox::is_overflow_condition<unsigned long>(const unsigned int, const unsigned long)
@@ -15083,57 +15083,57 @@ FUNC 3e224 1a0 0 __crt_strtox::wide_character_to_digit(const wchar_t)
 3e3b2 e 85 357
 3e3c0 3 88 357
 3e3c3 1 89 357
-FUNC 3e42c 4 0 _acrt_get_locale_data_prefix(void const* const)
+FUNC 3e42c 4 0 __acrt_get_locale_data_prefix(void const* const)
 3e42c 3 206 218
 3e42f 1 207 218
-FUNC 3e430 19 0 _ascii_iswalpha(const int)
+FUNC 3e430 19 0 __ascii_iswalpha(const int)
 3e430 12 167 218
 3e442 1 168 218
 3e443 5 167 218
 3e448 1 168 218
-FUNC 3e450 e 0 _ascii_toupper(const int)
+FUNC 3e450 e 0 __ascii_toupper(const int)
 3e450 6 158 218
 3e456 5 160 218
 3e45b 2 162 218
 3e45d 1 163 218
-FUNC 3e464 d 0 _ascii_towupper(const int)
+FUNC 3e464 d 0 __ascii_towupper(const int)
 3e464 c 182 218
 3e470 1 183 218
-FUNC 3e474 29 0 atoi64(char const*)
+FUNC 3e474 29 0 _atoi64(char const*)
 3e474 4 51 356
 3e478 20 52 356
 3e498 5 53 356
-FUNC 3e4a8 2d 0 atoi64_l(char const*, __crt_locale_pointers*)
+FUNC 3e4a8 2d 0 _atoi64_l(char const*, __crt_locale_pointers*)
 3e4a8 4 56 356
 3e4ac 6 57 356
 3e4b2 3 56 356
 3e4b5 1b 57 356
 3e4d0 5 58 356
-FUNC 3e4e0 2d 0 atoi_l(char const*, __crt_locale_pointers*)
+FUNC 3e4e0 2d 0 _atoi_l(char const*, __crt_locale_pointers*)
 3e4e0 4 26 356
 3e4e4 6 27 356
 3e4ea 3 26 356
 3e4ed 1b 27 356
 3e508 5 28 356
-FUNC 3e518 2d 0 atol_l(char const*, __crt_locale_pointers*)
+FUNC 3e518 2d 0 _atol_l(char const*, __crt_locale_pointers*)
 3e518 4 36 356
 3e51c 6 37 356
 3e522 3 36 356
 3e525 1b 37 356
 3e540 5 38 356
-FUNC 3e550 2d 0 atoll_l(char const*, __crt_locale_pointers*)
+FUNC 3e550 2d 0 _atoll_l(char const*, __crt_locale_pointers*)
 3e550 4 46 356
 3e554 6 47 356
 3e55a 3 46 356
 3e55d 1b 47 356
 3e578 5 48 356
-FUNC 3e588 61 0 chvalidchk_l(const int, const int, __crt_locale_pointers* const)
+FUNC 3e588 61 0 _chvalidchk_l(const int, const int, __crt_locale_pointers* const)
 3e588 17 218 218
 3e59f c 222 218
 3e5ab 14 224 218
 3e5bf 11 227 218
 3e5d0 19 229 218
-FUNC 3e604 76 0 ischartype_l(const int, const int, __crt_locale_pointers* const)
+FUNC 3e604 76 0 _ischartype_l(const int, const int, __crt_locale_pointers* const)
 3e604 17 239 218
 3e61b c 240 218
 3e627 b 241 218
@@ -15143,41 +15143,41 @@ FUNC 3e604 76 0 ischartype_l(const int, const int, __crt_locale_pointers* const)
 3e64c 4 251 218
 3e650 15 254 218
 3e665 15 255 218
-FUNC 3e698 29 0 wtoi(wchar_t const*)
+FUNC 3e698 29 0 _wtoi(wchar_t const*)
 3e698 4 68 356
 3e69c 20 70 356
 3e6bc 5 71 356
-FUNC 3e6cc 29 0 wtoi64(wchar_t const*)
+FUNC 3e6cc 29 0 _wtoi64(wchar_t const*)
 3e6cc 4 99 356
 3e6d0 20 100 356
 3e6f0 5 101 356
-FUNC 3e700 2d 0 wtoi64_l(wchar_t const*, __crt_locale_pointers*)
+FUNC 3e700 2d 0 _wtoi64_l(wchar_t const*, __crt_locale_pointers*)
 3e700 4 104 356
 3e704 6 105 356
 3e70a 3 104 356
 3e70d 1b 105 356
 3e728 5 106 356
-FUNC 3e738 2d 0 wtoi_l(wchar_t const*, __crt_locale_pointers*)
+FUNC 3e738 2d 0 _wtoi_l(wchar_t const*, __crt_locale_pointers*)
 3e738 4 74 356
 3e73c 6 75 356
 3e742 3 74 356
 3e745 1b 75 356
 3e760 5 76 356
-FUNC 3e770 29 0 wtol(wchar_t const*)
+FUNC 3e770 29 0 _wtol(wchar_t const*)
 3e770 4 79 356
 3e774 20 80 356
 3e794 5 81 356
-FUNC 3e7a4 2d 0 wtol_l(wchar_t const*, __crt_locale_pointers*)
+FUNC 3e7a4 2d 0 _wtol_l(wchar_t const*, __crt_locale_pointers*)
 3e7a4 4 84 356
 3e7a8 6 85 356
 3e7ae 3 84 356
 3e7b1 1b 85 356
 3e7cc 5 86 356
-FUNC 3e7dc 29 0 wtoll(wchar_t const*)
+FUNC 3e7dc 29 0 _wtoll(wchar_t const*)
 3e7dc 4 89 356
 3e7e0 20 90 356
 3e800 5 91 356
-FUNC 3e810 2d 0 wtoll_l(wchar_t const*, __crt_locale_pointers*)
+FUNC 3e810 2d 0 _wtoll_l(wchar_t const*, __crt_locale_pointers*)
 3e810 4 94 356
 3e814 6 95 356
 3e81a 3 94 356
@@ -15233,7 +15233,7 @@ FUNC 3e900 7d 0 strncmp()
 3e975 3 120 359
 3e978 4 121 359
 3e97c 1 122 359
-FUNC 3e9a0 1c 0 set_abort_behavior(unsigned int, unsigned int)
+FUNC 3e9a0 1c 0 _set_abort_behavior(unsigned int, unsigned int)
 3e9a0 6 111 363
 3e9a6 15 112 363
 3e9bb 1 114 363
@@ -15486,19 +15486,19 @@ FUNC 3f574 20 0 try_get_ptd_head()
 FUNC 3f59c 4 0 __crt_state_management::dual_state_global<__crt_locale_data *>::value()
 3f59c 3 147 180
 3f59f 1 148 180
-FUNC 3f5a0 41 0 _acrt_freeptd()
+FUNC 3f5a0 41 0 __acrt_freeptd()
 3f5a0 6 306 366
 3f5a6 18 307 366
 3f5be d 313 366
 3f5cb 10 314 366
 3f5db 6 315 366
-FUNC 3f5f4 d4 0 _acrt_getptd()
+FUNC 3f5f4 d4 0 __acrt_getptd()
 3f5f4 f 282 366
 3f603 9c 283 366
 3f69f 13 284 366
 3f6b2 10 290 366
 3f6c2 6 286 366
-FUNC 3f700 a7 0 _acrt_getptd_head()
+FUNC 3f700 a7 0 __acrt_getptd_head()
 3f700 6 293 366
 3f706 59 294 366
 3f75f 7 297 366
@@ -15507,11 +15507,11 @@ FUNC 3f700 a7 0 _acrt_getptd_head()
 3f798 3 300 366
 3f79b 6 301 366
 3f7a1 6 297 366
-FUNC 3f7d0 cc 0 _acrt_getptd_noexit()
+FUNC 3f7d0 cc 0 __acrt_getptd_noexit()
 3f7d0 f 277 366
 3f7df a4 278 366
 3f883 19 279 366
-FUNC 3f8d0 39 0 _acrt_initialize_ptd()
+FUNC 3f8d0 39 0 __acrt_initialize_ptd()
 3f8d0 4 28 366
 3f8d4 12 29 366
 3f8e6 5 30 366
@@ -15521,26 +15521,26 @@ FUNC 3f8d0 39 0 _acrt_initialize_ptd()
 3f900 2 38 366
 3f902 2 41 366
 3f904 5 42 366
-FUNC 3f918 22 0 _acrt_uninitialize_ptd(bool)
+FUNC 3f918 22 0 __acrt_uninitialize_ptd(bool)
 3f918 4 45 366
 3f91c b 46 366
 3f927 5 48 366
 3f92c 7 49 366
 3f933 2 52 366
 3f935 5 53 366
-FUNC 3f944 7 0 _threadhandle()
+FUNC 3f944 7 0 __threadhandle()
 3f944 7 327 366
-FUNC 3f94c 7 0 _threadid()
+FUNC 3f94c 7 0 __threadid()
 3f94c 7 322 366
 FUNC 3f954 8 0 select_heap(void* const)
 3f954 7 84 367
 3f95b 1 85 367
-FUNC 3f960 3d 0 free_base(void*)
+FUNC 3f960 3d 0 _free_base(void*)
 3f960 a 100 367
 3f96a 16 105 367
 3f980 17 107 367
 3f997 6 109 367
-FUNC 3f9ac 48 0 _acrt_initialize_locks()
+FUNC 3f9ac 48 0 __acrt_initialize_locks()
 3f9ac 6 26 368
 3f9b2 2 27 368
 3f9b4 20 29 368
@@ -15549,9 +15549,9 @@ FUNC 3f9ac 48 0 _acrt_initialize_locks()
 3f9e5 7 31 368
 3f9ec 2 32 368
 3f9ee 6 39 368
-FUNC 3fa08 19 0 _acrt_lock(__acrt_lock_id)
+FUNC 3fa08 19 0 __acrt_lock(__acrt_lock_id)
 3fa08 19 54 368
-FUNC 3fa28 37 0 _acrt_uninitialize_locks(bool)
+FUNC 3fa28 37 0 __acrt_uninitialize_locks(bool)
 3fa28 6 42 368
 3fa2e 8 43 368
 3fa36 17 45 368
@@ -15559,15 +15559,15 @@ FUNC 3fa28 37 0 _acrt_uninitialize_locks(bool)
 3fa53 4 43 368
 3fa57 2 49 368
 3fa59 6 50 368
-FUNC 3fa6c 19 0 _acrt_unlock(__acrt_lock_id)
+FUNC 3fa6c 19 0 __acrt_unlock(__acrt_lock_id)
 3fa6c 19 59 368
-FUNC 3fa8c 1b 0 lock_locales()
+FUNC 3fa8c 1b 0 _lock_locales()
 3fa8c 4 63 368
 3fa90 5 64 368
 3fa95 7 65 368
 3fa9c 4 66 368
 3faa0 7 65 368
-FUNC 3fab0 e 0 unlock_locales()
+FUNC 3fab0 e 0 _unlock_locales()
 3fab0 e 70 368
 FUNC 3fac4 4c 0 get_cached_win_policy<`__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties>(AppPolicyThreadInitializationType)
 3fac4 6 31 369
@@ -15632,23 +15632,23 @@ FUNC 3fc9c 27 0 `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy
 3fcbc 1 176 369
 3fcbd 5 167 369
 3fcc2 1 176 369
-FUNC 3fccc 51 0 _acrt_get_begin_thread_init_policy()
+FUNC 3fccc 51 0 __acrt_get_begin_thread_init_policy()
 3fccc 6 89 369
 3fcd2 45 115 369
 3fd17 6 116 369
-FUNC 3fd34 51 0 _acrt_get_developer_information_policy()
+FUNC 3fd34 51 0 __acrt_get_developer_information_policy()
 3fd34 6 120 369
 3fd3a 45 146 369
 3fd7f 6 147 369
-FUNC 3fd9c 3c 0 _acrt_get_process_end_policy()
+FUNC 3fd9c 3c 0 __acrt_get_process_end_policy()
 3fd9c 6 60 369
 3fda2 30 84 369
 3fdd2 6 85 369
-FUNC 3fde8 6c 0 _acrt_get_windowing_model_policy()
+FUNC 3fde8 6c 0 __acrt_get_windowing_model_policy()
 3fde8 6 151 369
 3fdee 60 184 369
 3fe4e 6 185 369
-FUNC 3fe70 45 0 _acrt_errno_from_os_error(unsigned long)
+FUNC 3fe70 45 0 __acrt_errno_from_os_error(unsigned long)
 3fe70 10 98 370
 3fe80 4 100 370
 3fe84 a 98 370
@@ -15659,38 +15659,38 @@ FUNC 3fe70 45 0 _acrt_errno_from_os_error(unsigned long)
 3feae 1 119 370
 3feaf 5 101 370
 3feb4 1 119 370
-FUNC 3fec8 4e 0 _acrt_errno_map_os_error(unsigned long)
+FUNC 3fec8 4e 0 __acrt_errno_map_os_error(unsigned long)
 3fec8 c 90 370
 3fed4 19 91 370
 3feed 1e 92 370
 3ff0b b 93 370
-FUNC 3ff2c 20 0 _doserrno()
+FUNC 3ff2c 20 0 __doserrno()
 3ff2c 4 182 370
 3ff30 5 183 370
 3ff35 5 184 370
 3ff3a 9 185 370
 3ff43 4 187 370
 3ff47 5 188 370
-FUNC 3ff54 20 0 errno()
+FUNC 3ff54 20 0 _errno()
 3ff54 4 173 370
 3ff58 5 174 370
 3ff5d 5 175 370
 3ff62 9 176 370
 3ff6b 4 178 370
 3ff6f 5 179 370
-FUNC 3ff7c 3b 0 get_doserrno(unsigned long*)
+FUNC 3ff7c 3b 0 _get_doserrno(unsigned long*)
 3ff7c 9 157 370
 3ff85 f 158 370
 3ff94 1b 161 370
 3ffaf 2 162 370
 3ffb1 6 163 370
-FUNC 3ffc8 3b 0 get_errno(int*)
+FUNC 3ffc8 3b 0 _get_errno(int*)
 3ffc8 9 135 370
 3ffd1 f 136 370
 3ffe0 1b 139 370
 3fffb 2 140 370
 3fffd 6 141 370
-FUNC 40014 3a 0 set_doserrno(unsigned long)
+FUNC 40014 3a 0 _set_doserrno(unsigned long)
 40014 8 147 370
 4001c 5 148 370
 40021 5 149 370
@@ -15698,7 +15698,7 @@ FUNC 40014 3a 0 set_doserrno(unsigned long)
 4002d 19 152 370
 40046 2 153 370
 40048 6 154 370
-FUNC 4005c 3a 0 set_errno(int)
+FUNC 4005c 3a 0 _set_errno(int)
 4005c 8 125 370
 40064 5 126 370
 40069 5 127 370
@@ -15706,7 +15706,7 @@ FUNC 4005c 3a 0 set_errno(int)
 40075 19 130 370
 4008e 2 131 370
 40090 6 132 370
-FUNC 400a4 75 0 calloc_base(unsigned long long, unsigned long long)
+FUNC 400a4 75 0 _calloc_base(unsigned long long, unsigned long long)
 400a4 c 23 371
 400b0 13 25 371
 400c3 4 28 371
@@ -16283,9 +16283,9 @@ FUNC 4263c 5 0 strpbrk(char* const, char const* const)
 4263c 5 512 237
 FUNC 42644 5 0 wcspbrk(wchar_t*, wchar_t const*)
 42644 5 547 185
-FUNC 4264c 5 0 _acrt_expand_narrow_argv_wildcards(char**, char***)
+FUNC 4264c 5 0 __acrt_expand_narrow_argv_wildcards(char**, char***)
 4264c 5 385 375
-FUNC 42654 5 0 _acrt_expand_wide_argv_wildcards(wchar_t**, wchar_t***)
+FUNC 42654 5 0 __acrt_expand_wide_argv_wildcards(wchar_t**, wchar_t***)
 42654 5 390 375
 FUNC 4265c 119 0 __acrt_convert_wcs_mbs_cp<wchar_t,char,<lambda_f788ae46380686e8b737efdd8c720d07>,__crt_win32_buffer_no_resizing>(wchar_t const* const, __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>&, __acrt_wcs_to_mbs_cp::__l2::<lambda_f788ae46380686e8b737efdd8c720d07> const&, const unsigned int)
 4265c 14 494 323
@@ -16364,7 +16364,7 @@ FUNC 42a20 5 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::size(uns
 FUNC 42a28 5 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::size() const
 42a28 4 258 323
 42a2c 1 259 323
-FUNC 42a30 11e 0 _acrt_GetModuleFileNameA(HINSTANCE__*, char*, unsigned long)
+FUNC 42a30 11e 0 __acrt_GetModuleFileNameA(HINSTANCE__*, char*, unsigned long)
 42a30 31 16 380
 42a61 11 20 380
 42a72 4 26 380
@@ -16567,7 +16567,7 @@ FUNC 43804 4 0 __crt_state_management::dual_state_global<unsigned char *>::value
 FUNC 43808 4 0 __crt_state_management::dual_state_global<__crt_multibyte_data *>::value()
 43808 3 147 180
 4380b 1 148 180
-FUNC 4380c 60 0 _acrt_initialize_multibyte()
+FUNC 4380c 60 0 __acrt_initialize_multibyte()
 4380c 4 895 384
 43810 9 907 384
 43819 e 913 384
@@ -16580,29 +16580,29 @@ FUNC 4380c 60 0 _acrt_initialize_multibyte()
 4385e 7 923 384
 43865 2 926 384
 43867 5 927 384
-FUNC 43884 1c 0 _acrt_update_thread_multibyte_data()
+FUNC 43884 1c 0 __acrt_update_thread_multibyte_data()
 43884 4 361 384
 43888 f 362 384
 43897 4 363 384
 4389b 5 362 384
-FUNC 438a8 8 0 _p__mbcasemap()
+FUNC 438a8 8 0 __p__mbcasemap()
 438a8 7 239 384
 438af 1 240 384
-FUNC 438b4 8 0 _p__mbctype()
+FUNC 438b4 8 0 __p__mbctype()
 438b4 7 234 384
 438bb 1 235 384
-FUNC 438c0 3a 0 getmbcp()
+FUNC 438c0 3a 0 _getmbcp()
 438c0 4 871 384
 438c4 c 873 384
 438d0 10 874 384
 438e0 15 877 384
 438f5 5 878 384
-FUNC 43908 25 0 setmbcp(int)
+FUNC 43908 25 0 _setmbcp(int)
 43908 8 688 384
 43910 13 689 384
 43923 5 690 384
 43928 5 689 384
-FUNC 43938 2b9 0 setmbcp_nolock(int, __crt_multibyte_data*)
+FUNC 43938 2b9 0 _setmbcp_nolock(int, __crt_multibyte_data*)
 43938 26 693 384
 4395e 5 700 384
 43963 c 703 384
@@ -16664,98 +16664,98 @@ FUNC 43d48 75 0 x_ismbbtype_l(__crt_locale_pointers*, unsigned int, int, int)
 43d5c 10 224 385
 43d6c 41 231 385
 43dad 10 233 385
-FUNC 43ddc 15 0 ismbbalnum(unsigned int)
+FUNC 43ddc 15 0 _ismbbalnum(unsigned int)
 43ddc 15 114 385
-FUNC 43df8 19 0 ismbbalnum_l(unsigned int, __crt_locale_pointers*)
+FUNC 43df8 19 0 _ismbbalnum_l(unsigned int, __crt_locale_pointers*)
 43df8 3 107 385
 43dfb 16 109 385
-FUNC 43e18 15 0 ismbbalpha(unsigned int)
+FUNC 43e18 15 0 _ismbbalpha(unsigned int)
 43e18 15 124 385
-FUNC 43e34 19 0 ismbbalpha_l(unsigned int, __crt_locale_pointers*)
+FUNC 43e34 19 0 _ismbbalpha_l(unsigned int, __crt_locale_pointers*)
 43e34 3 117 385
 43e37 16 119 385
-FUNC 43e54 1c 0 ismbbblank(unsigned int)
+FUNC 43e54 1c 0 _ismbbblank(unsigned int)
 43e54 8 164 385
 43e5c 1 165 385
 43e5d 13 164 385
-FUNC 43e78 20 0 ismbbblank_l(unsigned int, __crt_locale_pointers*)
+FUNC 43e78 20 0 _ismbbblank_l(unsigned int, __crt_locale_pointers*)
 43e78 3 157 385
 43e7b 8 159 385
 43e83 1 160 385
 43e84 14 159 385
-FUNC 43ea0 15 0 ismbbgraph(unsigned int)
+FUNC 43ea0 15 0 _ismbbgraph(unsigned int)
 43ea0 15 134 385
-FUNC 43ebc 19 0 ismbbgraph_l(unsigned int, __crt_locale_pointers*)
+FUNC 43ebc 19 0 _ismbbgraph_l(unsigned int, __crt_locale_pointers*)
 43ebc 3 127 385
 43ebf 16 129 385
-FUNC 43edc 12 0 ismbbkalnum(unsigned int)
+FUNC 43edc 12 0 _ismbbkalnum(unsigned int)
 43edc 12 81 385
-FUNC 43ef4 16 0 ismbbkalnum_l(unsigned int, __crt_locale_pointers*)
+FUNC 43ef4 16 0 _ismbbkalnum_l(unsigned int, __crt_locale_pointers*)
 43ef4 3 74 385
 43ef7 13 76 385
-FUNC 43f10 7 0 ismbbkana(unsigned int)
+FUNC 43f10 7 0 _ismbbkana(unsigned int)
 43f10 7 211 385
-FUNC 43f18 65 0 ismbbkana_l(unsigned int, __crt_locale_pointers*)
+FUNC 43f18 65 0 _ismbbkana_l(unsigned int, __crt_locale_pointers*)
 43f18 f 198 385
 43f27 a 200 385
 43f31 13 201 385
 43f44 17 204 385
 43f5b 15 206 385
 43f70 d 207 385
-FUNC 43f98 12 0 ismbbkprint(unsigned int)
+FUNC 43f98 12 0 _ismbbkprint(unsigned int)
 43f98 12 91 385
-FUNC 43fb0 16 0 ismbbkprint_l(unsigned int, __crt_locale_pointers*)
+FUNC 43fb0 16 0 _ismbbkprint_l(unsigned int, __crt_locale_pointers*)
 43fb0 3 84 385
 43fb3 13 86 385
-FUNC 43fcc 12 0 ismbbkpunct(unsigned int)
+FUNC 43fcc 12 0 _ismbbkpunct(unsigned int)
 43fcc 12 101 385
-FUNC 43fe4 16 0 ismbbkpunct_l(unsigned int, __crt_locale_pointers*)
+FUNC 43fe4 16 0 _ismbbkpunct_l(unsigned int, __crt_locale_pointers*)
 43fe4 3 94 385
 43fe7 13 96 385
-FUNC 44000 12 0 ismbblead(unsigned int)
+FUNC 44000 12 0 _ismbblead(unsigned int)
 44000 12 180 385
-FUNC 44018 16 0 ismbblead_l(unsigned int, __crt_locale_pointers*)
+FUNC 44018 16 0 _ismbblead_l(unsigned int, __crt_locale_pointers*)
 44018 3 171 385
 4401b 13 174 385
-FUNC 44034 15 0 ismbbprint(unsigned int)
+FUNC 44034 15 0 _ismbbprint(unsigned int)
 44034 15 144 385
-FUNC 44050 19 0 ismbbprint_l(unsigned int, __crt_locale_pointers*)
+FUNC 44050 19 0 _ismbbprint_l(unsigned int, __crt_locale_pointers*)
 44050 3 137 385
 44053 16 139 385
-FUNC 44070 13 0 ismbbpunct(unsigned int)
+FUNC 44070 13 0 _ismbbpunct(unsigned int)
 44070 13 154 385
-FUNC 44088 17 0 ismbbpunct_l(unsigned int, __crt_locale_pointers*)
+FUNC 44088 17 0 _ismbbpunct_l(unsigned int, __crt_locale_pointers*)
 44088 3 147 385
 4408b 14 149 385
-FUNC 440a4 12 0 ismbbtrail(unsigned int)
+FUNC 440a4 12 0 _ismbbtrail(unsigned int)
 440a4 12 192 385
-FUNC 440bc 16 0 ismbbtrail_l(unsigned int, __crt_locale_pointers*)
+FUNC 440bc 16 0 _ismbbtrail_l(unsigned int, __crt_locale_pointers*)
 440bc 3 183 385
 440bf 13 186 385
-FUNC 440d8 25 0 _acrt_initialize_command_line()
+FUNC 440d8 25 0 __acrt_initialize_command_line()
 440d8 4 62 386
 440dc d 63 386
 440e9 d 64 386
 440f6 2 65 386
 440f8 5 66 386
-FUNC 44108 3 0 _acrt_uninitialize_command_line(bool)
+FUNC 44108 3 0 __acrt_uninitialize_command_line(bool)
 44108 2 70 386
 4410a 1 71 386
-FUNC 4410c 8 0 _p___argc()
+FUNC 4410c 8 0 __p___argc()
 4410c 8 32 386
-FUNC 44118 8 0 _p___argv()
+FUNC 44118 8 0 __p___argv()
 44118 8 33 386
-FUNC 44124 8 0 _p___wargv()
+FUNC 44124 8 0 __p___wargv()
 44124 8 34 386
-FUNC 44130 8 0 _p__acmdln()
+FUNC 44130 8 0 __p__acmdln()
 44130 8 37 386
-FUNC 4413c 8 0 _p__pgmptr()
+FUNC 4413c 8 0 __p__pgmptr()
 4413c 8 35 386
-FUNC 44148 8 0 _p__wcmdln()
+FUNC 44148 8 0 __p__wcmdln()
 44148 8 38 386
-FUNC 44154 8 0 _p__wpgmptr()
+FUNC 44154 8 0 __p__wpgmptr()
 44154 8 36 386
-FUNC 44160 36 0 get_pgmptr(char**)
+FUNC 44160 36 0 _get_pgmptr(char**)
 44160 4 50 386
 44164 5 51 386
 44169 17 55 386
@@ -16763,7 +16763,7 @@ FUNC 44160 36 0 get_pgmptr(char**)
 4418c 3 53 386
 4418f 2 54 386
 44191 5 55 386
-FUNC 441a4 36 0 get_wpgmptr(wchar_t**)
+FUNC 441a4 36 0 _get_wpgmptr(wchar_t**)
 441a4 4 41 386
 441a8 5 42 386
 441ad 17 47 386
@@ -16794,7 +16794,7 @@ FUNC 442f0 55 0 filter_mbtowcs_flags(const unsigned int, const unsigned long)
 44317 28 41 388
 4433f 3 85 388
 44342 3 90 388
-FUNC 4435c 5a 0 _acrt_MultiByteToWideChar(unsigned int, unsigned long, char const*, int, wchar_t*, int)
+FUNC 4435c 5a 0 __acrt_MultiByteToWideChar(unsigned int, unsigned long, char const*, int, wchar_t*, int)
 4435c 53 101 388
 443af 7 103 388
 FUNC 443cc 44 0 filter_wcstomb_flags(const unsigned int, const unsigned long)
@@ -16803,7 +16803,7 @@ FUNC 443cc 44 0 filter_wcstomb_flags(const unsigned int, const unsigned long)
 4440c 1 89 389
 4440d 2 84 389
 4440f 1 89 389
-FUNC 44424 96 0 _acrt_WideCharToMultiByte(unsigned int, unsigned long, wchar_t const*, int, char*, int, char const*, int*)
+FUNC 44424 96 0 __acrt_WideCharToMultiByte(unsigned int, unsigned long, wchar_t const*, int, char*, int, char const*, int*)
 44424 2 101 389
 44426 10 102 389
 44436 58 103 389
@@ -16846,7 +16846,7 @@ FUNC 44594 3 0 `anonymous namespace'::environment_strings_traits::get_invalid_va
 FUNC 44598 8 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings_traits>::is_valid() const
 44598 7 1152 201
 4459f 1 1153 201
-FUNC 445a4 101 0 _dcrt_get_narrow_environment_from_os()
+FUNC 445a4 101 0 __dcrt_get_narrow_environment_from_os()
 445a4 19 76 390
 445bd 6 80 390
 445c3 3 81 390
@@ -16861,7 +16861,7 @@ FUNC 445a4 101 0 _dcrt_get_narrow_environment_from_os()
 4465d 4 117 390
 44661 26 120 390
 44687 1e 121 390
-FUNC 446e8 9f 0 _dcrt_get_wide_environment_from_os()
+FUNC 446e8 9f 0 __dcrt_get_wide_environment_from_os()
 446e8 14 53 390
 446fc 6 54 390
 44702 2 55 390
@@ -17104,13 +17104,13 @@ FUNC 454cc 5 0 strchr(char* const, const int)
 454cc 5 506 237
 FUNC 454d4 5 0 wcschr(wchar_t*, wchar_t)
 454d4 5 541 185
-FUNC 454dc 5 0 _dcrt_set_variable_in_narrow_environment_nolock(char*, int)
+FUNC 454dc 5 0 __dcrt_set_variable_in_narrow_environment_nolock(char*, int)
 454dc 5 364 391
-FUNC 454e4 5 0 _dcrt_set_variable_in_wide_environment_nolock(wchar_t*, int)
+FUNC 454e4 5 0 __dcrt_set_variable_in_wide_environment_nolock(wchar_t*, int)
 454e4 5 372 391
-FUNC 454ec 5 0 recalloc(void*, unsigned long long, unsigned long long)
+FUNC 454ec 5 0 _recalloc(void*, unsigned long long, unsigned long long)
 454ec 5 68 392
-FUNC 454f4 95 0 recalloc_base(void*, unsigned long long, unsigned long long)
+FUNC 454f4 95 0 _recalloc_base(void*, unsigned long long, unsigned long long)
 454f4 1d 27 392
 45511 22 29 392
 45533 11 31 392
@@ -17303,7 +17303,7 @@ FUNC 463f8 73 0 try_load_library_from_system_directory(wchar_t const* const)
 FUNC 46488 8 0 GetCurrentThreadEffectiveToken()
 46488 7 490 234
 4648f 1 491 234
-FUNC 46494 4e 0 _acrt_AppPolicyGetProcessTerminationMethodInternal(AppPolicyProcessTerminationMethod*)
+FUNC 46494 4e 0 __acrt_AppPolicyGetProcessTerminationMethodInternal(AppPolicyProcessTerminationMethod*)
 46494 9 736 393
 4649d 24 737 393
 464c1 a 739 393
@@ -17311,7 +17311,7 @@ FUNC 46494 4e 0 _acrt_AppPolicyGetProcessTerminationMethodInternal(AppPolicyProc
 464d0 7 739 393
 464d7 5 742 393
 464dc 6 743 393
-FUNC 464f8 4e 0 _acrt_AppPolicyGetShowDeveloperDiagnosticInternal(AppPolicyShowDeveloperDiagnostic*)
+FUNC 464f8 4e 0 __acrt_AppPolicyGetShowDeveloperDiagnosticInternal(AppPolicyShowDeveloperDiagnostic*)
 464f8 9 756 393
 46501 24 757 393
 46525 a 759 393
@@ -17319,7 +17319,7 @@ FUNC 464f8 4e 0 _acrt_AppPolicyGetShowDeveloperDiagnosticInternal(AppPolicyShowD
 46534 7 759 393
 4653b 5 762 393
 46540 6 763 393
-FUNC 4655c 4e 0 _acrt_AppPolicyGetThreadInitializationTypeInternal(AppPolicyThreadInitializationType*)
+FUNC 4655c 4e 0 __acrt_AppPolicyGetThreadInitializationTypeInternal(AppPolicyThreadInitializationType*)
 4655c 9 746 393
 46565 24 747 393
 46589 a 749 393
@@ -17327,7 +17327,7 @@ FUNC 4655c 4e 0 _acrt_AppPolicyGetThreadInitializationTypeInternal(AppPolicyThre
 46598 7 749 393
 4659f 5 752 393
 465a4 6 753 393
-FUNC 465c0 4e 0 _acrt_AppPolicyGetWindowingModelInternal(AppPolicyWindowingModel*)
+FUNC 465c0 4e 0 __acrt_AppPolicyGetWindowingModelInternal(AppPolicyWindowingModel*)
 465c0 9 766 393
 465c9 24 767 393
 465ed a 769 393
@@ -17335,14 +17335,14 @@ FUNC 465c0 4e 0 _acrt_AppPolicyGetWindowingModelInternal(AppPolicyWindowingModel
 465fc 7 769 393
 46603 5 772 393
 46608 6 773 393
-FUNC 46624 3a 0 _acrt_AreFileApisANSI()
+FUNC 46624 3a 0 __acrt_AreFileApisANSI()
 46624 4 383 393
 46628 21 384 393
 46649 4 392 393
 4664d 7 386 393
 46654 5 391 393
 46659 5 392 393
-FUNC 4666c dc 0 _acrt_CompareStringEx(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t const*, int, _nlsversioninfo*, void*, long long)
+FUNC 4666c dc 0 __acrt_CompareStringEx(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t const*, int, _nlsversioninfo*, void*, long long)
 4666c 1c 405 393
 46688 7 406 393
 4668f 3 405 393
@@ -17350,13 +17350,13 @@ FUNC 4666c dc 0 _acrt_CompareStringEx(wchar_t const*, unsigned long, wchar_t con
 466af 52 408 393
 46701 32 411 393
 46733 15 412 393
-FUNC 46780 95 0 _acrt_EnumSystemLocalesEx(int (*)(wchar_t*, unsigned long, long long), unsigned long, long long, void*)
+FUNC 46780 95 0 __acrt_EnumSystemLocalesEx(int (*)(wchar_t*, unsigned long, long long), unsigned long, long long, void*)
 46780 1c 438 393
 4679c 24 439 393
 467c0 15 441 393
 467d5 30 444 393
 46805 10 448 393
-FUNC 4683c 48 0 _acrt_FlsAlloc(void (*)(void*))
+FUNC 4683c 48 0 __acrt_FlsAlloc(void (*)(void*))
 4683c 9 451 393
 46845 24 452 393
 46869 3 454 393
@@ -17364,21 +17364,21 @@ FUNC 4683c 48 0 _acrt_FlsAlloc(void (*)(void*))
 46871 7 454 393
 46878 5 458 393
 4687d 7 457 393
-FUNC 46898 46 0 _acrt_FlsFree(unsigned long)
+FUNC 46898 46 0 __acrt_FlsFree(unsigned long)
 46898 8 461 393
 468a0 26 462 393
 468c6 5 468 393
 468cb 7 464 393
 468d2 5 468 393
 468d7 7 467 393
-FUNC 468f0 46 0 _acrt_FlsGetValue(unsigned long)
+FUNC 468f0 46 0 __acrt_FlsGetValue(unsigned long)
 468f0 8 471 393
 468f8 26 472 393
 4691e 5 478 393
 46923 7 474 393
 4692a 5 478 393
 4692f 7 477 393
-FUNC 46948 51 0 _acrt_FlsSetValue(unsigned long, void*)
+FUNC 46948 51 0 __acrt_FlsSetValue(unsigned long, void*)
 46948 d 481 393
 46955 7 482 393
 4695c 2 481 393
@@ -17386,7 +17386,7 @@ FUNC 46948 51 0 _acrt_FlsSetValue(unsigned long, void*)
 46980 8 484 393
 46988 6 487 393
 4698e b 488 393
-FUNC 469b0 b6 0 _acrt_GetDateFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME const*, wchar_t const*, wchar_t*, int, wchar_t const*)
+FUNC 469b0 b6 0 __acrt_GetDateFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME const*, wchar_t const*, wchar_t*, int, wchar_t const*)
 469b0 1c 499 393
 469cc 7 500 393
 469d3 3 499 393
@@ -17394,13 +17394,13 @@ FUNC 469b0 b6 0 _acrt_GetDateFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME
 469f3 32 502 393
 46a25 2c 505 393
 46a51 15 506 393
-FUNC 46a94 39 0 _acrt_GetEnabledXStateFeatures()
+FUNC 46a94 39 0 __acrt_GetEnabledXStateFeatures()
 46a94 4 509 393
 46a98 24 510 393
 46abc 4 516 393
 46ac0 7 512 393
 46ac7 6 515 393
-FUNC 46adc 82 0 _acrt_GetLocaleInfoEx(wchar_t const*, unsigned long, wchar_t*, int)
+FUNC 46adc 82 0 __acrt_GetLocaleInfoEx(wchar_t const*, unsigned long, wchar_t*, int)
 46adc 1c 524 393
 46af8 7 525 393
 46aff 3 524 393
@@ -17408,14 +17408,14 @@ FUNC 46adc 82 0 _acrt_GetLocaleInfoEx(wchar_t const*, unsigned long, wchar_t*, i
 46b22 10 527 393
 46b32 17 530 393
 46b49 15 531 393
-FUNC 46b80 48 0 _acrt_GetSystemTimePreciseAsFileTime(_FILETIME*)
+FUNC 46b80 48 0 __acrt_GetSystemTimePreciseAsFileTime(_FILETIME*)
 46b80 9 534 393
 46b89 27 535 393
 46bb0 5 541 393
 46bb5 7 537 393
 46bbc 5 541 393
 46bc1 7 540 393
-FUNC 46bdc ab 0 _acrt_GetTimeFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME const*, wchar_t const*, wchar_t*, int)
+FUNC 46bdc ab 0 __acrt_GetTimeFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME const*, wchar_t const*, wchar_t*, int)
 46bdc 1c 551 393
 46bf8 7 552 393
 46bff 3 551 393
@@ -17423,7 +17423,7 @@ FUNC 46bdc ab 0 _acrt_GetTimeFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME
 46c1f 27 554 393
 46c46 2c 557 393
 46c72 15 558 393
-FUNC 46cb4 61 0 _acrt_GetUserDefaultLocaleName(wchar_t*, int)
+FUNC 46cb4 61 0 __acrt_GetUserDefaultLocaleName(wchar_t*, int)
 46cb4 c 564 393
 46cc0 7 565 393
 46cc7 3 564 393
@@ -17431,7 +17431,7 @@ FUNC 46cb4 61 0 _acrt_GetUserDefaultLocaleName(wchar_t*, int)
 46ce7 d 567 393
 46cf4 16 570 393
 46d0a b 571 393
-FUNC 46d30 51 0 _acrt_GetXStateFeaturesMask(_CONTEXT*, unsigned long long*)
+FUNC 46d30 51 0 __acrt_GetXStateFeaturesMask(_CONTEXT*, unsigned long long*)
 46d30 d 577 393
 46d3d 7 578 393
 46d44 3 577 393
@@ -17440,7 +17440,7 @@ FUNC 46d30 51 0 _acrt_GetXStateFeaturesMask(_CONTEXT*, unsigned long long*)
 46d6a a 584 393
 46d74 7 580 393
 46d7b 6 583 393
-FUNC 46d98 61 0 _acrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsigned long, unsigned long)
+FUNC 46d98 61 0 __acrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsigned long, unsigned long)
 46d98 12 591 393
 46daa 7 592 393
 46db1 2 591 393
@@ -17450,7 +17450,7 @@ FUNC 46d98 61 0 _acrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsign
 46dd8 b 594 393
 46de3 6 597 393
 46de9 10 598 393
-FUNC 46e14 56 0 _acrt_IsValidLocaleName(wchar_t const*)
+FUNC 46e14 56 0 __acrt_IsValidLocaleName(wchar_t const*)
 46e14 9 601 393
 46e1d 27 602 393
 46e44 5 608 393
@@ -17458,7 +17458,7 @@ FUNC 46e14 56 0 _acrt_IsValidLocaleName(wchar_t const*)
 46e50 e 607 393
 46e5e 5 608 393
 46e63 7 607 393
-FUNC 46e80 70 0 _acrt_LCIDToLocaleName(unsigned long, wchar_t*, int, unsigned long)
+FUNC 46e80 70 0 __acrt_LCIDToLocaleName(unsigned long, wchar_t*, int, unsigned long)
 46e80 1d 636 393
 46e9d 7 637 393
 46ea4 2 636 393
@@ -17466,7 +17466,7 @@ FUNC 46e80 70 0 _acrt_LCIDToLocaleName(unsigned long, wchar_t*, int, unsigned lo
 46ecb b 639 393
 46ed6 5 642 393
 46edb 15 643 393
-FUNC 46f0c dc 0 _acrt_LCMapStringEx(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t*, int, _nlsversioninfo*, void*, long long)
+FUNC 46f0c dc 0 __acrt_LCMapStringEx(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t*, int, _nlsversioninfo*, void*, long long)
 46f0c 1c 621 393
 46f28 7 622 393
 46f2f 3 621 393
@@ -17474,7 +17474,7 @@ FUNC 46f0c dc 0 _acrt_LCMapStringEx(wchar_t const*, unsigned long, wchar_t const
 46f4f 52 624 393
 46fa1 32 627 393
 46fd3 15 628 393
-FUNC 47020 50 0 _acrt_LocaleNameToLCID(wchar_t const*, unsigned long)
+FUNC 47020 50 0 __acrt_LocaleNameToLCID(wchar_t const*, unsigned long)
 47020 c 649 393
 4702c 7 650 393
 47033 3 649 393
@@ -17482,7 +17482,7 @@ FUNC 47020 50 0 _acrt_LocaleNameToLCID(wchar_t const*, unsigned long)
 47056 a 652 393
 47060 5 655 393
 47065 b 656 393
-FUNC 47084 5f 0 _acrt_LocateXStateFeature(_CONTEXT*, unsigned long, unsigned long*)
+FUNC 47084 5f 0 __acrt_LocateXStateFeature(_CONTEXT*, unsigned long, unsigned long*)
 47084 12 663 393
 47096 7 664 393
 4709d 2 663 393
@@ -17493,7 +17493,7 @@ FUNC 47084 5f 0 _acrt_LocateXStateFeature(_CONTEXT*, unsigned long, unsigned lon
 470c7 f 670 393
 470d6 7 666 393
 470dd 6 669 393
-FUNC 470fc 71 0 _acrt_MessageBoxA(HWND__*, char const*, char const*, unsigned int)
+FUNC 470fc 71 0 __acrt_MessageBoxA(HWND__*, char const*, char const*, unsigned int)
 470fc 1d 678 393
 47119 7 679 393
 47120 3 678 393
@@ -17501,7 +17501,7 @@ FUNC 470fc 71 0 _acrt_MessageBoxA(HWND__*, char const*, char const*, unsigned in
 47140 12 681 393
 47152 15 685 393
 47167 6 684 393
-FUNC 4718c 71 0 _acrt_MessageBoxW(HWND__*, wchar_t const*, wchar_t const*, unsigned int)
+FUNC 4718c 71 0 __acrt_MessageBoxW(HWND__*, wchar_t const*, wchar_t const*, unsigned int)
 4718c 1d 693 393
 471a9 7 694 393
 471b0 3 693 393
@@ -17509,19 +17509,19 @@ FUNC 4718c 71 0 _acrt_MessageBoxW(HWND__*, wchar_t const*, wchar_t const*, unsig
 471d0 12 696 393
 471e2 15 700 393
 471f7 6 699 393
-FUNC 4721c 40 0 _acrt_RoInitialize(RO_INIT_TYPE)
+FUNC 4721c 40 0 __acrt_RoInitialize(RO_INIT_TYPE)
 4721c 8 716 393
 47224 24 717 393
 47248 2 719 393
 4724a 5 723 393
 4724f 7 719 393
 47256 6 723 393
-FUNC 4726c 33 0 _acrt_RoUninitialize()
+FUNC 4726c 33 0 __acrt_RoUninitialize()
 4726c 4 726 393
 47270 24 727 393
 47294 6 729 393
 4729a 5 733 393
-FUNC 472ac 4f 0 _acrt_RtlGenRandom(void*, unsigned long)
+FUNC 472ac 4f 0 __acrt_RtlGenRandom(void*, unsigned long)
 472ac c 706 393
 472b8 7 707 393
 472bf 3 706 393
@@ -17530,28 +17530,28 @@ FUNC 472ac 4f 0 _acrt_RtlGenRandom(void*, unsigned long)
 472e4 a 713 393
 472ee 7 709 393
 472f5 6 712 393
-FUNC 47310 42 0 _acrt_SetThreadStackGuarantee(unsigned long*)
+FUNC 47310 42 0 __acrt_SetThreadStackGuarantee(unsigned long*)
 47310 9 776 393
 47319 24 777 393
 4733d 3 779 393
 47340 5 783 393
 47345 7 779 393
 4734c 6 783 393
-FUNC 47364 6d 0 _acrt_can_show_message_box()
+FUNC 47364 6d 0 __acrt_can_show_message_box()
 47364 a 788 393
 4736e 2 789 393
 47370 54 792 393
 473c4 2 796 393
 473c6 b 797 393
-FUNC 473ec 2e 0 _acrt_can_use_vista_locale_apis()
+FUNC 473ec 2e 0 __acrt_can_use_vista_locale_apis()
 473ec 4 800 393
 473f0 25 801 393
 47415 5 802 393
-FUNC 47428 2e 0 _acrt_can_use_xstate_apis()
+FUNC 47428 2e 0 __acrt_can_use_xstate_apis()
 47428 4 824 393
 4742c 25 825 393
 47451 5 826 393
-FUNC 47464 15a 0 _acrt_eagerly_load_locale_apis()
+FUNC 47464 15a 0 __acrt_eagerly_load_locale_apis()
 47464 4 809 393
 47468 1c 810 393
 47484 1f 811 393
@@ -17566,7 +17566,7 @@ FUNC 47464 15a 0 _acrt_eagerly_load_locale_apis()
 4759b 1a 820 393
 475b5 4 821 393
 475b9 5 820 393
-FUNC 47614 78 0 _acrt_get_parent_window()
+FUNC 47614 78 0 __acrt_get_parent_window()
 47614 6 829 393
 4761a 1f 830 393
 47639 5 831 393
@@ -17580,11 +17580,11 @@ FUNC 47614 78 0 _acrt_get_parent_window()
 4767d 7 848 393
 47684 2 839 393
 47686 6 849 393
-FUNC 476ac 31 0 _acrt_initialize_winapi_thunks()
+FUNC 476ac 31 0 __acrt_initialize_winapi_thunks()
 476ac 5 153 393
 476b1 24 154 393
 476d5 8 162 393
-FUNC 476ec c6 0 _acrt_is_interactive()
+FUNC 476ec c6 0 __acrt_is_interactive()
 476ec 19 852 393
 47705 22 853 393
 47727 5 854 393
@@ -17598,7 +17598,7 @@ FUNC 476ec c6 0 _acrt_is_interactive()
 47794 4 879 393
 47798 2 882 393
 4779a 18 883 393
-FUNC 477e4 41 0 _acrt_uninitialize_winapi_thunks(bool)
+FUNC 477e4 41 0 __acrt_uninitialize_winapi_thunks(bool)
 477e4 6 165 393
 477ea 4 167 393
 477ee 7 172 393
@@ -17609,19 +17609,19 @@ FUNC 477e4 41 0 _acrt_uninitialize_winapi_thunks(bool)
 4780d 10 172 393
 4781d 2 185 393
 4781f 6 186 393
-FUNC 47838 8 0 _acrt_getheap()
+FUNC 47838 8 0 __acrt_getheap()
 47838 7 51 396
 4783f 1 52 396
-FUNC 47844 1c 0 _acrt_initialize_heap()
+FUNC 47844 1c 0 __acrt_initialize_heap()
 47844 4 22 396
 47848 6 23 396
 4784e d 24 396
 4785b 5 28 396
-FUNC 47868 b 0 _acrt_uninitialize_heap(bool)
+FUNC 47868 b 0 __acrt_uninitialize_heap(bool)
 47868 8 34 396
 47870 2 35 396
 47872 1 36 396
-FUNC 47878 8 0 get_heap_handle()
+FUNC 47878 8 0 _get_heap_handle()
 47878 7 43 396
 4787f 1 44 396
 FUNC 47884 1b 0 get_std_handle_id(const int)
@@ -17673,7 +17673,7 @@ FUNC 479d0 10c 0 initialize_stdio_handles_nolock()
 47aa7 b 183 397
 47ab2 f 125 397
 47ac1 1b 186 397
-FUNC 47b20 3b 0 _acrt_initialize_lowio()
+FUNC 47b20 3b 0 __acrt_initialize_lowio()
 47b20 6 225 397
 47b26 a 226 397
 47b30 2 227 397
@@ -17684,7 +17684,7 @@ FUNC 47b20 3b 0 _acrt_initialize_lowio()
 47b49 a 243 397
 47b53 2 246 397
 47b55 6 247 397
-FUNC 47b6c 40 0 _acrt_uninitialize_lowio(bool)
+FUNC 47b6c 40 0 __acrt_uninitialize_lowio(bool)
 47b6c a 254 397
 47b76 2 255 397
 47b78 10 257 397
@@ -17692,7 +17692,7 @@ FUNC 47b6c 40 0 _acrt_uninitialize_lowio(bool)
 47b8d 5 261 397
 47b92 d 255 397
 47b9f d 265 397
-FUNC 47bbc 80 0 _acrt_execute_initializers(__acrt_initializer const*, __acrt_initializer const*)
+FUNC 47bbc 80 0 __acrt_execute_initializers(__acrt_initializer const*, __acrt_initializer const*)
 47bbc 15 14 398
 47bd1 5 15 398
 47bd6 3 19 398
@@ -17707,7 +17707,7 @@ FUNC 47bbc 80 0 _acrt_execute_initializers(__acrt_initializer const*, __acrt_ini
 47c26 4 46 398
 47c2a 2 31 398
 47c2c 10 47 398
-FUNC 47c5c 3c 0 _acrt_execute_uninitializers(__acrt_initializer const*, __acrt_initializer const*)
+FUNC 47c5c 3c 0 __acrt_execute_uninitializers(__acrt_initializer const*, __acrt_initializer const*)
 47c5c 10 53 398
 47c6c 5 54 398
 47c71 9 60 398
@@ -17732,24 +17732,24 @@ FUNC 47d08 27 0 __crt_state_management::dual_state_global<int (__cdecl*)(unsigne
 FUNC 47d38 4 0 __crt_state_management::dual_state_global<int (__cdecl*)(unsigned __int64)>::value()
 47d38 3 147 180
 47d3b 1 148 180
-FUNC 47d3c 8 0 _acrt_initialize_new_handler(void*)
+FUNC 47d3c 8 0 __acrt_initialize_new_handler(void*)
 47d3c 7 20 399
 47d43 1 21 399
-FUNC 47d48 2f 0 callnewh(unsigned long long)
+FUNC 47d48 2f 0 _callnewh(unsigned long long)
 47d48 9 76 399
 47d51 5 77 399
 47d56 12 79 399
 47d68 7 82 399
 47d6f 2 80 399
 47d71 6 83 399
-FUNC 47d84 34 0 query_new_handler()
+FUNC 47d84 34 0 _query_new_handler()
 47d84 6 56 399
 47d8a 8 59 399
 47d92 16 62 399
 47da8 7 66 399
 47daf 3 69 399
 47db2 6 70 399
-FUNC 47dc8 59 0 set_new_handler(int (*)(unsigned long long))
+FUNC 47dc8 59 0 _set_new_handler(int (*)(unsigned long long))
 47dc8 d 25 399
 47dd5 8 28 399
 47ddd 1b 31 399
@@ -17848,21 +17848,21 @@ FUNC 480e4 27 0 signal_failed(const int)
 FUNC 48114 4 0 __crt_state_management::dual_state_global<void (__cdecl*)(int)>::value()
 48114 3 147 180
 48117 1 148 180
-FUNC 48118 2e 0 _acrt_get_sigabrt_handler()
+FUNC 48118 2e 0 __acrt_get_sigabrt_handler()
 48118 7 562 400
 4811f 22 563 400
 48141 5 567 400
-FUNC 48154 1d 0 _acrt_initialize_signal_handlers(void*)
+FUNC 48154 1d 0 __acrt_initialize_signal_handlers(void*)
 48154 7 47 400
 4815b 7 48 400
 48162 7 49 400
 48169 7 50 400
 48170 1 51 400
-FUNC 48178 12 0 _fpecode()
+FUNC 48178 12 0 __fpecode()
 48178 4 571 400
 4817c 9 572 400
 48185 5 573 400
-FUNC 48190 12 0 _pxcptinfoptrs()
+FUNC 48190 12 0 __pxcptinfoptrs()
 48190 4 577 400
 48194 9 578 400
 4819d 5 579 400
@@ -17971,13 +17971,13 @@ FUNC 48744 27 0 __crt_state_management::dual_state_global<int (__cdecl*)(_except
 FUNC 48774 4 0 __crt_state_management::dual_state_global<int (__cdecl*)(_exception *)>::value()
 48774 3 147 180
 48777 1 148 180
-FUNC 48778 1d 0 _acrt_has_user_matherr()
+FUNC 48778 1d 0 __acrt_has_user_matherr()
 48778 1c 34 401
 48794 1 35 401
-FUNC 4879c 8 0 _acrt_initialize_user_matherr(void*)
+FUNC 4879c 8 0 __acrt_initialize_user_matherr(void*)
 4879c 7 29 401
 487a3 1 30 401
-FUNC 487a8 2e 0 _acrt_invoke_user_matherr(_exception*)
+FUNC 487a8 2e 0 __acrt_invoke_user_matherr(_exception*)
 487a8 7 41 401
 487af 3 38 401
 487b2 f 41 401
@@ -17985,7 +17985,7 @@ FUNC 487a8 2e 0 _acrt_invoke_user_matherr(_exception*)
 487c6 2 43 401
 487c8 1 46 401
 487c9 d 45 401
-FUNC 487e4 25 0 _setusermatherr(int (*)(_exception*))
+FUNC 487e4 25 0 __setusermatherr(int (*)(_exception*))
 487e4 7 24 401
 487eb 3 23 401
 487ee 1a 24 401
@@ -18120,7 +18120,7 @@ FUNC 48e40 1e 0 __crt_stdio_stream::set_flags(const long) const
 48e40 1e 209 337
 FUNC 48e68 25 0 __crt_stdio_stream::unset_flags(const long) const
 48e68 25 210 337
-FUNC 48e98 7a 0 _acrt_stdio_flush_nolock(_iobuf*)
+FUNC 48e98 7a 0 __acrt_stdio_flush_nolock(_iobuf*)
 48e98 12 218 402
 48eaa 10 221 402
 48eba 5 226 402
@@ -18134,7 +18134,7 @@ FUNC 48e98 7a 0 _acrt_stdio_flush_nolock(_iobuf*)
 48efb 5 246 402
 48f00 2 249 402
 48f02 10 250 402
-FUNC 48f30 4b 0 fflush_nolock(_iobuf*)
+FUNC 48f30 4b 0 _fflush_nolock(_iobuf*)
 48f30 9 185 402
 48f39 5 189 402
 48f3e 5 210 402
@@ -18145,7 +18145,7 @@ FUNC 48f30 4b 0 fflush_nolock(_iobuf*)
 48f6e 4 209 402
 48f72 3 205 402
 48f75 6 210 402
-FUNC 48f90 7 0 flushall()
+FUNC 48f90 7 0 _flushall()
 48f90 7 258 402
 FUNC 48f98 66 0 fflush(_iobuf*)
 48f98 4 158 402
@@ -18156,7 +18156,7 @@ FUNC 48f98 66 0 fflush(_iobuf*)
 48fc3 4 173 402
 48fc7 32 176 402
 48ff9 5 180 402
-FUNC 49018 30 0 _p___mb_cur_max()
+FUNC 49018 30 0 __p___mb_cur_max()
 49018 4 18 403
 4901c 5 19 403
 49021 19 22 403
@@ -18180,7 +18180,7 @@ FUNC 49098 1b 0 __crt_unique_heap_ptr<__crt_stdio_stream_data *,__crt_internal_f
 490a1 8 395 99
 490a9 4 396 99
 490ad 6 397 99
-FUNC 490bc 11f 0 _acrt_initialize_stdio()
+FUNC 490bc 11f 0 __acrt_initialize_stdio()
 490bc 19 60 404
 490d5 11 65 404
 490e6 7 67 404
@@ -18199,10 +18199,10 @@ FUNC 490bc 11f 0 _acrt_initialize_stdio()
 491a9 15 92 404
 491be 2 112 404
 491c0 1b 113 404
-FUNC 49224 11 0 _acrt_iob_func(unsigned int)
+FUNC 49224 11 0 __acrt_iob_func(unsigned int)
 49224 10 24 404
 49234 1 25 404
-FUNC 4923c 5b 0 _acrt_uninitialize_stdio()
+FUNC 4923c 5b 0 __acrt_uninitialize_stdio()
 4923c 6 121 404
 49242 5 122 404
 49247 7 123 404
@@ -18211,7 +18211,7 @@ FUNC 4923c 5b 0 _acrt_uninitialize_stdio()
 4927d c 131 404
 49289 8 132 404
 49291 6 133 404
-FUNC 492b0 47 0 get_stream_buffer_pointers(_iobuf*, char***, char***, int**)
+FUNC 492b0 47 0 _get_stream_buffer_pointers(_iobuf*, char***, char***, int**)
 492b0 4 159 404
 492b4 1c 160 404
 492d0 5 163 404
@@ -18222,9 +18222,9 @@ FUNC 492b0 47 0 get_stream_buffer_pointers(_iobuf*, char***, char***, int**)
 492e9 7 175 404
 492f0 2 178 404
 492f2 5 179 404
-FUNC 49308 b 0 lock_file(_iobuf*)
+FUNC 49308 b 0 _lock_file(_iobuf*)
 49308 b 140 404
-FUNC 49318 b 0 unlock_file(_iobuf*)
+FUNC 49318 b 0 _unlock_file(_iobuf*)
 49318 b 148 404
 FUNC 49328 10 0 __crt_stdio_stream::has_any_buffer() const
 49328 10 221 337
@@ -18232,7 +18232,7 @@ FUNC 4933c c 0 __crt_stdio_stream::has_any_of(const long) const
 4933c c 206 337
 FUNC 4934c c 0 __crt_stdio_stream::has_temporary_buffer() const
 4934c c 218 337
-FUNC 4935c cf 0 _acrt_stdio_begin_temporary_buffering_nolock(_iobuf*)
+FUNC 4935c cf 0 __acrt_stdio_begin_temporary_buffering_nolock(_iobuf*)
 4935c d 37 405
 49369 14 43 405
 4937d f 47 405
@@ -18256,7 +18256,7 @@ FUNC 4935c cf 0 _acrt_stdio_begin_temporary_buffering_nolock(_iobuf*)
 4941c 2 81 405
 4941e 2 52 405
 49420 b 82 405
-FUNC 49460 39 0 _acrt_stdio_end_temporary_buffering_nolock(bool, _iobuf*)
+FUNC 49460 39 0 __acrt_stdio_end_temporary_buffering_nolock(bool, _iobuf*)
 49460 9 96 405
 49469 3 99 405
 4946c 3 93 405
@@ -18266,7 +18266,7 @@ FUNC 49460 39 0 _acrt_stdio_end_temporary_buffering_nolock(bool, _iobuf*)
 49486 9 105 405
 4948f 4 106 405
 49493 6 114 405
-FUNC 494a8 5e 0 malloc_base(unsigned long long)
+FUNC 494a8 5e 0 _malloc_base(unsigned long long)
 494a8 9 24 406
 494b1 6 26 406
 494b7 c 29 406
@@ -18328,113 +18328,113 @@ FUNC 496f4 2e 0 __crt_strtox::parse_integer_from_string<unsigned __int64,wchar_t
 496fd 3 1823 357
 49700 1d 1824 357
 4971d 5 1829 357
-FUNC 49730 2a 0 strtoi64(char const*, char**, int)
+FUNC 49730 2a 0 _strtoi64(char const*, char**, int)
 49730 4 114 407
 49734 21 115 407
 49755 5 116 407
-FUNC 49764 2e 0 strtoi64_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 49764 2e 0 _strtoi64_l(char const*, char**, int, __crt_locale_pointers*)
 49764 4 144 407
 49768 5 145 407
 4976d 3 144 407
 49770 1d 145 407
 4978d 5 146 407
-FUNC 497a0 2e 0 strtoimax_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 497a0 2e 0 _strtoimax_l(char const*, char**, int, __crt_locale_pointers*)
 497a0 4 164 407
 497a4 5 165 407
 497a9 3 164 407
 497ac 1d 165 407
 497c9 5 166 407
-FUNC 497dc 2e 0 strtol_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 497dc 2e 0 _strtol_l(char const*, char**, int, __crt_locale_pointers*)
 497dc 4 77 407
 497e0 5 78 407
 497e5 3 77 407
 497e8 1d 78 407
 49805 5 79 407
-FUNC 49818 2e 0 strtoll_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 49818 2e 0 _strtoll_l(char const*, char**, int, __crt_locale_pointers*)
 49818 4 154 407
 4981c 5 155 407
 49821 3 154 407
 49824 1d 155 407
 49841 5 156 407
-FUNC 49854 2a 0 strtoui64(char const*, char**, int)
+FUNC 49854 2a 0 _strtoui64(char const*, char**, int)
 49854 4 175 407
 49858 21 176 407
 49879 5 177 407
-FUNC 49888 2e 0 strtoui64_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 49888 2e 0 _strtoui64_l(char const*, char**, int, __crt_locale_pointers*)
 49888 4 205 407
 4988c 5 206 407
 49891 3 205 407
 49894 1d 206 407
 498b1 5 207 407
-FUNC 498c4 2e 0 strtoul_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 498c4 2e 0 _strtoul_l(char const*, char**, int, __crt_locale_pointers*)
 498c4 4 98 407
 498c8 5 99 407
 498cd 3 98 407
 498d0 1d 99 407
 498ed 5 100 407
-FUNC 49900 2e 0 strtoull_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 49900 2e 0 _strtoull_l(char const*, char**, int, __crt_locale_pointers*)
 49900 4 215 407
 49904 5 216 407
 49909 3 215 407
 4990c 1d 216 407
 49929 5 217 407
-FUNC 4993c 2e 0 strtoumax_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 4993c 2e 0 _strtoumax_l(char const*, char**, int, __crt_locale_pointers*)
 4993c 4 225 407
 49940 5 226 407
 49945 3 225 407
 49948 1d 226 407
 49965 5 227 407
-FUNC 49978 2a 0 wcstoi64(wchar_t const*, wchar_t**, int)
+FUNC 49978 2a 0 _wcstoi64(wchar_t const*, wchar_t**, int)
 49978 4 286 407
 4997c 21 287 407
 4999d 5 288 407
-FUNC 499ac 2e 0 wcstoi64_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 499ac 2e 0 _wcstoi64_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 499ac 4 316 407
 499b0 5 317 407
 499b5 3 316 407
 499b8 1d 317 407
 499d5 5 318 407
-FUNC 499e8 2e 0 wcstoimax_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 499e8 2e 0 _wcstoimax_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 499e8 4 336 407
 499ec 5 337 407
 499f1 3 336 407
 499f4 1d 337 407
 49a11 5 338 407
-FUNC 49a24 2e 0 wcstol_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 49a24 2e 0 _wcstol_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 49a24 4 251 407
 49a28 5 252 407
 49a2d 3 251 407
 49a30 1d 252 407
 49a4d 5 253 407
-FUNC 49a60 2e 0 wcstoll_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 49a60 2e 0 _wcstoll_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 49a60 4 326 407
 49a64 5 327 407
 49a69 3 326 407
 49a6c 1d 327 407
 49a89 5 328 407
-FUNC 49a9c 2a 0 wcstoui64(wchar_t const*, wchar_t**, int)
+FUNC 49a9c 2a 0 _wcstoui64(wchar_t const*, wchar_t**, int)
 49a9c 4 347 407
 49aa0 21 348 407
 49ac1 5 349 407
-FUNC 49ad0 2e 0 wcstoui64_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 49ad0 2e 0 _wcstoui64_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 49ad0 4 377 407
 49ad4 5 378 407
 49ad9 3 377 407
 49adc 1d 378 407
 49af9 5 379 407
-FUNC 49b0c 2e 0 wcstoul_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 49b0c 2e 0 _wcstoul_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 49b0c 4 270 407
 49b10 5 271 407
 49b15 3 270 407
 49b18 1d 271 407
 49b35 5 272 407
-FUNC 49b48 2e 0 wcstoull_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 49b48 2e 0 _wcstoull_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 49b48 4 387 407
 49b4c 5 388 407
 49b51 3 387 407
 49b54 1d 388 407
 49b71 5 389 407
-FUNC 49b84 2e 0 wcstoumax_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 49b84 2e 0 _wcstoumax_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 49b84 4 397 407
 49b88 5 398 407
 49b8d 3 397 407
@@ -18488,7 +18488,7 @@ FUNC 49dfc 2a 0 wcstoumax(wchar_t const*, wchar_t**, int)
 49dfc 4 365 407
 49e00 21 366 407
 49e21 5 367 407
-FUNC 49e30 17e 0 mbtowc_l(wchar_t*, char const*, unsigned long long, __crt_locale_pointers*)
+FUNC 49e30 17e 0 _mbtowc_l(wchar_t*, char const*, unsigned long long, __crt_locale_pointers*)
 49e30 14 50 409
 49e44 1d 52 409
 49e61 5 60 409
@@ -18513,14 +18513,14 @@ FUNC 49e30 17e 0 mbtowc_l(wchar_t*, char const*, unsigned long long, __crt_local
 49f97 17 129 409
 FUNC 4a010 8 0 mbtowc(wchar_t*, char const*, unsigned long long)
 4a010 8 137 409
-FUNC 4a01c 72 0 wctomb_l(char*, wchar_t, __crt_locale_pointers*)
+FUNC 4a01c 72 0 _wctomb_l(char*, wchar_t, __crt_locale_pointers*)
 4a01c 10 161 415
 4a02c d 162 415
 4a039 29 165 415
 4a062 c 172 415
 4a06e 13 175 415
 4a081 d 176 415
-FUNC 4a0ac 19c 0 wctomb_s_l(int*, char*, unsigned long long, wchar_t, __crt_locale_pointers*)
+FUNC 4a0ac 19c 0 _wctomb_s_l(int*, char*, unsigned long long, wchar_t, __crt_locale_pointers*)
 4a0ac 1e 36 415
 4a0ca a 38 415
 4a0d4 5 41 415
@@ -18780,12 +18780,12 @@ FUNC 4b170 1d6 0 wcsnlen(wchar_t const*, unsigned long long)
 4b176 6 208 416
 4b17c 1c9 209 416
 4b345 1 210 416
-FUNC 4b3bc 31 0 _acrt_update_locale_info(__acrt_ptd* const, __crt_locale_data** const)
+FUNC 4b3bc 31 0 __acrt_update_locale_info(__acrt_ptd* const, __crt_locale_data** const)
 4b3bc 6 15 419
 4b3c2 1d 16 419
 4b3df 8 18 419
 4b3e7 6 20 419
-FUNC 4b3fc 31 0 _acrt_update_multibyte_info(__acrt_ptd* const, __crt_multibyte_data** const)
+FUNC 4b3fc 31 0 __acrt_update_multibyte_info(__acrt_ptd* const, __crt_multibyte_data** const)
 4b3fc 6 26 419
 4b402 1d 27 419
 4b41f 8 29 419
@@ -18989,7 +18989,7 @@ FUNC 4c114 30 0 shift_bytes(char* const, const unsigned long long, char* const, 
 4c13f 5 38 420
 FUNC 4c150 5 0 strrchr(char* const, const int)
 4c150 5 518 237
-FUNC 4c158 304 0 _acrt_fp_format(double const*, char*, unsigned long long, char*, unsigned long long, int, int, unsigned long long, __crt_locale_pointers*)
+FUNC 4c158 304 0 __acrt_fp_format(double const*, char*, unsigned long long, char*, unsigned long long, int, int, unsigned long long, __crt_locale_pointers*)
 4c158 20 693 420
 4c178 5 694 420
 4c17d 18 741 420
@@ -19015,7 +19015,7 @@ FUNC 4c520 1c 0 fputwc_binary_nolock(const wchar_t, const __crt_stdio_stream)
 4c52e 6 23 421
 4c534 7 25 421
 4c53b 1 26 421
-FUNC 4c544 17c 0 fputwc_nolock(wchar_t, _iobuf*)
+FUNC 4c544 17c 0 _fputwc_nolock(wchar_t, _iobuf*)
 4c544 21 31 421
 4c565 3 35 421
 4c568 6 31 421
@@ -19031,12 +19031,12 @@ FUNC 4c544 17c 0 fputwc_nolock(wchar_t, _iobuf*)
 4c677 2 68 421
 4c679 7 65 421
 4c680 40 69 421
-FUNC 4c720 23 0 fputwchar(wchar_t)
+FUNC 4c720 23 0 _fputwchar(wchar_t)
 4c720 9 113 421
 4c729 10 114 421
 4c739 5 115 421
 4c73e 5 114 421
-FUNC 4c74c 5 0 putwc_nolock(wchar_t, _iobuf*)
+FUNC 4c74c 5 0 _putwc_nolock(wchar_t, _iobuf*)
 4c74c 5 75 421
 FUNC 4c754 5e 0 fputwc(wchar_t, _iobuf*)
 4c754 15 83 421
@@ -19052,23 +19052,23 @@ FUNC 4c7d4 5 0 putwchar(wchar_t)
 4c7d4 5 122 421
 FUNC 4c7dc 7 0 __crt_stdio_stream::lowio_handle() const
 4c7dc 7 225 337
-FUNC 4c7e4 26 0 fileno(_iobuf*)
+FUNC 4c7e4 26 0 _fileno(_iobuf*)
 4c7e4 4 14 422
 4c7e8 1a 17 422
 4c802 3 18 422
 4c805 5 19 422
-FUNC 4c814 16 0 fputc_nolock(int, _iobuf*)
+FUNC 4c814 16 0 _fputc_nolock(int, _iobuf*)
 4c814 4 16 423
 4c818 6 20 423
 4c81e 8 27 423
 4c826 3 28 423
 4c829 1 29 423
-FUNC 4c830 21 0 fputchar(int)
+FUNC 4c830 21 0 _fputchar(int)
 4c830 8 73 423
 4c838 f 74 423
 4c847 5 75 423
 4c84c 5 74 423
-FUNC 4c85c 16 0 putc_nolock(int, _iobuf*)
+FUNC 4c85c 16 0 _putc_nolock(int, _iobuf*)
 4c85c 15 33 423
 4c871 1 34 423
 FUNC 4c878 124 0 fputc(int, _iobuf*)
@@ -19084,10 +19084,10 @@ FUNC 4c9e8 5 0 putc(int, _iobuf*)
 4c9e8 5 66 423
 FUNC 4c9f0 5 0 putchar(int)
 4c9f0 5 82 423
-FUNC 4c9f8 18 0 get_printf_count_output()
+FUNC 4c9f8 18 0 _get_printf_count_output()
 4c9f8 17 34 424
 4ca0f 1 35 424
-FUNC 4ca18 27 0 set_printf_count_output(int)
+FUNC 4ca18 27 0 _set_printf_count_output(int)
 4ca18 17 23 424
 4ca2f f 24 424
 4ca3e 1 26 424
@@ -19307,7 +19307,7 @@ FUNC 4d4dc 1b 0 __crt_unique_heap_ptr<__crt_locale_pointers,__crt_internal_free_
 4d4e5 8 395 99
 4d4ed 4 396 99
 4d4f1 6 397 99
-FUNC 4d500 82 0 _acrt_copy_locale_name(wchar_t const*)
+FUNC 4d500 82 0 __acrt_copy_locale_name(wchar_t const*)
 4d500 12 1398 425
 4d512 5 1402 425
 4d517 d 1405 425
@@ -19318,22 +19318,22 @@ FUNC 4d500 82 0 _acrt_copy_locale_name(wchar_t const*)
 4d55a 2 1410 425
 4d55c 10 1414 425
 4d56c 16 1412 425
-FUNC 4d5a4 c 0 _acrt_set_locale_changed()
+FUNC 4d5a4 c 0 __acrt_set_locale_changed()
 4d5a4 b 56 425
 4d5af 1 57 425
-FUNC 4d5b4 2e 0 _acrt_uninitialize_locale()
+FUNC 4d5b4 2e 0 __acrt_uninitialize_locale()
 4d5b4 7 117 425
 4d5bb 22 118 425
 4d5dd 5 130 425
-FUNC 4d5f0 e 0 _ascii_tolower(const int)
+FUNC 4d5f0 e 0 __ascii_tolower(const int)
 4d5f0 6 149 218
 4d5f6 5 151 218
 4d5fb 2 153 218
 4d5fd 1 154 218
-FUNC 4d604 d 0 _ascii_towlower(const int)
+FUNC 4d604 d 0 __ascii_towlower(const int)
 4d604 c 177 218
 4d610 1 178 218
-FUNC 4d614 a2 0 _lc_lctowcs(wchar_t*, unsigned long long, __crt_locale_strings const*)
+FUNC 4d614 a2 0 __lc_lctowcs(wchar_t*, unsigned long long, __crt_locale_strings const*)
 4d614 1d 1388 425
 4d631 b 1389 425
 4d63c c 1390 425
@@ -19342,7 +19342,7 @@ FUNC 4d614 a2 0 _lc_lctowcs(wchar_t*, unsigned long long, __crt_locale_strings c
 4d66f 1d 1393 425
 4d68c 15 1394 425
 4d6a1 15 1389 425
-FUNC 4d6e0 166 0 _lc_wcstolc(__crt_locale_strings*, wchar_t const*)
+FUNC 4d6e0 166 0 __lc_wcstolc(__crt_locale_strings*, wchar_t const*)
 4d6e0 1b 1323 425
 4d6fb 10 1328 425
 4d70b 9 1330 425
@@ -19367,7 +19367,7 @@ FUNC 4d6e0 166 0 _lc_wcstolc(__crt_locale_strings*, wchar_t const*)
 4d815 3 1369 425
 4d818 19 1384 425
 4d831 15 1366 425
-FUNC 4d8a0 69 0 configthreadlocale(int)
+FUNC 4d8a0 69 0 _configthreadlocale(int)
 4d8a0 8 72 425
 4d8a8 5 86 425
 4d8ad 11 87 425
@@ -19387,7 +19387,7 @@ FUNC 4d924 be 0 _copytlocinfo_nolock(__crt_locale_data*, __crt_locale_data*)
 4d9d4 4 281 425
 4d9d8 5 282 425
 4d9dd 5 284 425
-FUNC 4da14 76 0 create_locale(int, char const*)
+FUNC 4da14 76 0 _create_locale(int, char const*)
 4da14 1d 377 425
 4da31 a 381 425
 4da3b 26 384 425
@@ -19442,7 +19442,7 @@ FUNC 4daa8 47f 0 _expandlocale(wchar_t const*, wchar_t*, unsigned long long, wch
 4def5 5 1300 425
 4defa 18 1196 425
 4df12 15 1276 425
-FUNC 4e048 a2 0 free_locale(__crt_locale_pointers*)
+FUNC 4e048 a2 0 _free_locale(__crt_locale_pointers*)
 4e048 e 152 425
 4e056 3 151 425
 4e059 b 154 425
@@ -19457,7 +19457,7 @@ FUNC 4e048 a2 0 free_locale(__crt_locale_pointers*)
 4e0d2 a 189 425
 4e0dc 8 193 425
 4e0e4 6 195 425
-FUNC 4e114 bb 0 get_current_locale()
+FUNC 4e114 bb 0 _get_current_locale()
 4e114 b 209 425
 4e11f 5 210 425
 4e124 10 212 425
@@ -19476,7 +19476,7 @@ FUNC 4e114 bb 0 get_current_locale()
 4e18c 26 231 425
 4e1b2 15 236 425
 4e1c7 8 237 425
-FUNC 4e200 148 0 wcreate_locale(int, wchar_t const*)
+FUNC 4e200 148 0 _wcreate_locale(int, wchar_t const*)
 4e200 23 339 425
 4e223 14 340 425
 4e237 12 343 425
@@ -19497,7 +19497,7 @@ FUNC 4e200 148 0 wcreate_locale(int, wchar_t const*)
 4e30a 1d 366 425
 4e327 2 341 425
 4e329 1f 367 425
-FUNC 4e39c 65 0 wcscats(wchar_t*, unsigned long long, int, <NoType>)
+FUNC 4e39c 65 0 _wcscats(wchar_t*, unsigned long long, int, <NoType>)
 4e39c 5 1312 425
 4e3a1 12 1306 425
 4e3b3 5 1310 425
@@ -19506,7 +19506,7 @@ FUNC 4e39c 65 0 wcscats(wchar_t*, unsigned long long, int, <NoType>)
 4e3da 8 1312 425
 4e3e2 9 1317 425
 4e3eb 16 1314 425
-FUNC 4e41c a1 0 wsetlocale(int, wchar_t const*)
+FUNC 4e41c a1 0 _wsetlocale(int, wchar_t const*)
 4e41c 11 440 425
 4e42d 5 441 425
 4e432 5 442 425
@@ -19734,16 +19734,16 @@ FUNC 4f5c0 29 0 sync_legacy_variables_lk()
 4f5d5 a 296 425
 4f5df 9 297 425
 4f5e8 1 298 425
-FUNC 4f5f4 2f 0 _pctype_func()
+FUNC 4f5f4 2f 0 __pctype_func()
 4f5f4 4 20 426
 4f5f8 5 22 426
 4f5fd 19 25 426
 4f616 8 26 426
 4f61e 5 27 426
-FUNC 4f630 8 0 _pwctype_func()
+FUNC 4f630 8 0 __pwctype_func()
 4f630 7 16 426
 4f637 1 17 426
-FUNC 4f63c 5 0 iswctype_l(unsigned short, unsigned short, __crt_locale_pointers*)
+FUNC 4f63c 5 0 _iswctype_l(unsigned short, unsigned short, __crt_locale_pointers*)
 4f63c 5 37 427
 FUNC 4f644 6f 0 iswctype(unsigned short, unsigned short)
 4f644 a 41 427
@@ -19756,11 +19756,11 @@ FUNC 4f644 6f 0 iswctype(unsigned short, unsigned short)
 4f69f 7 54 427
 4f6a6 2 52 427
 4f6a8 b 55 427
-FUNC 4f6d0 30 0 isctype(int, int)
+FUNC 4f6d0 30 0 _isctype(int, int)
 4f6d0 10 110 428
 4f6e0 1f 115 428
 4f6ff 1 116 428
-FUNC 4f70c 108 0 isctype_l(int, int, __crt_locale_pointers*)
+FUNC 4f70c 108 0 _isctype_l(int, int, __crt_locale_pointers*)
 4f70c 2d 63 428
 4f739 c 64 428
 4f745 c 66 428
@@ -19776,10 +19776,10 @@ FUNC 4f70c 108 0 isctype_l(int, int, __crt_locale_pointers*)
 4f7c5 14 102 428
 4f7d9 4 105 428
 4f7dd 37 106 428
-FUNC 4f858 18 0 isleadbyte_fast_internal(const unsigned char, __crt_locale_pointers* const)
+FUNC 4f858 18 0 _isleadbyte_fast_internal(const unsigned char, __crt_locale_pointers* const)
 4f858 17 1565 201
 4f86f 1 1566 201
-FUNC 4f878 8b 0 _acrt_add_locale_ref(__crt_locale_data*)
+FUNC 4f878 8b 0 __acrt_add_locale_ref(__crt_locale_data*)
 4f878 4 24 429
 4f87c c 26 429
 4f888 3 28 429
@@ -19795,7 +19795,7 @@ FUNC 4f878 8b 0 _acrt_add_locale_ref(__crt_locale_data*)
 4f8ea 3 57 429
 4f8ed a 46 429
 4f8f7 c 61 429
-FUNC 4f928 176 0 _acrt_free_locale(__crt_locale_data*)
+FUNC 4f928 176 0 __acrt_free_locale(__crt_locale_data*)
 4f928 14 126 429
 4f93c 2c 132 429
 4f968 11 135 429
@@ -19821,25 +19821,25 @@ FUNC 4f928 176 0 _acrt_free_locale(__crt_locale_data*)
 4fa82 3 188 429
 4fa85 14 189 429
 4fa99 5 188 429
-FUNC 4fafc 27 0 _acrt_locale_add_lc_time_reference(__crt_lc_time_data const*)
+FUNC 4fafc 27 0 __acrt_locale_add_lc_time_reference(__crt_lc_time_data const*)
 4fafc 11 317 429
 4fb0d f 322 429
 4fb1c 1 323 429
 4fb1d 5 319 429
 4fb22 1 323 429
-FUNC 4fb2c 36 0 _acrt_locale_free_lc_time_if_unreferenced(__crt_lc_time_data const*)
+FUNC 4fb2c 36 0 __acrt_locale_free_lc_time_if_unreferenced(__crt_lc_time_data const*)
 4fb2c 19 341 429
 4fb45 a 346 429
 4fb4f 5 351 429
 4fb54 8 352 429
 4fb5c 6 353 429
-FUNC 4fb70 25 0 _acrt_locale_release_lc_time_reference(__crt_lc_time_data const*)
+FUNC 4fb70 25 0 __acrt_locale_release_lc_time_reference(__crt_lc_time_data const*)
 4fb70 11 329 429
 4fb81 d 334 429
 4fb8e 1 335 429
 4fb8f 5 331 429
 4fb94 1 335 429
-FUNC 4fba0 a8 0 _acrt_release_locale_ref(__crt_locale_data*)
+FUNC 4fba0 a8 0 __acrt_release_locale_ref(__crt_locale_data*)
 4fba0 4 72 429
 4fba4 9 73 429
 4fbad 9 76 429
@@ -19858,7 +19858,7 @@ FUNC 4fba0 a8 0 _acrt_release_locale_ref(__crt_locale_data*)
 4fc2d a 90 429
 4fc37 c 105 429
 4fc43 5 106 429
-FUNC 4fc74 6c 0 _acrt_update_thread_locale_data()
+FUNC 4fc74 6c 0 __acrt_update_thread_locale_data()
 4fc74 a 268 429
 4fc7e 5 270 429
 4fc83 1d 272 429
@@ -19869,7 +19869,7 @@ FUNC 4fc74 6c 0 _acrt_update_thread_locale_data()
 4fccc 3 294 429
 4fccf b 295 429
 4fcda 6 291 429
-FUNC 4fcfc 65 0 updatetlocinfoEx_nolock(__crt_locale_data**, __crt_locale_data*)
+FUNC 4fcfc 65 0 _updatetlocinfoEx_nolock(__crt_locale_data**, __crt_locale_data*)
 4fcfc d 204 429
 4fd09 a 205 429
 4fd13 3 208 429
@@ -19887,10 +19887,10 @@ FUNC 4fcfc 65 0 updatetlocinfoEx_nolock(__crt_locale_data**, __crt_locale_data*)
 FUNC 4fd7c 4 0 __crt_state_management::dual_state_global<long>::value()
 4fd7c 3 147 180
 4fd7f 1 148 180
-FUNC 4fd80 7 0 query_new_mode()
+FUNC 4fd80 7 0 _query_new_mode()
 4fd80 6 30 430
 4fd86 1 31 430
-FUNC 4fd88 2b 0 set_new_mode(int)
+FUNC 4fd88 2b 0 _set_new_mode(int)
 4fd88 4 20 430
 4fd8c 1a 22 430
 4fda6 8 24 430
@@ -20192,9 +20192,9 @@ FUNC 508d0 3e0 0 strpbrk(char const*, char const*)
 50bc0 c 492 437
 50bcc 2 499 437
 50bce e2 501 437
-FUNC 50da8 8 0 mbsdec(unsigned char const*, unsigned char const*)
+FUNC 50da8 8 0 _mbsdec(unsigned char const*, unsigned char const*)
 50da8 8 108 438
-FUNC 50db4 94 0 mbsdec_l(unsigned char const*, unsigned char const*, __crt_locale_pointers*)
+FUNC 50db4 94 0 _mbsdec_l(unsigned char const*, unsigned char const*, __crt_locale_pointers*)
 50db4 10 44 438
 50dc4 5 48 438
 50dc9 14 101 438
@@ -20217,17 +20217,17 @@ FUNC 50e80 22 0 __crt_scoped_stack_ptr<wchar_t>::~__crt_scoped_stack_ptr<wchar_t
 50e9d 5 457 99
 FUNC 50eac 4 0 __crt_scoped_stack_ptr<wchar_t>::get() const
 50eac 4 459 99
-FUNC 50eb0 e 0 MallocaComputeSize(unsigned long long)
+FUNC 50eb0 e 0 _MallocaComputeSize(unsigned long long)
 50eb0 4 104 131
 50eb4 9 105 131
 50ebd 1 106 131
-FUNC 50ec4 f 0 MarkAllocaS(void*, unsigned int)
+FUNC 50ec4 f 0 _MarkAllocaS(void*, unsigned int)
 50ec4 5 94 131
 50ec9 2 96 131
 50ecb 4 97 131
 50ecf 3 99 131
 50ed2 1 100 131
-FUNC 50ed8 18d 0 _acrt_GetStringTypeA(__crt_locale_pointers*, unsigned long, char const*, int, unsigned short*, int, int)
+FUNC 50ed8 18d 0 __acrt_GetStringTypeA(__crt_locale_pointers*, unsigned long, char const*, int, unsigned short*, int, int)
 50ed8 33 52 439
 50f0b f 53 439
 50f1a 11 64 439
@@ -20242,7 +20242,7 @@ FUNC 50ed8 18d 0 _acrt_GetStringTypeA(__crt_locale_pointers*, unsigned long, cha
 50ff6 4 96 439
 50ffa 45 99 439
 5103f 26 100 439
-FUNC 510c8 1f 0 freea_crt(void*)
+FUNC 510c8 1f 0 _freea_crt(void*)
 510c8 4 308 99
 510cc 5 309 99
 510d1 4 313 99
@@ -20285,7 +20285,7 @@ FUNC 510fc 315 0 __acrt_LCMapStringA_stat(__crt_locale_pointers*, wchar_t const*
 513ef f 194 440
 513fe 11 205 440
 5140f 2 207 440
-FUNC 514d8 96 0 _acrt_LCMapStringA(__crt_locale_pointers*, wchar_t const*, unsigned long, char const*, int, char*, int, int, int)
+FUNC 514d8 96 0 __acrt_LCMapStringA(__crt_locale_pointers*, wchar_t const*, unsigned long, char const*, int, char*, int, int, int)
 514d8 15 221 440
 514ed 10 222 440
 514fd 5f 224 440
@@ -20294,7 +20294,7 @@ FUNC 51594 17 0 initialize_multibyte()
 51594 4 16 442
 51598 e 17 442
 515a6 5 18 442
-FUNC 515b0 4f 0 wcsnicoll(wchar_t const*, wchar_t const*, unsigned long long)
+FUNC 515b0 4f 0 _wcsnicoll(wchar_t const*, wchar_t const*, unsigned long long)
 515b0 4 89 443
 515b4 9 90 443
 515bd 5 93 443
@@ -20306,7 +20306,7 @@ FUNC 515b0 4f 0 wcsnicoll(wchar_t const*, wchar_t const*, unsigned long long)
 515f3 3 101 443
 515f6 4 103 443
 515fa 5 101 443
-FUNC 51614 f0 0 wcsnicoll_l(wchar_t const*, wchar_t const*, unsigned long long, __crt_locale_pointers*)
+FUNC 51614 f0 0 _wcsnicoll_l(wchar_t const*, wchar_t const*, unsigned long long, __crt_locale_pointers*)
 51614 1d 49 443
 51631 5 52 443
 51636 7 54 443
@@ -20321,10 +20321,10 @@ FUNC 51614 f0 0 wcsnicoll_l(wchar_t const*, wchar_t const*, unsigned long long, 
 516ca d 77 443
 516d7 16 81 443
 516ed 17 82 443
-FUNC 51740 15 0 strnicoll(char const*, char const*, unsigned long long)
+FUNC 51740 15 0 _strnicoll(char const*, char const*, unsigned long long)
 51740 d 85 444
 5174d 8 91 444
-FUNC 5175c 100 0 strnicoll_l(char const*, char const*, unsigned long long, __crt_locale_pointers*)
+FUNC 5175c 100 0 _strnicoll_l(char const*, char const*, unsigned long long, __crt_locale_pointers*)
 5175c 1a 47 444
 51776 f 49 444
 51785 c 51 444
@@ -20367,7 +20367,7 @@ FUNC 51a74 25 0 <lambda_7c9dea7b4ca7285d2cdb541a38da6275>::operator()(const unsi
 51a74 4 630 323
 51a78 1c 632 323
 51a94 5 640 323
-FUNC 51aa4 197 0 _acrt_SetEnvironmentVariableA(char const*, char const*)
+FUNC 51aa4 197 0 __acrt_SetEnvironmentVariableA(char const*, char const*)
 51aa4 1f 15 445
 51ac3 3 16 445
 51ac6 6 15 445
@@ -20385,16 +20385,16 @@ FUNC 51aa4 197 0 _acrt_SetEnvironmentVariableA(char const*, char const*)
 51be3 8 35 445
 51beb 31 39 445
 51c1c 1f 40 445
-FUNC 51ca0 5 0 msize(void*)
+FUNC 51ca0 5 0 _msize(void*)
 51ca0 5 40 446
-FUNC 51ca8 39 0 msize_base(void*)
+FUNC 51ca8 39 0 _msize_base(void*)
 51ca8 4 21 446
 51cac 19 23 446
 51cc5 5 26 446
 51cca c 25 446
 51cd6 4 26 446
 51cda 7 25 446
-FUNC 51cf0 7a 0 realloc_base(void*, unsigned long long)
+FUNC 51cf0 7a 0 _realloc_base(void*, unsigned long long)
 51cf0 10 28 447
 51d00 5 30 447
 51d05 a 31 447
@@ -20429,7 +20429,7 @@ FUNC 51de8 87 0 GetTableIndexFromLocaleName(wchar_t const*)
 51e49 5 523 448
 51e4e 8 515 448
 51e56 19 524 448
-FUNC 51e90 f4 0 _acrt_DownlevelLCIDToLocaleName(unsigned long, wchar_t*, int)
+FUNC 51e90 f4 0 __acrt_DownlevelLCIDToLocaleName(unsigned long, wchar_t*, int)
 51e90 1d 571 448
 51ead 14 577 448
 51ec1 15 583 448
@@ -20444,7 +20444,7 @@ FUNC 51e90 f4 0 _acrt_DownlevelLCIDToLocaleName(unsigned long, wchar_t*, int)
 51f57 2 580 448
 51f59 15 604 448
 51f6e 16 600 448
-FUNC 51fc4 af 0 _acrt_DownlevelLocaleNameToLCID(wchar_t const*)
+FUNC 51fc4 af 0 __acrt_DownlevelLocaleNameToLCID(wchar_t const*)
 51fc4 1b 552 448
 51fdf 5 555 448
 51fe4 5a 558 448
@@ -20479,7 +20479,7 @@ FUNC 52100 1b 0 __crt_unique_heap_ptr<__crt_lowio_handle_data,__crt_internal_fre
 52109 8 395 99
 52111 4 396 99
 52115 6 397 99
-FUNC 52124 a5 0 _acrt_lowio_create_handle_array()
+FUNC 52124 a5 0 __acrt_lowio_create_handle_array()
 52124 14 14 449
 52138 d 15 449
 52145 2 19 449
@@ -20498,14 +20498,14 @@ FUNC 52124 a5 0 _acrt_lowio_create_handle_array()
 5219a d 24 449
 521a7 a 43 449
 521b1 18 44 449
-FUNC 521f4 50 0 _acrt_lowio_destroy_handle_array(__crt_lowio_handle_data*)
+FUNC 521f4 50 0 __acrt_lowio_destroy_handle_array(__crt_lowio_handle_data*)
 521f4 14 48 449
 52208 a 52 449
 52212 8 53 449
 5221a 12 55 449
 5222c 8 58 449
 52234 10 59 449
-FUNC 52258 a8 0 _acrt_lowio_ensure_fh_exists(int)
+FUNC 52258 a8 0 __acrt_lowio_ensure_fh_exists(int)
 52258 17 67 449
 5226f 1b 68 449
 5228a 16 98 449
@@ -20522,9 +20522,9 @@ FUNC 52258 a8 0 _acrt_lowio_ensure_fh_exists(int)
 522ed 5 75 449
 522f2 a 94 449
 522fc 4 97 449
-FUNC 5232c 27 0 _acrt_lowio_lock_fh(int)
+FUNC 5232c 27 0 __acrt_lowio_lock_fh(int)
 5232c 27 339 449
-FUNC 5235c bf 0 _acrt_lowio_set_os_handle(int, long long)
+FUNC 5235c bf 0 __acrt_lowio_set_os_handle(int, long long)
 5235c 1f 194 449
 5237b 30 196 449
 523ab a 199 449
@@ -20538,9 +20538,9 @@ FUNC 5235c bf 0 _acrt_lowio_set_os_handle(int, long long)
 523f5 8 216 449
 523fd 3 217 449
 52400 1b 219 449
-FUNC 5244c 27 0 _acrt_lowio_unlock_fh(int)
+FUNC 5244c 27 0 __acrt_lowio_unlock_fh(int)
 5244c 27 347 449
-FUNC 5247c 13e 0 alloc_osfhnd()
+FUNC 5247c 13e 0 _alloc_osfhnd()
 5247c 19 116 449
 52495 a 117 449
 5249f 4 118 449
@@ -20571,7 +20571,7 @@ FUNC 5247c 13e 0 alloc_osfhnd()
 52593 a 184 449
 5259d 3 186 449
 525a0 1a 187 449
-FUNC 5260c ba 0 free_osfhnd(int)
+FUNC 5260c ba 0 _free_osfhnd(int)
 5260c 18 226 449
 52624 37 229 449
 5265b a 232 449
@@ -20585,14 +20585,14 @@ FUNC 5260c ba 0 free_osfhnd(int)
 526a5 8 248 449
 526ad 3 249 449
 526b0 16 251 449
-FUNC 526f4 75 0 get_osfhandle(int)
+FUNC 526f4 75 0 _get_osfhandle(int)
 526f4 4 258 449
 526f8 1a 259 449
 52712 c 260 449
 5271e 23 261 449
 52741 7 263 449
 52748 21 264 449
-FUNC 52788 101 0 open_osfhandle(long long, int)
+FUNC 52788 101 0 _open_osfhandle(long long, int)
 52788 12 272 449
 5279a 7 276 449
 527a1 7 279 449
@@ -20653,7 +20653,7 @@ FUNC 52a50 7 0 <lambda_99fb1378e971ab6e7edea83e3a7a83a2>::operator()() const
 52a50 7 223 338
 FUNC 52a58 7 0 <lambda_a37b2b86f63e897a80ea819b0eb08c01>::operator()() const
 52a58 7 221 338
-FUNC 52a60 91 0 commit(int)
+FUNC 52a60 91 0 _commit(int)
 52a60 b 16 450
 52a6b 12 17 450
 52a7d c 18 450
@@ -20821,10 +20821,10 @@ FUNC 535b8 170 0 write_text_utf8_nolock(const int, char const* const, const unsi
 536d9 8 581 451
 536e1 10 585 451
 536f1 37 589 451
-FUNC 53784 e 0 utf8_no_of_trailbytes(const unsigned char)
+FUNC 53784 e 0 _utf8_no_of_trailbytes(const unsigned char)
 53784 d 47 338
 53791 1 48 338
-FUNC 53798 eb 0 write(int, void const*, unsigned int)
+FUNC 53798 eb 0 _write(int, void const*, unsigned int)
 53798 24 47 451
 537bc 1d 48 451
 537d9 c 49 451
@@ -20839,7 +20839,7 @@ FUNC 53798 eb 0 write(int, void const*, unsigned int)
 53845 7 68 451
 5384c 4 70 451
 53850 33 71 451
-FUNC 538c0 2da 0 write_nolock(int, void const*, unsigned int)
+FUNC 538c0 2da 0 _write_nolock(int, void const*, unsigned int)
 538c0 20 612 451
 538e0 9 614 451
 538e9 5 618 451
@@ -20889,7 +20889,7 @@ FUNC 53c50 33 0 localeconv()
 FUNC 53c90 c 0 __crt_stdio_stream::is_in_use() const
 53c90 b 179 337
 53c9b 1 180 337
-FUNC 53ca0 b1 0 fcloseall()
+FUNC 53ca0 b1 0 _fcloseall()
 53ca0 a 16 453
 53caa 5 17 453
 53caf b 19 453
@@ -20907,7 +20907,7 @@ FUNC 53ca0 b1 0 fcloseall()
 53d46 b 44 453
 FUNC 53d80 c 0 __crt_stdio_stream::has_crt_buffer() const
 53d80 c 216 337
-FUNC 53d90 40 0 _acrt_stdio_free_buffer_nolock(_iobuf*)
+FUNC 53d90 40 0 __acrt_stdio_free_buffer_nolock(_iobuf*)
 53d90 6 16 454
 53d96 3 21 454
 53d99 3 16 454
@@ -20919,59 +20919,59 @@ FUNC 53d90 40 0 _acrt_stdio_free_buffer_nolock(_iobuf*)
 53dc4 3 31 454
 53dc7 3 32 454
 53dca 6 33 454
-FUNC 53de0 5f 0 isatty(int)
+FUNC 53de0 5f 0 _isatty(int)
 53de0 4 15 456
 53de4 12 16 456
 53df6 c 17 456
 53e02 26 19 456
 53e28 10 17 456
 53e38 7 20 456
-FUNC 53e58 2c 0 _iswcsym(unsigned short)
+FUNC 53e58 2c 0 __iswcsym(unsigned short)
 53e58 6 158 457
 53e5e 20 160 457
 53e7e 6 161 457
-FUNC 53e90 2c 0 _iswcsymf(unsigned short)
+FUNC 53e90 2c 0 __iswcsymf(unsigned short)
 53e90 6 168 457
 53e96 20 170 457
 53eb6 6 171 457
-FUNC 53ec8 4b 0 isleadbyte_l(int, __crt_locale_pointers*)
+FUNC 53ec8 4b 0 _isleadbyte_l(int, __crt_locale_pointers*)
 53ec8 9 17 457
 53ed1 a 19 457
 53edb 32 20 457
 53f0d 6 21 457
-FUNC 53f28 a 0 iswalnum_l(unsigned short, __crt_locale_pointers*)
+FUNC 53f28 a 0 _iswalnum_l(unsigned short, __crt_locale_pointers*)
 53f28 a 110 457
-FUNC 53f34 a 0 iswalpha_l(unsigned short, __crt_locale_pointers*)
+FUNC 53f34 a 0 _iswalpha_l(unsigned short, __crt_locale_pointers*)
 53f34 a 30 457
-FUNC 53f40 16 0 iswblank_l(unsigned short, __crt_locale_pointers*)
+FUNC 53f40 16 0 _iswblank_l(unsigned short, __crt_locale_pointers*)
 53f40 b 100 457
 53f4b 1 101 457
 53f4c a 100 457
-FUNC 53f5c a 0 iswcntrl_l(unsigned short, __crt_locale_pointers*)
+FUNC 53f5c a 0 _iswcntrl_l(unsigned short, __crt_locale_pointers*)
 53f5c a 140 457
-FUNC 53f68 2c 0 iswcsym_l(unsigned short, __crt_locale_pointers*)
+FUNC 53f68 2c 0 _iswcsym_l(unsigned short, __crt_locale_pointers*)
 53f68 6 153 457
 53f6e 20 155 457
 53f8e 6 156 457
-FUNC 53fa0 2c 0 iswcsymf_l(unsigned short, __crt_locale_pointers*)
+FUNC 53fa0 2c 0 _iswcsymf_l(unsigned short, __crt_locale_pointers*)
 53fa0 6 163 457
 53fa6 20 165 457
 53fc6 6 166 457
-FUNC 53fd8 a 0 iswdigit_l(unsigned short, __crt_locale_pointers*)
+FUNC 53fd8 a 0 _iswdigit_l(unsigned short, __crt_locale_pointers*)
 53fd8 a 60 457
-FUNC 53fe4 a 0 iswgraph_l(unsigned short, __crt_locale_pointers*)
+FUNC 53fe4 a 0 _iswgraph_l(unsigned short, __crt_locale_pointers*)
 53fe4 a 130 457
-FUNC 53ff0 a 0 iswlower_l(unsigned short, __crt_locale_pointers*)
+FUNC 53ff0 a 0 _iswlower_l(unsigned short, __crt_locale_pointers*)
 53ff0 a 50 457
-FUNC 53ffc a 0 iswprint_l(unsigned short, __crt_locale_pointers*)
+FUNC 53ffc a 0 _iswprint_l(unsigned short, __crt_locale_pointers*)
 53ffc a 120 457
-FUNC 54008 a 0 iswpunct_l(unsigned short, __crt_locale_pointers*)
+FUNC 54008 a 0 _iswpunct_l(unsigned short, __crt_locale_pointers*)
 54008 a 90 457
-FUNC 54014 a 0 iswspace_l(unsigned short, __crt_locale_pointers*)
+FUNC 54014 a 0 _iswspace_l(unsigned short, __crt_locale_pointers*)
 54014 a 80 457
-FUNC 54020 a 0 iswupper_l(unsigned short, __crt_locale_pointers*)
+FUNC 54020 a 0 _iswupper_l(unsigned short, __crt_locale_pointers*)
 54020 a 40 457
-FUNC 5402c a 0 iswxdigit_l(unsigned short, __crt_locale_pointers*)
+FUNC 5402c a 0 _iswxdigit_l(unsigned short, __crt_locale_pointers*)
 5402c a 70 457
 FUNC 54038 4d 0 isleadbyte(int)
 54038 9 23 457
@@ -21187,34 +21187,34 @@ FUNC 54b3c 1b 0 __crt_unique_heap_ptr<long,__crt_internal_free_policy>::release(
 54b45 8 395 99
 54b4d 4 396 99
 54b51 6 397 99
-FUNC 54b60 2f 0 __lc_codepage_func()
+FUNC 54b60 2f 0 ___lc_codepage_func()
 54b60 4 297 459
 54b64 5 303 459
 54b69 19 306 459
 54b82 8 308 459
 54b8a 5 309 459
-FUNC 54b9c 2f 0 __lc_collate_cp_func()
+FUNC 54b9c 2f 0 ___lc_collate_cp_func()
 54b9c 4 312 459
 54ba0 5 318 459
 54ba5 19 321 459
 54bbe 8 323 459
 54bc6 5 324 459
-FUNC 54bd8 32 0 __lc_locale_name_func()
+FUNC 54bd8 32 0 ___lc_locale_name_func()
 54bd8 4 327 459
 54bdc 5 333 459
 54be1 19 336 459
 54bfa b 338 459
 54c05 5 339 459
-FUNC 54c18 2f 0 __mb_cur_max_func()
+FUNC 54c18 2f 0 ___mb_cur_max_func()
 54c18 4 275 459
 54c1c 5 281 459
 54c21 19 284 459
 54c3a 8 286 459
 54c42 5 287 459
-FUNC 54c54 10 0 __mb_cur_max_l_func(__crt_locale_pointers*)
+FUNC 54c54 10 0 ___mb_cur_max_l_func(__crt_locale_pointers*)
 54c54 f 291 459
 54c63 1 294 459
-FUNC 54c68 661 0 _acrt_locale_initialize_ctype(__crt_locale_data*)
+FUNC 54c68 661 0 __acrt_locale_initialize_ctype(__crt_locale_data*)
 54c68 31 54 459
 54c99 28 76 459
 54cc1 11 80 459
@@ -21324,7 +21324,7 @@ FUNC 55550 1c 0 __crt_mbstring::return_illegal_sequence(_Mbstatet*)
 55567 5 140 382
 FUNC 55574 5 0 c32rtomb(char*, char32_t, _Mbstatet*)
 55574 5 16 460
-FUNC 5557c e2 0 _acrt_fp_strflt_to_string(char*, unsigned long long, int, _strflt*)
+FUNC 5557c e2 0 __acrt_fp_strflt_to_string(char*, unsigned long long, int, _strflt*)
 5557c 10 28 461
 5558c 5 29 461
 55591 18 87 461
@@ -21714,7 +21714,7 @@ FUNC 581b0 14d 0 __crt_strtox::shift_left(__crt_strtox::big_integer&, const unsi
 582c5 1e 216 355
 582e3 2 217 355
 582e5 18 250 355
-FUNC 58350 1231 0 _acrt_fltout(_CRT_DOUBLE, unsigned int, _strflt*, char*, unsigned long long)
+FUNC 58350 1231 0 __acrt_fltout(_CRT_DOUBLE, unsigned int, _strflt*, char*, unsigned long long)
 58350 35 271 462
 58385 5 275 462
 5838a f 271 462
@@ -21852,13 +21852,13 @@ FUNC 59f54 79 0 stream_is_at_end_of_file_nolock(const __crt_stdio_stream)
 59fb6 f 48 463
 59fc5 2 45 463
 59fc7 6 49 463
-FUNC 59fec ea 0 _acrt_stdio_flush_and_write_narrow_nolock(int, _iobuf*)
+FUNC 59fec ea 0 __acrt_stdio_flush_and_write_narrow_nolock(int, _iobuf*)
 59fec 14 195 463
 5a000 1f 196 463
 5a01f d 197 463
 5a02c 9a 196 463
 5a0c6 10 197 463
-FUNC 5a110 eb 0 _acrt_stdio_flush_and_write_wide_nolock(int, _iobuf*)
+FUNC 5a110 eb 0 __acrt_stdio_flush_and_write_wide_nolock(int, _iobuf*)
 5a110 14 205 463
 5a124 1f 206 463
 5a143 f 207 463
@@ -21882,7 +21882,7 @@ FUNC 5a27c 1b 0 __crt_unique_heap_ptr<lconv,__crt_internal_free_policy>::release
 5a285 8 395 99
 5a28d 4 396 99
 5a291 6 397 99
-FUNC 5a2a0 10a 0 _acrt_locale_free_monetary(lconv*)
+FUNC 5a2a0 10a 0 __acrt_locale_free_monetary(lconv*)
 5a2a0 e 267 464
 5a2ae 3 266 464
 5a2b1 d 270 464
@@ -21912,7 +21912,7 @@ FUNC 5a2a0 10a 0 _acrt_locale_free_monetary(lconv*)
 5a38f 10 306 464
 5a39f 5 307 464
 5a3a4 6 308 464
-FUNC 5a3ec 533 0 _acrt_locale_initialize_monetary(__crt_locale_data*)
+FUNC 5a3ec 533 0 __acrt_locale_initialize_monetary(__crt_locale_data*)
 5a3ec 1f 64 464
 5a40b 3 69 464
 5a40e 4 72 464
@@ -21989,7 +21989,7 @@ FUNC 5aa6c 34 0 fix_grouping(char*)
 5aa8e 9 249 464
 5aa97 7 250 464
 5aa9e 2 254 464
-FUNC 5aab0 6c 0 _acrt_locale_free_numeric(lconv*)
+FUNC 5aab0 6c 0 __acrt_locale_free_numeric(lconv*)
 5aab0 a 214 465
 5aaba 3 213 465
 5aabd c 217 465
@@ -22003,7 +22003,7 @@ FUNC 5aab0 6c 0 _acrt_locale_free_numeric(lconv*)
 5ab04 d 229 465
 5ab11 5 230 465
 5ab16 6 231 465
-FUNC 5ab38 2e8 0 _acrt_locale_initialize_numeric(__crt_locale_data*)
+FUNC 5ab38 2e8 0 __acrt_locale_initialize_numeric(__crt_locale_data*)
 5ab38 1c 79 465
 5ab54 d 88 465
 5ab61 12 90 465
@@ -22142,7 +22142,7 @@ FUNC 5b4dc 1b 0 __crt_unique_heap_ptr<__crt_lc_time_data,__crt_internal_free_pol
 5b4e5 8 395 99
 5b4ed 4 396 99
 5b4f1 6 397 99
-FUNC 5b500 108 0 _acrt_locale_free_time(__crt_lc_time_data*)
+FUNC 5b500 108 0 __acrt_locale_free_time(__crt_lc_time_data*)
 5b500 18 151 466
 5b518 5 156 466
 5b51d 3 150 466
@@ -22164,7 +22164,7 @@ FUNC 5b500 108 0 _acrt_locale_free_time(__crt_lc_time_data*)
 5b5e0 c 174 466
 5b5ec c 176 466
 5b5f8 10 177 466
-FUNC 5b64c 9c 0 _acrt_locale_initialize_time(__crt_locale_data*)
+FUNC 5b64c 9c 0 __acrt_locale_initialize_time(__crt_locale_data*)
 5b64c f 107 466
 5b65b 2 108 466
 5b65d 3 107 466
@@ -22361,7 +22361,7 @@ FUNC 5c4bc 99 0 TranslateName(__crt_locale_string_table const*, int, wchar_t con
 5c52b 4 330 470
 5c52f 2 343 470
 5c531 24 344 470
-FUNC 5c57c 263 0 _acrt_get_qualified_locale(__crt_locale_strings const*, unsigned int*, __crt_locale_strings*)
+FUNC 5c57c 263 0 __acrt_get_qualified_locale(__crt_locale_strings const*, unsigned int*, __crt_locale_strings*)
 5c57c 26 171 470
 5c5a2 5 173 470
 5c5a7 3 174 470
@@ -22555,7 +22555,7 @@ FUNC 5d29c 7f 0 TranslateName(__crt_locale_string_table const*, int, wchar_t con
 5d2f4 19 255 471
 5d30d a 245 471
 5d317 4 246 471
-FUNC 5d33c 27e 0 _acrt_get_qualified_locale_downlevel(__crt_locale_strings const*, unsigned int*, __crt_locale_strings*)
+FUNC 5d33c 27e 0 __acrt_get_qualified_locale_downlevel(__crt_locale_strings const*, unsigned int*, __crt_locale_strings*)
 5d33c 29 90 471
 5d365 8 94 471
 5d36d 9 100 471
@@ -22594,13 +22594,13 @@ FUNC 5d33c 27e 0 _acrt_get_qualified_locale_downlevel(__crt_locale_strings const
 5d596 7 209 471
 5d59d 2 170 471
 5d59f 1b 210 471
-FUNC 5d65c 7 0 _acrt_GetStringTypeW(unsigned long, wchar_t const*, int, unsigned short*)
+FUNC 5d65c 7 0 __acrt_GetStringTypeW(unsigned long, wchar_t const*, int, unsigned short*)
 5d65c 7 46 473
-FUNC 5d664 15 0 _strncnt(char const*, unsigned long long)
+FUNC 5d664 15 0 __strncnt(char const*, unsigned long long)
 5d664 2 19 474
 5d666 12 21 474
 5d678 1 24 474
-FUNC 5d680 bd 0 _acrt_CompareStringW(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t const*, int)
+FUNC 5d680 bd 0 __acrt_CompareStringW(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t const*, int)
 5d680 24 43 475
 5d6a4 5 49 475
 5d6a9 e 50 475
@@ -22610,7 +22610,7 @@ FUNC 5d680 bd 0 _acrt_CompareStringW(wchar_t const*, unsigned long, wchar_t cons
 5d6de 2d 58 475
 5d70b 17 55 475
 5d722 1b 67 475
-FUNC 5d76c 4b 0 _ascii_wcsnicmp(wchar_t const*, wchar_t const*, unsigned long long)
+FUNC 5d76c 4b 0 __ascii_wcsnicmp(wchar_t const*, wchar_t const*, unsigned long long)
 5d76c 6 92 476
 5d772 5 93 476
 5d777 2 95 476
@@ -22624,18 +22624,18 @@ FUNC 5d76c 4b 0 _ascii_wcsnicmp(wchar_t const*, wchar_t const*, unsigned long lo
 5d7a1 8 109 476
 5d7a9 d 111 476
 5d7b6 1 114 476
-FUNC 5d7cc 26 0 towlower_fast_internal(const unsigned char, __crt_locale_pointers* const)
+FUNC 5d7cc 26 0 _towlower_fast_internal(const unsigned char, __crt_locale_pointers* const)
 5d7cc 12 1522 201
 5d7de f 1524 201
 5d7ed 1 1528 201
 5d7ee 3 1527 201
 5d7f1 1 1528 201
-FUNC 5d7fc 34 0 towlower_internal(const unsigned short, __crt_locale_pointers* const)
+FUNC 5d7fc 34 0 _towlower_internal(const unsigned short, __crt_locale_pointers* const)
 5d7fc a 1535 201
 5d806 24 1537 201
 5d82a 1 1541 201
 5d82b 5 1540 201
-FUNC 5d840 46 0 wcsnicmp(wchar_t const*, wchar_t const*, unsigned long long)
+FUNC 5d840 46 0 _wcsnicmp(wchar_t const*, wchar_t const*, unsigned long long)
 5d840 4 121 476
 5d844 9 122 476
 5d84d 5 125 476
@@ -22646,7 +22646,7 @@ FUNC 5d840 46 0 wcsnicmp(wchar_t const*, wchar_t const*, unsigned long long)
 5d87a 3 131 476
 5d87d 4 132 476
 5d881 5 131 476
-FUNC 5d898 150 0 wcsnicmp_l(wchar_t const*, wchar_t const*, unsigned long long, __crt_locale_pointers*)
+FUNC 5d898 150 0 _wcsnicmp_l(wchar_t const*, wchar_t const*, unsigned long long, __crt_locale_pointers*)
 5d898 26 50 476
 5d8be 5 52 476
 5d8c3 1a 85 476
@@ -22663,7 +22663,7 @@ FUNC 5d898 150 0 wcsnicmp_l(wchar_t const*, wchar_t const*, unsigned long long, 
 5d9a4 10 82 476
 5d9b4 15 84 476
 5d9c9 1f 85 476
-FUNC 5da3c 49 0 _ascii_strnicmp(char const*, char const*, unsigned long long)
+FUNC 5da3c 49 0 __ascii_strnicmp(char const*, char const*, unsigned long long)
 5da3c 6 86 477
 5da42 5 87 477
 5da47 2 89 477
@@ -22677,7 +22677,7 @@ FUNC 5da3c 49 0 _ascii_strnicmp(char const*, char const*, unsigned long long)
 5da6f 8 103 477
 5da77 d 105 477
 5da84 1 108 477
-FUNC 5da98 4f 0 strnicmp(char const*, char const*, unsigned long long)
+FUNC 5da98 4f 0 _strnicmp(char const*, char const*, unsigned long long)
 5da98 4 117 477
 5da9c 9 118 477
 5daa5 5 121 477
@@ -22689,7 +22689,7 @@ FUNC 5da98 4f 0 strnicmp(char const*, char const*, unsigned long long)
 5dadb 3 128 477
 5dade 4 129 477
 5dae2 5 128 477
-FUNC 5dafc ad 0 strnicmp_l(char const*, char const*, unsigned long long, __crt_locale_pointers*)
+FUNC 5dafc ad 0 _strnicmp_l(char const*, char const*, unsigned long long, __crt_locale_pointers*)
 5dafc 18 47 477
 5db14 5 49 477
 5db19 17 76 477
@@ -22750,7 +22750,7 @@ FUNC 5dbd4 35d 0 InternalCompareStringA(__crt_locale_pointers*, wchar_t const*, 
 5df0b 7 137 478
 5df12 2 155 478
 5df14 1d 207 478
-FUNC 5e008 89 0 _acrt_CompareStringA(__crt_locale_pointers*, wchar_t const*, unsigned long, char const*, int, char const*, int, int)
+FUNC 5e008 89 0 __acrt_CompareStringA(__crt_locale_pointers*, wchar_t const*, unsigned long, char const*, int, char const*, int, int)
 5e008 15 219 478
 5e01d 10 220 478
 5e02d 54 222 478
@@ -22776,7 +22776,7 @@ FUNC 5e0f0 a7 0 write_string_to_console(wchar_t const* const)
 5e130 1e 137 479
 5e14e 30 145 479
 5e17e 19 146 479
-FUNC 5e1c0 15d 0 _acrt_report_runtime_error(wchar_t const*)
+FUNC 5e1c0 15d 0 __acrt_report_runtime_error(wchar_t const*)
 5e1c0 1b 151 479
 5e1db 26 159 479
 5e201 27 172 479
@@ -22792,10 +22792,10 @@ FUNC 5e1c0 15d 0 _acrt_report_runtime_error(wchar_t const*)
 5e2e7 8 161 479
 5e2ef 19 198 479
 5e308 15 172 479
-FUNC 5e374 7 0 query_app_type()
+FUNC 5e374 7 0 _query_app_type()
 5e374 6 87 479
 5e37a 1 88 479
-FUNC 5e37c 7 0 set_app_type(_crt_app_type)
+FUNC 5e37c 7 0 _set_app_type(_crt_app_type)
 5e37c 6 82 479
 5e382 1 83 479
 FUNC 5e384 eb 0 common_lseek<long>(const int, const long, const int)
@@ -22870,13 +22870,13 @@ FUNC 5e890 33 0 common_lseek_do_seek_nolock(void* const, const long long, const 
 5e8b3 6 60 480
 5e8b9 5 63 480
 5e8be 5 64 480
-FUNC 5e8d0 5 0 lseek(int, long, int)
+FUNC 5e8d0 5 0 _lseek(int, long, int)
 5e8d0 5 130 480
-FUNC 5e8d8 5 0 lseek_nolock(int, long, int)
+FUNC 5e8d8 5 0 _lseek_nolock(int, long, int)
 5e8d8 5 140 480
-FUNC 5e8e0 5 0 lseeki64(int, long long, int)
+FUNC 5e8e0 5 0 _lseeki64(int, long long, int)
 5e8e0 5 135 480
-FUNC 5e8e8 5 0 lseeki64_nolock(int, long long, int)
+FUNC 5e8e8 5 0 _lseeki64_nolock(int, long long, int)
 5e8e8 5 145 480
 FUNC 5e8f0 40 0 __crt_seh_guarded_call<unsigned short>::operator()<<lambda_0384895ae1aa6ccbfe369a30d6ca2ef7>,<lambda_9e0b6ab72a5b3ae37ad997d08b519f50> &,<lambda_7e22f70504d73c22058e5832bde5914f> >(__acrt_lock_and_call::__l2::<lambda_0384895ae1aa6ccbfe369a30d6ca2ef7>&&, _putwch::__l2::<lambda_9e0b6ab72a5b3ae37ad997d08b519f50>&, __acrt_lock_and_call::__l2::<lambda_7e22f70504d73c22058e5832bde5914f>&&)
 5e8f0 15 198 99
@@ -22901,11 +22901,11 @@ FUNC 5e998 7 0 <lambda_7e22f70504d73c22058e5832bde5914f>::operator()() const
 5e998 7 974 201
 FUNC 5e9a0 b 0 <lambda_9e0b6ab72a5b3ae37ad997d08b519f50>::operator()() const
 5e9a0 b 17 481
-FUNC 5e9b0 3b 0 putwch(wchar_t)
+FUNC 5e9b0 3b 0 _putwch(wchar_t)
 5e9b0 c 14 481
 5e9bc 2a 15 481
 5e9e6 5 19 481
-FUNC 5e9fc 3b 0 putwch_nolock(wchar_t)
+FUNC 5e9fc 3b 0 _putwch_nolock(wchar_t)
 5e9fc 9 22 481
 5ea05 9 23 481
 5ea0e 18 28 481
@@ -23054,7 +23054,7 @@ FUNC 5f214 8f 0 translate_utf16_from_console_nolock(const int, wchar_t* const, c
 5f272 2 71 482
 5f274 21 73 482
 5f295 e 93 482
-FUNC 5f2c8 119 0 read(int, void*, unsigned int)
+FUNC 5f2c8 119 0 _read(int, void*, unsigned int)
 5f2c8 25 378 482
 5f2ed 1d 379 482
 5f30a 14 380 482
@@ -23070,7 +23070,7 @@ FUNC 5f2c8 119 0 read(int, void*, unsigned int)
 5f3a1 7 400 482
 5f3a8 4 402 482
 5f3ac 35 403 482
-FUNC 5f428 456 0 read_nolock(int, void*, unsigned int)
+FUNC 5f428 456 0 _read_nolock(int, void*, unsigned int)
 5f428 22 412 482
 5f44a 1f 413 482
 5f469 17 414 482
@@ -23130,7 +23130,7 @@ FUNC 5f428 456 0 read_nolock(int, void*, unsigned int)
 5f841 7 584 482
 5f848 4 420 482
 5f84c 32 635 482
-FUNC 5f994 83 0 fclose_nolock(_iobuf*)
+FUNC 5f994 83 0 _fclose_nolock(_iobuf*)
 5f994 d 49 483
 5f9a1 1a 52 483
 5f9bb 3 56 483
@@ -23211,7 +23211,7 @@ FUNC 5fd10 179 0 InternalGetLocaleInfoA(__crt_locale_pointers* const, wchar_t co
 5fdea 14 34 485
 5fdfe 65 38 485
 5fe63 26 47 485
-FUNC 5fee8 1c8 0 _acrt_GetLocaleInfoA(__crt_locale_pointers*, int, wchar_t const*, unsigned long, void*)
+FUNC 5fee8 1c8 0 __acrt_GetLocaleInfoA(__crt_locale_pointers*, int, wchar_t const*, unsigned long, void*)
 5fee8 2c 78 485
 5ff14 e 79 485
 5ff22 9 81 485
@@ -23542,7 +23542,7 @@ FUNC 60310 5ab 0 log10()
 608b0 6 597 496
 608b6 4 598 496
 608ba 1 599 496
-FUNC 60a28 66 0 _acrt_stdio_allocate_buffer_nolock(_iobuf*)
+FUNC 60a28 66 0 __acrt_stdio_allocate_buffer_nolock(_iobuf*)
 60a28 a 17 498
 60a32 9 23 498
 60a3b 17 27 498
@@ -23680,109 +23680,109 @@ FUNC 61040 69 0 common_xtox_s<unsigned __int64,wchar_t>(const unsigned long long
 61098 7 120 499
 6109f 5 121 499
 610a4 5 120 499
-FUNC 610c4 31 0 i64toa(long long, char*, int)
+FUNC 610c4 31 0 _i64toa(long long, char*, int)
 610c4 6 231 499
 610ca 12 232 499
 610dc 10 233 499
 610ec 3 234 499
 610ef 6 235 499
-FUNC 61104 21 0 i64toa_s(long long, char*, unsigned long long, int)
+FUNC 61104 21 0 _i64toa_s(long long, char*, unsigned long long, int)
 61104 4 209 499
 61108 f 210 499
 61117 9 211 499
 61120 5 212 499
-FUNC 61130 31 0 i64tow(long long, wchar_t*, int)
+FUNC 61130 31 0 _i64tow(long long, wchar_t*, int)
 61130 6 355 499
 61136 12 356 499
 61148 10 357 499
 61158 3 358 499
 6115b 6 359 499
-FUNC 61170 21 0 i64tow_s(long long, wchar_t*, unsigned long long, int)
+FUNC 61170 21 0 _i64tow_s(long long, wchar_t*, unsigned long long, int)
 61170 4 333 499
 61174 f 334 499
 61183 9 335 499
 6118c 5 336 499
-FUNC 6119c 30 0 itoa(int, char*, int)
+FUNC 6119c 30 0 _itoa(int, char*, int)
 6119c 6 169 499
 611a2 11 170 499
 611b3 10 171 499
 611c3 3 172 499
 611c6 6 173 499
-FUNC 611d8 20 0 itoa_s(int, char*, unsigned long long, int)
+FUNC 611d8 20 0 _itoa_s(int, char*, unsigned long long, int)
 611d8 4 136 499
 611dc e 137 499
 611ea 9 138 499
 611f3 5 139 499
-FUNC 61200 30 0 itow(int, wchar_t*, int)
+FUNC 61200 30 0 _itow(int, wchar_t*, int)
 61200 6 293 499
 61206 11 294 499
 61217 10 295 499
 61227 3 296 499
 6122a 6 297 499
-FUNC 6123c 20 0 itow_s(int, wchar_t*, unsigned long long, int)
+FUNC 6123c 20 0 _itow_s(int, wchar_t*, unsigned long long, int)
 6123c 4 260 499
 61240 e 261 499
 6124e 9 262 499
 61257 5 263 499
-FUNC 61264 30 0 ltoa(long, char*, int)
+FUNC 61264 30 0 _ltoa(long, char*, int)
 61264 6 180 499
 6126a 11 181 499
 6127b 10 182 499
 6128b 3 183 499
 6128e 6 184 499
-FUNC 612a0 20 0 ltoa_s(long, char*, unsigned long long, int)
+FUNC 612a0 20 0 _ltoa_s(long, char*, unsigned long long, int)
 612a0 4 147 499
 612a4 e 148 499
 612b2 9 149 499
 612bb 5 150 499
-FUNC 612c8 30 0 ltow(long, wchar_t*, int)
+FUNC 612c8 30 0 _ltow(long, wchar_t*, int)
 612c8 6 304 499
 612ce 11 305 499
 612df 10 306 499
 612ef 3 307 499
 612f2 6 308 499
-FUNC 61304 20 0 ltow_s(long, wchar_t*, unsigned long long, int)
+FUNC 61304 20 0 _ltow_s(long, wchar_t*, unsigned long long, int)
 61304 4 271 499
 61308 e 272 499
 61316 9 273 499
 6131f 5 274 499
-FUNC 6132c 23 0 ui64toa(unsigned long long, char*, int)
+FUNC 6132c 23 0 _ui64toa(unsigned long long, char*, int)
 6132c 6 242 499
 61332 14 243 499
 61346 3 244 499
 61349 6 245 499
-FUNC 61358 13 0 ui64toa_s(unsigned long long, char*, unsigned long long, int)
+FUNC 61358 13 0 _ui64toa_s(unsigned long long, char*, unsigned long long, int)
 61358 4 220 499
 6135c a 221 499
 61366 5 222 499
-FUNC 61370 23 0 ui64tow(unsigned long long, wchar_t*, int)
+FUNC 61370 23 0 _ui64tow(unsigned long long, wchar_t*, int)
 61370 6 366 499
 61376 14 367 499
 6138a 3 368 499
 6138d 6 369 499
-FUNC 6139c 13 0 ui64tow_s(unsigned long long, wchar_t*, unsigned long long, int)
+FUNC 6139c 13 0 _ui64tow_s(unsigned long long, wchar_t*, unsigned long long, int)
 6139c 4 344 499
 613a0 a 345 499
 613aa 5 346 499
-FUNC 613b4 23 0 ultoa(unsigned long, char*, int)
+FUNC 613b4 23 0 _ultoa(unsigned long, char*, int)
 613b4 6 191 499
 613ba 14 192 499
 613ce 3 193 499
 613d1 6 194 499
-FUNC 613e0 13 0 ultoa_s(unsigned long, char*, unsigned long long, int)
+FUNC 613e0 13 0 _ultoa_s(unsigned long, char*, unsigned long long, int)
 613e0 4 158 499
 613e4 a 159 499
 613ee 5 160 499
-FUNC 613f8 23 0 ultow(unsigned long, wchar_t*, int)
+FUNC 613f8 23 0 _ultow(unsigned long, wchar_t*, int)
 613f8 6 315 499
 613fe 14 316 499
 61412 3 317 499
 61415 6 318 499
-FUNC 61424 13 0 ultow_s(unsigned long, wchar_t*, unsigned long long, int)
+FUNC 61424 13 0 _ultow_s(unsigned long, wchar_t*, unsigned long long, int)
 61424 4 282 499
 61428 a 283 499
 61432 5 284 499
-FUNC 6143c 3e 0 _ascii_wcsicmp(wchar_t const*, wchar_t const*)
+FUNC 6143c 3e 0 __ascii_wcsicmp(wchar_t const*, wchar_t const*)
 6143c 6 79 500
 61442 8 88 500
 6144a 8 89 500
@@ -23793,7 +23793,7 @@ FUNC 6143c 3e 0 _ascii_wcsicmp(wchar_t const*, wchar_t const*)
 6146a 8 90 500
 61472 7 92 500
 61479 1 95 500
-FUNC 6148c 46 0 wcsicmp(wchar_t const*, wchar_t const*)
+FUNC 6148c 46 0 _wcsicmp(wchar_t const*, wchar_t const*)
 6148c 4 101 500
 61490 9 102 500
 61499 5 105 500
@@ -23804,7 +23804,7 @@ FUNC 6148c 46 0 wcsicmp(wchar_t const*, wchar_t const*)
 614c6 3 111 500
 614c9 4 112 500
 614cd 5 111 500
-FUNC 614e4 127 0 wcsicmp_l(wchar_t const*, wchar_t const*, __crt_locale_pointers*)
+FUNC 614e4 127 0 _wcsicmp_l(wchar_t const*, wchar_t const*, __crt_locale_pointers*)
 614e4 1e 44 500
 61502 5 46 500
 61507 1a 73 500
@@ -23824,7 +23824,7 @@ FUNC 61654 35 0 wcscmp(wchar_t const*, wchar_t const*)
 61668 11 36 501
 61679 f 39 501
 61688 1 40 501
-FUNC 61698 bb 0 towlower_l(unsigned short, __crt_locale_pointers*)
+FUNC 61698 bb 0 _towlower_l(unsigned short, __crt_locale_pointers*)
 61698 9 32 502
 616a1 e 35 502
 616af a 40 502
@@ -23837,7 +23837,7 @@ FUNC 61698 bb 0 towlower_l(unsigned short, __crt_locale_pointers*)
 6174e 5 69 502
 FUNC 61784 7 0 towlower(unsigned short)
 61784 7 93 502
-FUNC 6178c 40 0 set_error_mode(int)
+FUNC 6178c 40 0 _set_error_mode(int)
 6178c 4 50 503
 61790 e 51 503
 6179e 8 64 503
@@ -23892,13 +23892,13 @@ FUNC 619d8 8 0 __crt_char_traits<char>::output_debug_string<char const * const &
 619d8 8 109 322
 FUNC 619e4 a 0 __crt_char_traits<wchar_t>::output_debug_string<wchar_t const * const &>(wchar_t const* const&)
 619e4 a 124 322
-FUNC 619f0 a3 0 _acrt_show_narrow_message_box(char const*, char const*, unsigned int)
+FUNC 619f0 a3 0 __acrt_show_narrow_message_box(char const*, char const*, unsigned int)
 619f0 1d 83 504
 61a0d 50 84 504
 61a5d 10 85 504
 61a6d 11 84 504
 61a7e 15 85 504
-FUNC 61abc a4 0 _acrt_show_wide_message_box(wchar_t const*, wchar_t const*, unsigned int)
+FUNC 61abc a4 0 __acrt_show_wide_message_box(wchar_t const*, wchar_t const*, unsigned int)
 61abc 1d 92 504
 61ad9 51 93 504
 61b2a 10 94 504
@@ -23926,18 +23926,18 @@ FUNC 61cac 3b 0 __dcrt_lowio_initialize_console_output()
 61cac 4 20 505
 61cb0 32 21 505
 61ce2 5 29 505
-FUNC 61cf8 52 0 _dcrt_lowio_ensure_console_output_initialized()
+FUNC 61cf8 52 0 __dcrt_lowio_ensure_console_output_initialized()
 61cf8 6 32 505
 61cfe f 33 505
 61d0d 2e 35 505
 61d3b 9 38 505
 61d44 6 43 505
-FUNC 61d60 1c 0 _dcrt_terminate_console_output()
+FUNC 61d60 1c 0 __dcrt_terminate_console_output()
 61d60 4 47 505
 61d64 d 49 505
 61d71 6 51 505
 61d77 5 53 505
-FUNC 61d84 be 0 _dcrt_write_console(void const*, unsigned long, unsigned long*)
+FUNC 61d84 be 0 __dcrt_write_console(void const*, unsigned long, unsigned long*)
 61d84 14 72 505
 61d98 5 73 505
 61d9d 3 72 505
@@ -23985,14 +23985,14 @@ FUNC 61fc0 7e 0 close_os_handle_nolock(const int)
 62029 8 38 506
 62031 2 36 506
 62033 b 39 506
-FUNC 62060 a1 0 close(int)
+FUNC 62060 a1 0 _close(int)
 62060 b 46 506
 6206b 1a 47 506
 62085 c 48 506
 62091 23 49 506
 620b4 2d 51 506
 620e1 20 64 506
-FUNC 6212c bd 0 close_nolock(int)
+FUNC 6212c bd 0 _close_nolock(int)
 6212c d 69 506
 62139 d 70 506
 62146 4 72 506
@@ -24294,24 +24294,24 @@ FUNC 62c2c 30 0 translate_control_denormal_control_to_sse(const __acrt_fenv_abst
 62c55 1 119 508
 62c56 5 113 508
 62c5b 1 119 508
-FUNC 62c68 17 0 _acrt_fenv_expand_round_control(__acrt_fenv_abstract_control)
+FUNC 62c68 17 0 __acrt_fenv_expand_round_control(__acrt_fenv_abstract_control)
 62c68 16 504 508
 62c7e 1 509 508
-FUNC 62c84 9 0 _acrt_fenv_get_common_round_control(__acrt_fenv_abstract_control)
+FUNC 62c84 9 0 __acrt_fenv_get_common_round_control(__acrt_fenv_abstract_control)
 62c84 8 527 508
 62c8c 1 529 508
-FUNC 62c90 f1 0 _acrt_fenv_get_control()
+FUNC 62c90 f1 0 __acrt_fenv_get_control()
 62c90 da 449 508
 62d6a 16 450 508
 62d80 1 451 508
-FUNC 62dc0 b 0 _acrt_fenv_get_fp_status_word_from_exception_mask(__acrt_fenv_abstract_status)
+FUNC 62dc0 b 0 __acrt_fenv_get_fp_status_word_from_exception_mask(__acrt_fenv_abstract_status)
 62dc0 a 490 508
 62dca 1 495 508
-FUNC 62dd0 53 0 _acrt_fenv_get_status()
+FUNC 62dd0 53 0 __acrt_fenv_get_status()
 62dd0 4b 438 508
 62e1b 7 439 508
 62e22 1 440 508
-FUNC 62e38 147 0 _acrt_fenv_set_control(__acrt_fenv_abstract_control)
+FUNC 62e38 147 0 __acrt_fenv_set_control(__acrt_fenv_abstract_control)
 62e38 f 454 508
 62e47 fc 455 508
 62f43 5 456 508
@@ -24321,7 +24321,7 @@ FUNC 62e38 147 0 _acrt_fenv_set_control(__acrt_fenv_abstract_control)
 62f53 5 456 508
 62f58 26 455 508
 62f7e 1 456 508
-FUNC 62fd0 83 0 _acrt_fenv_set_status(__acrt_fenv_abstract_status)
+FUNC 62fd0 83 0 __acrt_fenv_set_status(__acrt_fenv_abstract_status)
 62fd0 2 443 508
 62fd2 80 444 508
 63052 1 445 508
@@ -24355,17 +24355,17 @@ FUNC 6316c 5b 0 _abstract_sw(unsigned int)
 631be 5 388 509
 631c3 3 391 509
 631c6 1 392 509
-FUNC 631e0 6e 0 clearfp(<NoType>)
+FUNC 631e0 6e 0 _clearfp(<NoType>)
 631e0 6 72 509
 631e6 7 75 509
 631ed 5 76 509
 631f2 56 78 509
 63248 6 79 509
-FUNC 6326c 5 0 control87(unsigned int, unsigned int)
+FUNC 6326c 5 0 _control87(unsigned int, unsigned int)
 6326c 5 143 509
-FUNC 63274 9 0 controlfp(unsigned int, unsigned int)
+FUNC 63274 9 0 _controlfp(unsigned int, unsigned int)
 63274 9 165 509
-FUNC 63280 a 0 fpreset(<NoType>)
+FUNC 63280 a 0 _fpreset(<NoType>)
 63280 a 418 509
 FUNC 6328c bf 0 _hw_cw(unsigned int)
 6328c 3 295 509
@@ -24384,14 +24384,14 @@ FUNC 6328c bf 0 _hw_cw(unsigned int)
 63342 6 342 509
 63348 2 350 509
 6334a 1 351 509
-FUNC 6337c 34 0 set_controlfp(unsigned int, unsigned int)
+FUNC 6337c 34 0 _set_controlfp(unsigned int, unsigned int)
 6337c 4 185 509
 63380 d 189 509
 6338d 9 193 509
 63396 c 194 509
 633a2 9 201 509
 633ab 5 202 509
-FUNC 633c0 62 0 statusfp(<NoType>)
+FUNC 633c0 62 0 _statusfp(<NoType>)
 633c0 a 51 509
 633ca 57 53 509
 63421 1 54 509
@@ -24446,7 +24446,7 @@ FUNC 6382c ba 0 _exception_enabled(unsigned int, unsigned long long)
 638c2 a 118 510
 638cc 3 119 510
 638cf 17 123 510
-FUNC 63914 127 0 handle_error(char*, int, unsigned long long, int, int, int, double, double, int)
+FUNC 63914 127 0 _handle_error(char*, int, unsigned long long, int, int, int, double, double, int)
 63914 2b 197 510
 6393f 15 202 510
 63954 2c 205 510
@@ -24459,7 +24459,7 @@ FUNC 63914 127 0 handle_error(char*, int, unsigned long long, int, int, int, dou
 639fd 7 229 510
 63a04 15 231 510
 63a19 22 232 510
-FUNC 63a84 133 0 handle_errorf(char*, int, unsigned long long, int, int, int, float, float, int)
+FUNC 63a84 133 0 _handle_errorf(char*, int, unsigned long long, int, int, int, float, float, int)
 63a84 2b 144 510
 63aaf 15 149 510
 63ac4 2b 152 510
@@ -24472,15 +24472,15 @@ FUNC 63a84 133 0 handle_errorf(char*, int, unsigned long long, int, int, int, fl
 63b79 7 173 510
 63b80 15 175 510
 63b95 22 176 510
-FUNC 63c04 19 0 handle_nan(unsigned long long)
+FUNC 63c04 19 0 _handle_nan(unsigned long long)
 63c04 d 181 510
 63c11 b 182 510
 63c1c 1 184 510
-FUNC 63c24 f 0 handle_nanf(unsigned int)
+FUNC 63c24 f 0 _handle_nanf(unsigned int)
 63c24 4 128 510
 63c28 a 129 510
 63c32 1 131 510
-FUNC 63c40 70 0 _acrt_initialize_fma3(<NoType>)
+FUNC 63c40 70 0 __acrt_initialize_fma3(<NoType>)
 63c40 6 32 513
 63c46 3 37 513
 63c49 15 40 513
@@ -24490,21 +24490,21 @@ FUNC 63c40 70 0 _acrt_initialize_fma3(<NoType>)
 63ca1 7 53 513
 63ca8 2 54 513
 63caa 6 55 513
-FUNC 63ccc 7 0 get_FMA3_enable(<NoType>)
+FUNC 63ccc 7 0 _get_FMA3_enable(<NoType>)
 63ccc 6 26 513
 63cd2 1 27 513
-FUNC 63cd4 17 0 set_FMA3_enable(int)
+FUNC 63cd4 17 0 _set_FMA3_enable(int)
 63cd4 16 16 513
 63cea 1 22 513
-FUNC 63cf0 20 0 log10_special(double, double, unsigned int)
+FUNC 63cf0 20 0 _log10_special(double, double, unsigned int)
 63cf0 4 141 514
 63cf4 17 142 514
 63d0b 5 143 514
-FUNC 63d18 20 0 log10f_special(float, float, unsigned int)
+FUNC 63d18 20 0 _log10f_special(float, float, unsigned int)
 63d18 4 109 514
 63d1c 17 110 514
 63d33 5 111 514
-FUNC 63d40 20 0 log_special(double, double, unsigned int)
+FUNC 63d40 20 0 _log_special(double, double, unsigned int)
 63d40 4 136 514
 63d44 17 137 514
 63d5b 5 138 514
@@ -24515,7 +24515,7 @@ FUNC 63d68 96 0 _log_special_common(double, double, unsigned int, unsigned int, 
 63dac 2d 120 514
 63dd9 1b 132 514
 63df4 a 133 514
-FUNC 63e24 20 0 logf_special(float, float, unsigned int)
+FUNC 63e24 20 0 _logf_special(float, float, unsigned int)
 63e24 4 104 514
 63e28 17 105 514
 63e3f 5 106 514
@@ -24526,7 +24526,7 @@ FUNC 63e4c 9c 0 _logf_special_common(float, float, unsigned int, unsigned int, c
 63e90 2d 88 514
 63ebd 21 100 514
 63ede a 101 514
-FUNC 63f10 87 0 _acrt_LCMapStringW(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t*, int)
+FUNC 63f10 87 0 __acrt_LCMapStringW(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t*, int)
 63f10 1f 53 516
 63f2f 5 57 516
 63f34 b 59 516
@@ -24535,7 +24535,7 @@ FUNC 63f10 87 0 _acrt_LCMapStringW(wchar_t const*, unsigned long, wchar_t const*
 63f46 2 69 516
 63f48 3a 73 516
 63f82 15 74 516
-FUNC 63fb8 9c 0 _acrt_OutputDebugStringA(char const*)
+FUNC 63fb8 9c 0 __acrt_OutputDebugStringA(char const*)
 63fb8 20 14 517
 63fd8 5 15 517
 63fdd 12 19 517
@@ -24544,23 +24544,23 @@ FUNC 63fb8 9c 0 _acrt_OutputDebugStringA(char const*)
 64017 1e 27 517
 64035 9 29 517
 6403e 16 31 517
-FUNC 64090 10 0 get_fpsr()
+FUNC 64090 10 0 _get_fpsr()
 64090 4 6 519
 64094 4 9 519
 64098 3 10 519
 6409b 4 11 519
 6409f 1 12 519
-FUNC 640a0 a 0 set_fpsr()
+FUNC 640a0 a 0 _set_fpsr()
 640a0 4 19 519
 640a4 5 20 519
 640a9 1 21 519
-FUNC 640aa 14 0 fclrf()
+FUNC 640aa 14 0 _fclrf()
 640aa 5 28 519
 640af 5 29 519
 640b4 4 30 519
 640b8 5 31 519
 640bd 1 32 519
-FUNC 640be 1f 0 frnd()
+FUNC 640be 1f 0 _frnd()
 640be 8 43 519
 640c6 2 44 519
 640c8 8 45 519
@@ -24568,7 +24568,7 @@ FUNC 640be 1f 0 frnd()
 640d2 5 47 519
 640d7 5 48 519
 640dc 1 50 519
-FUNC 640f4 43 0 errcode(unsigned int)
+FUNC 640f4 43 0 _errcode(unsigned int)
 640f4 2 995 520
 640f6 5 998 520
 640fb 5 999 520
@@ -24585,7 +24585,7 @@ FUNC 640f4 43 0 errcode(unsigned int)
 64128 c 1010 520
 64134 2 1019 520
 64136 1 1020 520
-FUNC 64148 f1 0 except1(int, int, double, double, unsigned long long)
+FUNC 64148 f1 0 _except1(int, int, double, double, unsigned long long)
 64148 27 251 520
 6416f 25 254 520
 64194 8 268 520
@@ -24597,7 +24597,7 @@ FUNC 64148 f1 0 except1(int, int, double, double, unsigned long long)
 641fc 7 288 520
 64203 12 291 520
 64215 24 292 520
-FUNC 64278 106 0 except2(int, int, double, double, double, unsigned long long)
+FUNC 64278 106 0 _except2(int, int, double, double, double, unsigned long long)
 64278 2b 336 520
 642a3 23 339 520
 642c6 3 352 520
@@ -24621,7 +24621,7 @@ FUNC 643c0 31 0 _get_fname(unsigned int)
 643e4 1 974 520
 643e5 b 971 520
 643f0 1 974 520
-FUNC 64400 267 0 handle_exc(unsigned int, double*, unsigned long long)
+FUNC 64400 267 0 _handle_exc(unsigned int, double*, unsigned long long)
 64400 14 662 520
 64414 24 670 520
 64438 9 676 520
@@ -24668,14 +24668,14 @@ FUNC 64400 267 0 handle_exc(unsigned int, double*, unsigned long long)
 64637 a 802 520
 64641 3 803 520
 64644 23 807 520
-FUNC 64700 5 0 handle_qnan2(double, double)
+FUNC 64700 5 0 _handle_qnan2(double, double)
 64700 4 221 520
 64704 1 224 520
-FUNC 64708 27 0 raise_exc(_FPIEEE_RECORD*, unsigned long long*, int, int, double*, double*)
+FUNC 64708 27 0 _raise_exc(_FPIEEE_RECORD*, unsigned long long*, int, int, double*, double*)
 64708 4 630 520
 6470c 1e 631 520
 6472a 5 632 520
-FUNC 64738 30d 0 raise_exc_ex(_FPIEEE_RECORD*, unsigned long long*, int, int, void*, void*, int)
+FUNC 64738 30d 0 _raise_exc_ex(_FPIEEE_RECORD*, unsigned long long*, int, int, void*, void*, int)
 64738 21 415 520
 64759 a 423 520
 64763 7 424 520
@@ -24752,17 +24752,17 @@ FUNC 64738 30d 0 raise_exc_ex(_FPIEEE_RECORD*, unsigned long long*, int, int, vo
 64a27 2 620 520
 64a29 7 621 520
 64a30 15 623 520
-FUNC 64b08 2a 0 raise_excf(_FPIEEE_RECORD*, unsigned long long*, int, int, float*, float*)
+FUNC 64b08 2a 0 _raise_excf(_FPIEEE_RECORD*, unsigned long long*, int, int, float*, float*)
 64b08 4 639 520
 64b0c 21 640 520
 64b2d 5 641 520
-FUNC 64b3c 2e 0 set_errno_from_matherr(int)
+FUNC 64b3c 2e 0 _set_errno_from_matherr(int)
 64b3c 4 898 520
 64b40 d 899 520
 64b4d d 905 520
 64b5a b 901 520
 64b65 5 908 520
-FUNC 64b78 d4 0 umatherr(int, unsigned int, double, double, double, unsigned long long)
+FUNC 64b78 d4 0 _umatherr(int, unsigned int, double, double, double, unsigned long long)
 64b78 11 844 520
 64b89 7 851 520
 64b90 2 844 520
@@ -24779,14 +24779,14 @@ FUNC 64b78 d4 0 umatherr(int, unsigned int, double, double, double, unsigned lon
 64c36 7 873 520
 64c3d 9 874 520
 64c46 6 877 520
-FUNC 64c84 1d 0 clrfp(<NoType>)
+FUNC 64c84 1d 0 _clrfp(<NoType>)
 64c84 6 59 521
 64c8a 7 62 521
 64c91 3 63 521
 64c94 5 64 521
 64c99 2 66 521
 64c9b 6 67 521
-FUNC 64ca8 7c 0 ctrlfp(unsigned long long, unsigned long long)
+FUNC 64ca8 7c 0 _ctrlfp(unsigned long long, unsigned long long)
 64ca8 15 85 521
 64cbd b 90 521
 64cc8 4 91 521
@@ -24804,14 +24804,14 @@ FUNC 64ca8 7c 0 ctrlfp(unsigned long long, unsigned long long)
 64d0d 5 106 521
 64d12 2 109 521
 64d14 10 110 521
-FUNC 64d44 1f 0 set_statfp(unsigned long long)
+FUNC 64d44 1f 0 _set_statfp(unsigned long long)
 64d44 9 129 521
 64d4d 5 132 521
 64d52 5 134 521
 64d57 2 136 521
 64d59 5 138 521
 64d5e 5 136 521
-FUNC 64d6c 11 0 statfp(<NoType>)
+FUNC 64d6c 11 0 _statfp(<NoType>)
 64d6c 4 35 521
 64d70 5 38 521
 64d75 3 39 521
@@ -24848,9 +24848,9 @@ FUNC 64d84 200 0 _mbstowcs_l_helper(wchar_t*, char const*, unsigned long long, _
 64f46 d 168 523
 64f53 18 172 523
 64f6b 19 176 523
-FUNC 65004 5 0 mbstowcs_l(wchar_t*, char const*, unsigned long long, __crt_locale_pointers*)
+FUNC 65004 5 0 _mbstowcs_l(wchar_t*, char const*, unsigned long long, __crt_locale_pointers*)
 65004 5 187 523
-FUNC 6500c 133 0 mbstowcs_s_l(unsigned long long*, wchar_t*, unsigned long long, char const*, unsigned long long, __crt_locale_pointers*)
+FUNC 6500c 133 0 _mbstowcs_s_l(unsigned long long*, wchar_t*, unsigned long long, char const*, unsigned long long, __crt_locale_pointers*)
 6500c 19 241 523
 65025 12 243 523
 65037 a 246 523
@@ -24890,11 +24890,11 @@ FUNC 651ac 1e 0 mbstowcs_s(unsigned long long*, wchar_t*, unsigned long long, ch
 651ac 4 313 523
 651b0 15 314 523
 651c5 5 315 523
-FUNC 651d4 4e 0 add_exp(double, int)
+FUNC 651d4 4e 0 _add_exp(double, int)
 651d4 6 44 524
 651da 47 45 524
 65221 1 46 524
-FUNC 65238 12e 0 decomp(double, int*)
+FUNC 65238 12e 0 _decomp(double, int*)
 65238 f 89 524
 65247 8 93 524
 6524f 2 95 524
@@ -24922,22 +24922,22 @@ FUNC 65238 12e 0 decomp(double, int*)
 65356 c 118 524
 65362 3 121 524
 65365 1 123 524
-FUNC 653b4 1d 0 get_exp(double)
+FUNC 653b4 1d 0 _get_exp(double)
 653b4 6 35 524
 653ba 11 37 524
 653cb 5 39 524
 653d0 1 40 524
-FUNC 653d8 30 0 set_bexp(double, int)
+FUNC 653d8 30 0 _set_bexp(double, int)
 653d8 6 51 524
 653de 23 54 524
 65401 6 55 524
 65407 1 56 524
-FUNC 65414 38 0 set_exp(double, int)
+FUNC 65414 38 0 _set_exp(double, int)
 65414 6 24 524
 6541a 2b 29 524
 65445 6 30 524
 6544b 1 31 524
-FUNC 6545c 74 0 sptype(double)
+FUNC 6545c 74 0 _sptype(double)
 6545c 6 60 524
 65462 18 61 524
 6547a 5 62 524
@@ -24953,7 +24953,7 @@ FUNC 6545c 74 0 sptype(double)
 654cc 1 70 524
 654cd 2 69 524
 654cf 1 70 524
-FUNC 654f0 44 0 FindPESection(unsigned char*, unsigned long long)
+FUNC 654f0 44 0 _FindPESection(unsigned char*, unsigned long long)
 654f0 4 91 525
 654f4 e 100 525
 65502 11 101 525
@@ -24961,7 +24961,7 @@ FUNC 654f0 44 0 FindPESection(unsigned char*, unsigned long long)
 65525 c 102 525
 65531 2 117 525
 65533 1 118 525
-FUNC 65550 4d 0 IsNonwritableInCurrentImage(void const*)
+FUNC 65550 4d 0 _IsNonwritableInCurrentImage(void const*)
 65550 d 143 525
 6555d 13 158 525
 65570 3 168 525
@@ -24970,7 +24970,7 @@ FUNC 65550 4d 0 IsNonwritableInCurrentImage(void const*)
 65583 d 179 525
 65590 2 187 525
 65592 b 189 525
-FUNC 655b0 2d 0 ValidateImageBase(unsigned char*)
+FUNC 655b0 2d 0 _ValidateImageBase(unsigned char*)
 655b0 a 44 525
 655ba 7 49 525
 655c1 8 50 525
@@ -24983,12 +24983,12 @@ FUNC 655e8 b 0 type_info::~type_info()
 655e8 a 17 526
 655f2 1 18 526
 FUNC 655f8 2b 0 type_info::`scalar deleting destructor'(unsigned int)
-FUNC 65630 1d 0 _GSHandlerCheck(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
+FUNC 65630 1d 0 __GSHandlerCheck(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
 65630 4 74 527
 65634 f 82 527
 65643 5 93 527
 65648 5 94 527
-FUNC 65654 5b 0 _GSHandlerCheckCommon(void*, _DISPATCHER_CONTEXT*, _GS_HANDLER_DATA*)
+FUNC 65654 5b 0 __GSHandlerCheckCommon(void*, _DISPATCHER_CONTEXT*, _GS_HANDLER_DATA*)
 65654 2 128 527
 65656 d 142 527
 65663 9 151 527
@@ -25001,7 +25001,7 @@ FUNC 65654 5b 0 _GSHandlerCheckCommon(void*, _DISPATCHER_CONTEXT*, _GS_HANDLER_D
 656a6 3 187 527
 656a9 1 188 527
 656aa 5 187 527
-FUNC 656e0 21 0 _security_check_cookie()
+FUNC 656e0 21 0 __security_check_cookie()
 656e0 7 47 528
 656e7 3 48 528
 656ea 4 49 528
@@ -25010,21 +25010,21 @@ FUNC 656e0 21 0 _security_check_cookie()
 656f6 2 52 528
 656f8 4 62 528
 656fc 5 66 528
-FUNC 65710 85 0 _GSHandlerCheck_SEH(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
+FUNC 65710 85 0 __GSHandlerCheck_SEH(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
 65710 19 67 529
 65729 d 79 529
 65736 1c 86 529
 65752 17 99 529
 65769 11 103 529
 6577a 1b 116 529
-FUNC 657b8 34 0 _raise_securityfailure(_EXCEPTION_POINTERS* const)
+FUNC 657b8 34 0 __raise_securityfailure(_EXCEPTION_POINTERS* const)
 657b8 9 140 530
 657c1 8 146 530
 657c9 9 147 530
 657d2 e 160 530
 657e0 5 161 530
 657e5 7 160 530
-FUNC 657fc d1 0 _report_gsfailure(unsigned long long)
+FUNC 657fc d1 0 __report_gsfailure(unsigned long long)
 657fc 9 217 530
 65805 e 218 530
 65813 7 220 530
@@ -25041,11 +25041,11 @@ FUNC 657fc d1 0 _report_gsfailure(unsigned long long)
 658a7 15 294 530
 658bc c 298 530
 658c8 5 299 530
-FUNC 65904 13 0 _report_rangecheckfailure(<NoType>)
+FUNC 65904 13 0 __report_rangecheckfailure(<NoType>)
 65904 4 555 530
 65908 a 556 530
 65912 5 557 530
-FUNC 6591c 9b 0 _report_securityfailure(unsigned long)
+FUNC 6591c 9b 0 __report_securityfailure(unsigned long)
 6591c 8 462 530
 65924 e 463 530
 65932 8 465 530
@@ -25059,7 +25059,7 @@ FUNC 6591c 9b 0 _report_securityfailure(unsigned long)
 6598e 18 535 530
 659a6 c 542 530
 659b2 5 543 530
-FUNC 659e0 10e 0 _report_securityfailureEx(unsigned long, unsigned long, void**)
+FUNC 659e0 10e 0 __report_securityfailureEx(unsigned long, unsigned long, void**)
 659e0 11 338 530
 659f1 e 339 530
 659ff 8 341 530
@@ -25097,7 +25097,7 @@ FUNC 65bbc 71 0 capture_previous_context(_CONTEXT*)
 65be7 5 105 530
 65bec 39 107 530
 65c25 8 122 530
-FUNC 65c60 51 0 _chkstk()
+FUNC 65c60 51 0 __chkstk()
 65c60 4 71 531
 65c64 4 83 531
 65c68 5 84 531
@@ -25260,7 +25260,7 @@ FUNC 65fcc 149 0 strrchr(char const*, int)
 6610a 4 212 534
 6610e 2 213 534
 66110 5 196 534
-FUNC 66168 29 0 local_unwind(void*, void*)
+FUNC 66168 29 0 _local_unwind(void*, void*)
 66168 e 28 535
 66176 16 30 535
 6618c 5 31 535
@@ -25333,7 +25333,7 @@ FUNC 661b0 c7 0 memcmp()
 66273 3 178 536
 66276 1 179 536
 PUBLIC 662ac 0 RtlUnwind
-FUNC 67e10 2 0 guard_dispatch_icall_nop()
+FUNC 67e10 2 0 _guard_dispatch_icall_nop()
 67e10 2 59 45
 FUNC 68e20 17 0 `dllmain_crt_process_attach'::`1'::fin$0
 68e20 9 68 24

--- a/test_data/windows/basic32.sym
+++ b/test_data/windows/basic32.sym
@@ -1250,7 +1250,7 @@ abfb 8 59 45
 ac03 2 59 45
 ac05 9 55 45
 ac0e 2 62 45
-FUNC ac20 46 0 _SEH_prolog4()
+FUNC ac20 46 0 __SEH_prolog4()
 ac20 5 71 46
 ac25 7 72 46
 ac2c 4 73 46
@@ -1272,7 +1272,7 @@ ac58 3 88 46
 ac5b 3 89 46
 ac5e 6 90 46
 ac64 2 91 46
-FUNC ac66 15 0 _SEH_epilog4()
+FUNC ac66 15 0 __SEH_epilog4()
 ac66 3 113 46
 ac69 7 114 46
 ac70 1 115 46
@@ -1724,7 +1724,7 @@ b704 5 346 56
 b709 3 347 56
 b70c 1 348 56
 b70d 3 349 56
-FUNC b710 17 0 _EH4_CallFilterFunc()
+FUNC b710 17 0 @_EH4_CallFilterFunc@8()
 b710 1 387 56
 b711 1 388 56
 b712 1 389 56
@@ -1741,7 +1741,7 @@ b723 1 399 56
 b724 1 400 56
 b725 1 401 56
 b726 1 402 56
-FUNC b728 19 0 _EH4_TransferToHandler()
+FUNC b728 19 0 @_EH4_TransferToHandler@8()
 b728 2 431 56
 b72a 2 432 56
 b72c 2 433 56
@@ -1753,7 +1753,7 @@ b739 2 438 56
 b73b 2 439 56
 b73d 2 440 56
 b73f 2 441 56
-FUNC b744 1a 0 _EH4_GlobalUnwind2()
+FUNC b744 1a 0 @_EH4_GlobalUnwind2@8()
 b744 1 467 56
 b745 2 468 56
 b747 1 469 56
@@ -1769,7 +1769,7 @@ b75a 1 479 56
 b75b 1 480 56
 b75c 1 481 56
 b75d 1 482 56
-FUNC b760 17 8 _EH4_LocalUnwind()
+FUNC b760 17 8 @_EH4_LocalUnwind@16()
 b760 1 513 56
 b761 4 514 56
 b765 1 515 56
@@ -4321,7 +4321,7 @@ FUNC 1345a 1d 0 __crt_fast_encode_pointer<void (__cdecl*)(void)>(void (* const)(
 FUNC 1347e b 0 __vcrt_initialize_pure_virtual_call_handler()
 1347e a 21 65
 13488 1 22 65
-FUNC 13490 21 0 _global_unwind2()
+FUNC 13490 21 0 __global_unwind2()
 13490 7 92 66
 13497 2 93 66
 13499 2 94 66
@@ -4352,7 +4352,7 @@ FUNC 134b1 45 0 __unwind_handler()
 134ee 2 169 66
 134f0 5 171 66
 134f5 1 173 66
-FUNC 134f6 84 0 _local_unwind2()
+FUNC 134f6 84 0 __local_unwind2()
 134f6 1 205 66
 134f7 1 206 66
 134f8 1 207 66
@@ -4395,7 +4395,7 @@ FUNC 134f6 84 0 _local_unwind2()
 13577 1 260 66
 13578 1 261 66
 13579 1 262 66
-FUNC 1357a 23 0 _abnormal_termination()
+FUNC 1357a 23 0 __abnormal_termination()
 1357a 2 275 66
 1357c 7 277 66
 13583 7 278 66

--- a/test_data/windows/basic64.sym
+++ b/test_data/windows/basic64.sym
@@ -689,7 +689,7 @@ FUNC 7290 19 0 std::_String_val<std::_Simple_types<char> >::~_String_val()
 FUNC 72b0 7 0 std::_String_val<std::_Simple_types<char> >::_Bxty::~_Bxty()
 72b0 5 1861 1
 72b5 2 1862 1
-FUNC 99f0 21 0 _security_check_cookie()
+FUNC 99f0 21 0 __security_check_cookie()
 99f0 7 47 16
 99f7 3 48 16
 99fa 4 49 16
@@ -783,23 +783,23 @@ FUNC 9e20 19 0 dllmain_raw(HINSTANCE__* const, const unsigned long, void* const)
 9e2c 5 164 30
 9e31 1 167 30
 9e32 7 166 30
-FUNC 9e40 5 0 CRT_INIT(HINSTANCE__* const, const unsigned long, void* const)
+FUNC 9e40 5 0 _CRT_INIT(HINSTANCE__* const, const unsigned long, void* const)
 9e40 5 154 30
-FUNC 9e48 3d 0 DllMainCRTStartup(HINSTANCE__* const, const unsigned long, void* const)
+FUNC 9e48 3d 0 _DllMainCRTStartup(HINSTANCE__* const, const unsigned long, void* const)
 9e48 17 243 30
 9e5f 5 244 30
 9e64 5 250 30
 9e69 8 253 30
 9e71 f 254 30
 9e80 5 253 30
-FUNC 9e94 34 0 _raise_securityfailure(_EXCEPTION_POINTERS* const)
+FUNC 9e94 34 0 __raise_securityfailure(_EXCEPTION_POINTERS* const)
 9e94 9 140 33
 9e9d 8 146 33
 9ea5 9 147 33
 9eae e 160 33
 9ebc 5 161 33
 9ec1 7 160 33
-FUNC 9ed8 d1 0 _report_gsfailure(unsigned long long)
+FUNC 9ed8 d1 0 __report_gsfailure(unsigned long long)
 9ed8 9 217 33
 9ee1 e 218 33
 9eef 7 220 33
@@ -816,11 +816,11 @@ FUNC 9ed8 d1 0 _report_gsfailure(unsigned long long)
 9f83 15 294 33
 9f98 c 298 33
 9fa4 5 299 33
-FUNC 9fe0 13 0 _report_rangecheckfailure(<NoType>)
+FUNC 9fe0 13 0 __report_rangecheckfailure(<NoType>)
 9fe0 4 555 33
 9fe4 a 556 33
 9fee 5 557 33
-FUNC 9ff8 9b 0 _report_securityfailure(unsigned long)
+FUNC 9ff8 9b 0 __report_securityfailure(unsigned long)
 9ff8 8 462 33
 a000 e 463 33
 a00e 8 465 33
@@ -834,7 +834,7 @@ a060 a 534 33
 a06a 18 535 33
 a082 c 542 33
 a08e 5 543 33
-FUNC a0bc 10e 0 _report_securityfailureEx(unsigned long, unsigned long, void**)
+FUNC a0bc 10e 0 __report_securityfailureEx(unsigned long, unsigned long, void**)
 a0bc 11 338 33
 a0cd e 339 33
 a0db 8 341 33
@@ -885,7 +885,7 @@ a364 e 113 35
 a372 3 115 35
 a375 20 132 35
 a395 6 136 35
-FUNC a3b8 ac 0 _security_init_cookie()
+FUNC a3b8 ac 0 __security_init_cookie()
 a3b8 d 158 35
 a3c5 16 169 35
 a3db 5c 184 35
@@ -899,13 +899,13 @@ FUNC a498 e 0 __scrt_initialize_type_info()
 a498 e 17 37
 FUNC a4ac c 0 __scrt_uninitialize_type_info()
 a4ac c 25 37
-FUNC a4bc 8 0 _local_stdio_printf_options()
+FUNC a4bc 8 0 __local_stdio_printf_options()
 a4bc 7 83 43
 a4c3 1 84 43
-FUNC a4c8 8 0 _local_stdio_scanf_options()
+FUNC a4c8 8 0 __local_stdio_scanf_options()
 a4c8 7 93 43
 a4cf 1 94 43
-FUNC a4d4 1b 0 _scrt_initialize_default_local_stdio_options()
+FUNC a4d4 1b 0 __scrt_initialize_default_local_stdio_options()
 a4d4 4 17 40
 a4d8 9 18 40
 a4e1 9 19 40
@@ -947,7 +947,7 @@ a5f6 1 54 44
 FUNC a604 a 0 NtCurrentTeb()
 a604 9 21341 14
 a60d 1 21342 14
-FUNC a610 39 0 _scrt_acquire_startup_lock()
+FUNC a610 39 0 __scrt_acquire_startup_lock()
 a610 4 139 44
 a614 9 140 44
 a61d d 146 44
@@ -957,7 +957,7 @@ a631 d 148 44
 a63e 2 156 44
 a640 5 157 44
 a645 4 152 44
-FUNC a658 34 0 _scrt_dllmain_after_initialize_c()
+FUNC a658 34 0 __scrt_dllmain_after_initialize_c()
 a658 4 376 44
 a65c 9 377 44
 a665 5 379 44
@@ -967,11 +967,11 @@ a67c 4 385 44
 a680 5 388 44
 a685 2 391 44
 a687 5 392 44
-FUNC a69c 15 0 _scrt_dllmain_before_initialize_c()
+FUNC a69c 15 0 __scrt_dllmain_before_initialize_c()
 a69c 4 366 44
 a6a0 c 367 44
 a6ac 5 373 44
-FUNC a6b8 28 0 _scrt_dllmain_crt_thread_attach()
+FUNC a6b8 28 0 __scrt_dllmain_crt_thread_attach()
 a6b8 4 434 44
 a6bc 9 436 44
 a6c5 4 448 44
@@ -980,20 +980,20 @@ a6d2 5 443 44
 a6d7 2 444 44
 a6d9 2 447 44
 a6db 5 448 44
-FUNC a6ec 15 0 _scrt_dllmain_crt_thread_detach()
+FUNC a6ec 15 0 __scrt_dllmain_crt_thread_detach()
 a6ec 4 451 44
 a6f0 5 453 44
 a6f5 5 454 44
 a6fa 2 455 44
 a6fc 5 456 44
-FUNC a708 60 0 _scrt_dllmain_exception_filter(HINSTANCE__*, unsigned long, void*, int (*)(HINSTANCE__*, unsigned long, void*), unsigned long, _EXCEPTION_POINTERS*)
+FUNC a708 60 0 __scrt_dllmain_exception_filter(HINSTANCE__*, unsigned long, void*, int (*)(HINSTANCE__*, unsigned long, void*), unsigned long, _EXCEPTION_POINTERS*)
 a708 1f 350 44
 a727 e 351 44
 a735 11 359 44
 a746 9 362 44
 a74f 14 363 44
 a763 5 362 44
-FUNC a780 30 0 _scrt_dllmain_uninitialize_c()
+FUNC a780 30 0 __scrt_dllmain_uninitialize_c()
 a780 4 395 44
 a784 9 396 44
 a78d 7 398 44
@@ -1002,12 +1002,12 @@ a798 5 398 44
 a79d 9 402 44
 a7a6 5 404 44
 a7ab 5 407 44
-FUNC a7bc 14 0 _scrt_dllmain_uninitialize_critical()
+FUNC a7bc 14 0 __scrt_dllmain_uninitialize_critical()
 a7bc 4 410 44
 a7c0 7 429 44
 a7c7 4 431 44
 a7cb 5 430 44
-FUNC a7d8 49 0 _scrt_initialize_crt(__scrt_module_type)
+FUNC a7d8 49 0 __scrt_initialize_crt(__scrt_module_type)
 a7d8 6 185 44
 a7de 17 186 44
 a7f5 5 191 44
@@ -1018,7 +1018,7 @@ a810 7 201 44
 a817 2 202 44
 a819 2 205 44
 a81b 6 206 44
-FUNC a834 d8 0 _scrt_initialize_onexit_tables(__scrt_module_type)
+FUNC a834 d8 0 __scrt_initialize_onexit_tables(__scrt_module_type)
 a834 6 296 44
 a83a f 297 44
 a849 9 302 44
@@ -1032,7 +1032,7 @@ a8c1 31 328 44
 a8f2 7 331 44
 a8f9 8 333 44
 a901 b 304 44
-FUNC a944 99 0 _scrt_is_nonwritable_in_current_image(void const*)
+FUNC a944 99 0 __scrt_is_nonwritable_in_current_image(void const*)
 a944 7 88 44
 a94b 33 99 44
 a97e 3 107 44
@@ -1045,19 +1045,19 @@ a9ce 4 121 44
 a9d2 4 101 44
 a9d6 2 127 44
 a9d8 5 129 44
-FUNC aa04 24 0 _scrt_release_startup_lock(bool)
+FUNC aa04 24 0 __scrt_release_startup_lock(bool)
 aa04 8 160 44
 aa0c b 161 44
 aa17 4 167 44
 aa1b 7 172 44
 aa22 6 173 44
-FUNC aa34 2b 0 _scrt_uninitialize_crt(bool, bool)
+FUNC aa34 2b 0 __scrt_uninitialize_crt(bool, bool)
 aa34 6 209 44
 aa3a f 214 44
 aa49 7 220 44
 aa50 7 221 44
 aa57 8 224 44
-FUNC aa6c 4f 0 onexit(int (*)())
+FUNC aa6c 4f 0 _onexit(int (*)())
 aa6c 6 256 44
 aa72 7 257 44
 aa79 3 256 44
@@ -1077,13 +1077,13 @@ FUNC ab14 17 0 atexit(void (*)())
 ab14 4 274 44
 ab18 e 275 44
 ab26 5 278 44
-FUNC ab30 8 0 _scrt_get_dyn_tls_init_callback(<NoType>)
+FUNC ab30 8 0 __scrt_get_dyn_tls_init_callback(<NoType>)
 ab30 7 20 45
 ab37 1 21 45
-FUNC ab3c 8 0 _crt_debugger_hook(int)
+FUNC ab3c 8 0 __crt_debugger_hook(int)
 ab3c 7 131 46
 ab43 1 132 46
-FUNC ab48 14a 0 _scrt_fastfail(unsigned int)
+FUNC ab48 14a 0 __scrt_fastfail(unsigned int)
 ab48 17 147 46
 ab5f e 150 46
 ab6d 4 151 46
@@ -1104,18 +1104,18 @@ ac66 b 227 46
 ac71 8 231 46
 ac79 8 232 46
 ac81 11 233 46
-FUNC ace4 3a 0 _scrt_get_show_window_mode()
+FUNC ace4 3a 0 __scrt_get_show_window_mode()
 ace4 7 22 46
 aceb 10 23 46
 acfb b 24 46
 ad06 10 26 46
 ad16 8 29 46
-FUNC ad2c 5 0 _scrt_initialize_mta()
+FUNC ad2c 5 0 __scrt_initialize_mta()
 ad2c 5 83 46
-FUNC ad34 3 0 _scrt_initialize_winrt()
+FUNC ad34 3 0 __scrt_initialize_winrt()
 ad34 2 67 46
 ad36 1 68 46
-FUNC ad38 52 0 _scrt_is_managed_app()
+FUNC ad38 52 0 __scrt_is_managed_app()
 ad38 4 32 46
 ad3c 8 33 46
 ad44 5 34 46
@@ -1128,33 +1128,33 @@ ad76 9 58 46
 ad7f 4 61 46
 ad83 2 59 46
 ad85 5 62 46
-FUNC ada0 e 0 _scrt_set_unhandled_exception_filter()
+FUNC ada0 e 0 __scrt_set_unhandled_exception_filter()
 ada0 e 99 46
-FUNC adb4 3 0 _scrt_stub_for_initialize_mta()
+FUNC adb4 3 0 __scrt_stub_for_initialize_mta()
 adb4 2 76 46
 adb6 1 77 46
-FUNC adb8 38 0 _scrt_unhandled_exception_filter(_EXCEPTION_POINTERS* const)
+FUNC adb8 38 0 __scrt_unhandled_exception_filter(_EXCEPTION_POINTERS* const)
 adb8 4 87 46
 adbc 3 88 46
 adbf 24 89 46
 ade3 2 94 46
 ade5 5 95 46
 adea 6 91 46
-FUNC ae00 3c 0 RTC_Initialize()
+FUNC ae00 3c 0 _RTC_Initialize()
 ae00 a 38 47
 ae0a 10 41 47
 ae1a 8 43 47
 ae22 6 45 47
 ae28 9 41 47
 ae31 b 48 47
-FUNC ae4c 3c 0 RTC_Terminate()
+FUNC ae4c 3c 0 _RTC_Terminate()
 ae4c a 52 47
 ae56 10 55 47
 ae66 8 57 47
 ae6e 6 59 47
 ae74 9 55 47
 ae7d b 62 47
-FUNC ae98 3 0 guard_check_icall_nop(unsigned long long)
+FUNC ae98 3 0 _guard_check_icall_nop(unsigned long long)
 ae98 3 82 48
 FUNC ae9c 4 0 ReadNoFence64(long long const*)
 ae9c 3 7716 14
@@ -1162,13 +1162,13 @@ ae9f 1 7718 14
 FUNC aea0 4 0 ReadPointerNoFence(void* const*)
 aea0 3 8335 14
 aea3 1 8336 14
-FUNC aea4 17 0 guard_icall_checks_enforced()
+FUNC aea4 17 0 _guard_icall_checks_enforced()
 aea4 16 130 48
 aeba 1 131 48
-FUNC aec0 3 0 guard_rf_checks_enforced()
+FUNC aec0 3 0 _guard_rf_checks_enforced()
 aec0 2 162 48
 aec2 1 163 48
-FUNC aec4 1b9 0 _isa_available_init(<NoType>)
+FUNC aec4 1b9 0 __isa_available_init(<NoType>)
 aec4 12 70 49
 aed6 1a 82 49
 aef0 6 86 49
@@ -1197,10 +1197,10 @@ b04f 6 158 49
 b055 d 160 49
 b062 6 161 49
 b068 15 168 49
-FUNC b0ec 6 0 get_startup_argv_mode()
+FUNC b0ec 6 0 _get_startup_argv_mode()
 b0ec 5 15 50
 b0f1 1 16 50
-FUNC b0f4 c 0 _scrt_is_ucrt_dll_in_use(<NoType>)
+FUNC b0f4 c 0 __scrt_is_ucrt_dll_in_use(<NoType>)
 b0f4 b 23 51
 b0ff 1 24 51
 PUBLIC b110 0 RtlCaptureContext
@@ -1219,7 +1219,7 @@ PUBLIC b158 0 InitializeSListHead
 PUBLIC b15e 0 IsDebuggerPresent
 PUBLIC b164 0 GetStartupInfoW
 PUBLIC b16a 0 GetModuleHandleW
-FUNC b170 20b 0 _C_specific_handler(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
+FUNC b170 20b 0 __C_specific_handler(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
 b170 22 175 53
 b192 e 196 53
 b1a0 4 205 53
@@ -1330,13 +1330,13 @@ b52c 9 394 28
 b535 8 395 28
 b53d 4 396 28
 b541 6 397 28
-FUNC b550 27 0 _std_type_info_compare(__std_type_info_data const*, __std_type_info_data const*)
+FUNC b550 27 0 __std_type_info_compare(__std_type_info_data const*, __std_type_info_data const*)
 b550 5 23 54
 b555 19 28 54
 b56e 3 29 54
 b571 5 28 54
 b576 1 29 54
-FUNC b580 2a 0 _std_type_info_destroy_list(__type_info_node*)
+FUNC b580 2a 0 __std_type_info_destroy_list(__type_info_node*)
 b580 6 139 54
 b586 6 140 54
 b58c 5 141 54
@@ -1344,7 +1344,7 @@ b591 3 143 54
 b594 8 144 54
 b59c 8 145 54
 b5a4 6 147 54
-FUNC b5b4 3b 0 _std_type_info_hash(__std_type_info_data const*)
+FUNC b5b4 3b 0 __std_type_info_hash(__std_type_info_data const*)
 b5b4 a 47 54
 b5be 6 48 54
 b5c4 3 50 54
@@ -1352,7 +1352,7 @@ b5c7 17 51 54
 b5de 6 48 54
 b5e4 a 56 54
 b5ee 1 62 54
-FUNC b600 11c 0 _std_type_info_name(__std_type_info_data*, __type_info_node*)
+FUNC b600 11c 0 __std_type_info_name(__std_type_info_data*, __type_info_node*)
 b600 1c 68 54
 b61c 3 72 54
 b61f 6 68 54
@@ -1379,7 +1379,7 @@ b6df 3 129 54
 b6e2 6 130 54
 b6e8 16 131 54
 b6fe 1e 132 54
-FUNC b764 32 0 _vcrt_initialize()
+FUNC b764 32 0 __vcrt_initialize()
 b764 4 54 55
 b768 5 61 55
 b76d 5 62 55
@@ -1390,16 +1390,16 @@ b788 5 71 55
 b78d 2 72 55
 b78f 2 75 55
 b791 5 76 55
-FUNC b7a4 14 0 _vcrt_thread_attach()
+FUNC b7a4 14 0 __vcrt_thread_attach()
 b7a4 4 104 55
 b7a8 b 108 55
 b7b3 5 112 55
-FUNC b7c0 12 0 _vcrt_thread_detach()
+FUNC b7c0 12 0 __vcrt_thread_detach()
 b7c0 4 115 55
 b7c4 7 117 55
 b7cb 2 118 55
 b7cd 5 119 55
-FUNC b7d8 20 0 _vcrt_uninitialize(bool)
+FUNC b7d8 20 0 __vcrt_uninitialize(bool)
 b7d8 4 79 55
 b7dc 4 85 55
 b7e0 5 88 55
@@ -1407,7 +1407,7 @@ b7e5 5 89 55
 b7ea 7 90 55
 b7f1 2 93 55
 b7f3 5 94 55
-FUNC b800 10 0 _vcrt_uninitialize_critical()
+FUNC b800 10 0 __vcrt_uninitialize_critical()
 b800 4 97 55
 b804 5 98 55
 b809 2 100 55
@@ -1509,32 +1509,32 @@ b9d7 1 305 56
 b9d8 3 308 56
 b9db 4 309 56
 b9df 1 310 56
-FUNC ba60 18 0 NLG_Notify()
+FUNC ba60 18 0 _NLG_Notify()
 ba60 5 51 57
 ba65 5 52 57
 ba6a 5 53 57
 ba6f 7 54 57
 ba76 2 55 57
-FUNC ba80 1 0 _NLG_Dispatch2()
+FUNC ba80 1 0 __NLG_Dispatch2()
 ba80 1 60 57
-FUNC ba90 1 0 _NLG_Return2()
+FUNC ba90 1 0 __NLG_Return2()
 ba90 1 84 57
 FUNC baa4 5 0 __except_get_jumpbuf_sp(_SETJMP_FLOAT128*)
 baa4 4 159 58
 baa8 1 160 58
-FUNC baac 37 0 _except_validate_context_record(_CONTEXT*)
+FUNC baac 37 0 __except_validate_context_record(_CONTEXT*)
 baac 13 83 58
 babf 9 84 58
 bac8 7 90 58
 bacf c 91 58
 badb 7 94 58
 bae2 1 97 58
-FUNC baf0 3f 0 _except_validate_jump_buffer(_SETJMP_FLOAT128*)
+FUNC baf0 3f 0 __except_validate_jump_buffer(_SETJMP_FLOAT128*)
 baf0 7 167 58
 baf7 3 166 58
 bafa 34 167 58
 bb2e 1 168 58
-FUNC bb40 5b 0 _except_validate_jump_buffer_common(_SETJMP_FLOAT128*, void* (*)(_SETJMP_FLOAT128*))
+FUNC bb40 5b 0 __except_validate_jump_buffer_common(_SETJMP_FLOAT128*, void* (*)(_SETJMP_FLOAT128*))
 bb40 a 123 58
 bb4a 7 135 58
 bb51 3 123 58
@@ -1546,7 +1546,7 @@ bb86 2 143 58
 bb88 6 147 58
 bb8e 2 149 58
 bb90 b 153 58
-FUNC bbb4 71 0 _DestructExceptionObject(EHExceptionRecord*, unsigned char)
+FUNC bbb4 71 0 __DestructExceptionObject(EHExceptionRecord*, unsigned char)
 bbb4 5 223 65
 bbb9 8 220 65
 bbc1 1b 223 65
@@ -1564,7 +1564,7 @@ bc44 3 149 69
 FUNC bc48 5 0 type_info::raw_name() const
 bc48 4 103 38
 bc4c 1 104 38
-FUNC bc50 2f 0 IsExceptionObjectToBeDestroyed(void*)
+FUNC bc50 2f 0 _IsExceptionObjectToBeDestroyed(void*)
 bc50 9 276 65
 bc59 b 279 65
 bc64 5 280 65
@@ -1572,16 +1572,16 @@ bc69 9 279 65
 bc72 3 284 65
 bc75 6 285 65
 bc7b 4 281 65
-FUNC bc8c 8 0 SetWinRTOutOfMemoryExceptionCallback(void* (*)())
+FUNC bc8c 8 0 _SetWinRTOutOfMemoryExceptionCallback(void* (*)())
 bc8c 7 185 65
 bc93 1 186 65
-FUNC bc98 23 0 _AdjustPointer(void*, PMD const&)
+FUNC bc98 23 0 __AdjustPointer(void*, PMD const&)
 bc98 6 48 65
 bc9e 6 50 65
 bca4 10 51 65
 bcb4 6 58 65
 bcba 1 62 65
-FUNC bcc4 4a 0 _FrameUnwindFilter(_EXCEPTION_POINTERS*)
+FUNC bcc4 4a 0 __FrameUnwindFilter(_EXCEPTION_POINTERS*)
 bcc4 4 134 65
 bcc8 1d 139 65
 bce5 b 168 65
@@ -1590,7 +1590,7 @@ bcf8 2 172 65
 bcfa 5 178 65
 bcff 9 141 65
 bd08 6 142 65
-FUNC bd20 5b 0 _GetPlatformExceptionInfo(int*)
+FUNC bd20 5b 0 __GetPlatformExceptionInfo(int*)
 bd20 6 75 65
 bd26 6 76 65
 bd2c 9 77 65
@@ -1604,22 +1604,22 @@ bd55 6 93 65
 bd5b 18 95 65
 bd73 2 100 65
 bd75 6 101 65
-FUNC bd94 12 0 _current_exception()
+FUNC bd94 12 0 __current_exception()
 bd94 4 112 65
 bd98 9 113 65
 bda1 5 114 65
-FUNC bdac 12 0 _current_exception_context()
+FUNC bdac 12 0 __current_exception_context()
 bdac 4 117 65
 bdb0 9 118 65
 bdb9 5 119 65
-FUNC bdc4 12 0 _processing_throw()
+FUNC bdc4 12 0 __processing_throw()
 bdc4 4 122 65
 bdc8 9 123 65
 bdd1 5 124 65
-FUNC bddc a 0 _std_terminate()
+FUNC bddc a 0 __std_terminate()
 bddc 4 197 65
 bde0 6 198 65
-FUNC bde8 a5 0 is_exception_typeof(type_info const&, _EXCEPTION_POINTERS*)
+FUNC bde8 a5 0 _is_exception_typeof(type_info const&, _EXCEPTION_POINTERS*)
 bde8 9 292 65
 bdf1 9 293 65
 bdfa 3 295 65
@@ -3755,11 +3755,11 @@ FUNC 148f0 2c 0 und_strncmp(char const*, char const*, unsigned int)
 1490e 5 1084 74
 14913 8 1090 74
 1491b 1 1091 74
-FUNC 14928 27 0 _unDName(char*, char const*, int, void* (*)(unsigned long long), void (*)(void*), unsigned short)
+FUNC 14928 27 0 __unDName(char*, char const*, int, void* (*)(unsigned long long), void (*)(void*), unsigned short)
 14928 4 707 73
 1492c 1e 708 73
 1494a 5 710 73
-FUNC 14958 132 0 _unDNameEx(char*, char const*, int, void* (*)(unsigned long long), void (*)(void*), char* (*)(long), unsigned long)
+FUNC 14958 132 0 __unDNameEx(char*, char const*, int, void* (*)(unsigned long long), void (*)(void*), char* (*)(long), unsigned long)
 14958 24 746 73
 1497c 5 749 73
 14981 2 750 73
@@ -3771,7 +3771,7 @@ FUNC 14958 132 0 _unDNameEx(char*, char const*, int, void* (*)(unsigned long lon
 14a43 38 770 73
 14a7b 7 776 73
 14a82 8 782 73
-FUNC 14ad8 62 0 vsprintf_s_l(char* const, const unsigned long long, char const* const, __crt_locale_pointers* const, char*)
+FUNC 14ad8 62 0 _vsprintf_s_l(char* const, const unsigned long long, char const* const, __crt_locale_pointers* const, char*)
 14ad8 20 1493 41
 14af8 25 1494 41
 14b1d 1d 1499 41
@@ -3837,25 +3837,25 @@ FUNC 14db4 34 0 store_and_initialize_ptd(__vcrt_ptd* const)
 14dd9 7 59 75
 14de0 2 61 75
 14de2 6 62 75
-FUNC 14df8 1f 0 _vcrt_freefls(void*)
+FUNC 14df8 1f 0 __vcrt_freefls(void*)
 14df8 4 194 75
 14dfc 11 195 75
 14e0d 5 198 75
 14e12 5 199 75
-FUNC 14e20 4d 0 _vcrt_freeptd(__vcrt_ptd*)
+FUNC 14e20 4d 0 __vcrt_freeptd(__vcrt_ptd*)
 14e20 9 175 75
 14e29 b 177 75
 14e34 13 183 75
 14e47 7 187 75
 14e4e 19 188 75
 14e67 6 189 75
-FUNC 14e80 19 0 _vcrt_getptd()
+FUNC 14e80 19 0 __vcrt_getptd()
 14e80 4 164 75
 14e84 5 165 75
 14e89 5 166 75
 14e8e 5 172 75
 14e93 6 168 75
-FUNC 14ea0 cb 0 _vcrt_getptd_noexit()
+FUNC 14ea0 cb 0 __vcrt_getptd_noexit()
 14ea0 f 95 75
 14eaf 9 106 75
 14eb8 7 108 75
@@ -3874,7 +3874,7 @@ FUNC 14ea0 cb 0 _vcrt_getptd_noexit()
 14f3b 6 139 75
 14f41 1a 143 75
 14f5b 10 144 75
-FUNC 14fa0 4d 0 _vcrt_getptd_noinit()
+FUNC 14fa0 4d 0 __vcrt_getptd_noinit()
 14fa0 a 148 75
 14faa 9 150 75
 14fb3 4 151 75
@@ -3883,7 +3883,7 @@ FUNC 14fa0 4d 0 _vcrt_getptd_noinit()
 14fca b 157 75
 14fd5 d 159 75
 14fe2 b 160 75
-FUNC 15000 51 0 _vcrt_initialize_ptd()
+FUNC 15000 51 0 __vcrt_initialize_ptd()
 15000 4 67 75
 15004 12 68 75
 15016 5 69 75
@@ -3891,14 +3891,14 @@ FUNC 15000 51 0 _vcrt_initialize_ptd()
 15041 4 80 75
 15045 5 76 75
 1504a 7 81 75
-FUNC 15068 22 0 _vcrt_uninitialize_ptd()
+FUNC 15068 22 0 __vcrt_uninitialize_ptd()
 15068 4 84 75
 1506c b 85 75
 15077 5 87 75
 1507c 7 88 75
 15083 2 91 75
 15085 5 92 75
-FUNC 15094 46 0 _vcrt_initialize_locks()
+FUNC 15094 46 0 __vcrt_initialize_locks()
 15094 6 25 76
 1509a 2 26 76
 1509c 20 28 76
@@ -3907,9 +3907,9 @@ FUNC 15094 46 0 _vcrt_initialize_locks()
 150cd 5 30 76
 150d2 2 31 76
 150d4 6 38 76
-FUNC 150ec 19 0 _vcrt_lock(__vcrt_lock_id)
+FUNC 150ec 19 0 __vcrt_lock(__vcrt_lock_id)
 150ec 19 53 76
-FUNC 1510c 37 0 _vcrt_uninitialize_locks()
+FUNC 1510c 37 0 __vcrt_uninitialize_locks()
 1510c 6 41 76
 15112 8 42 76
 1511a 17 44 76
@@ -3917,7 +3917,7 @@ FUNC 1510c 37 0 _vcrt_uninitialize_locks()
 15137 4 42 76
 1513b 2 48 76
 1513d 6 49 76
-FUNC 15150 19 0 _vcrt_unlock(__vcrt_lock_id)
+FUNC 15150 19 0 __vcrt_unlock(__vcrt_lock_id)
 15150 19 58 76
 FUNC 15170 8 0 __crt_fast_encoded_nullptr_t::operator<void> void *() const
 15170 7 536 28
@@ -4014,7 +4014,7 @@ FUNC 15924 73 0 try_load_library_from_system_directory(wchar_t const* const)
 15988 7 143 77
 1598f 2 146 77
 15991 6 147 77
-FUNC 159b4 45 0 _vcrt_FlsAlloc(void (*)(void*))
+FUNC 159b4 45 0 __vcrt_FlsAlloc(void (*)(void*))
 159b4 9 312 77
 159bd 21 313 77
 159de 3 315 77
@@ -4022,21 +4022,21 @@ FUNC 159b4 45 0 _vcrt_FlsAlloc(void (*)(void*))
 159e6 7 315 77
 159ed 5 319 77
 159f2 7 318 77
-FUNC 15a0c 46 0 _vcrt_FlsFree(unsigned long)
+FUNC 15a0c 46 0 __vcrt_FlsFree(unsigned long)
 15a0c 8 322 77
 15a14 26 323 77
 15a3a 5 329 77
 15a3f 7 325 77
 15a46 5 329 77
 15a4b 7 328 77
-FUNC 15a64 46 0 _vcrt_FlsGetValue(unsigned long)
+FUNC 15a64 46 0 __vcrt_FlsGetValue(unsigned long)
 15a64 8 332 77
 15a6c 26 333 77
 15a92 5 339 77
 15a97 7 335 77
 15a9e 5 339 77
 15aa3 7 338 77
-FUNC 15abc 51 0 _vcrt_FlsSetValue(unsigned long, void*)
+FUNC 15abc 51 0 __vcrt_FlsSetValue(unsigned long, void*)
 15abc d 342 77
 15ac9 7 343 77
 15ad0 2 342 77
@@ -4044,7 +4044,7 @@ FUNC 15abc 51 0 _vcrt_FlsSetValue(unsigned long, void*)
 15af4 8 345 77
 15afc 6 348 77
 15b02 b 349 77
-FUNC 15b24 61 0 _vcrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsigned long, unsigned long)
+FUNC 15b24 61 0 __vcrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsigned long, unsigned long)
 15b24 12 356 77
 15b36 7 357 77
 15b3d 2 356 77
@@ -4054,11 +4054,11 @@ FUNC 15b24 61 0 _vcrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsign
 15b64 b 359 77
 15b6f 6 362 77
 15b75 10 363 77
-FUNC 15ba0 2f 0 _vcrt_initialize_winapi_thunks()
+FUNC 15ba0 2f 0 __vcrt_initialize_winapi_thunks()
 15ba0 5 86 77
 15ba5 24 87 77
 15bc9 6 93 77
-FUNC 15bdc 3e 0 _vcrt_uninitialize_winapi_thunks(bool)
+FUNC 15bdc 3e 0 __vcrt_uninitialize_winapi_thunks(bool)
 15bdc 9 98 77
 15be5 7 103 77
 15bec 8 105 77
@@ -4073,7 +4073,7 @@ FUNC 15c2c 8 0 __crt_fast_encoded_nullptr_t::operator<void __cdecl(void)> void (
 FUNC 15c38 1e 0 __crt_fast_encode_pointer<void (__cdecl*)(void)>(void (* const)())
 15c38 1d 517 28
 15c55 1 523 28
-FUNC 15c60 f 0 _vcrt_initialize_pure_virtual_call_handler()
+FUNC 15c60 f 0 __vcrt_initialize_pure_virtual_call_handler()
 15c60 e 21 78
 15c6e 1 22 78
 FUNC 15c74 16 0 __crt_fast_decode_pointer<void (__cdecl*)(void)>(void (* const)())
@@ -4085,16 +4085,16 @@ FUNC 15c90 7 0 __crt_interlocked_exchange_pointer<void __cdecl(void),void (__cde
 FUNC 15c98 4 0 __crt_interlocked_read_pointer<void __cdecl(void)>(void (* const*)())
 15c98 3 638 28
 15c9b 1 642 28
-FUNC 15c9c 1a 0 get_purecall_handler()
+FUNC 15c9c 1a 0 _get_purecall_handler()
 15c9c 19 44 79
 15cb5 1 45 79
-FUNC 15cbc 2e 0 purecall()
+FUNC 15cbc 2e 0 _purecall()
 15cbc 4 19 79
 15cc0 19 20 79
 15cd9 5 21 79
 15cde 6 23 79
 15ce4 6 29 79
-FUNC 15cf8 37 0 set_purecall_handler(void (*)())
+FUNC 15cf8 37 0 _set_purecall_handler(void (*)())
 15cf8 7 36 79
 15cff 3 35 79
 15d02 2c 36 79
@@ -4367,14 +4367,14 @@ FUNC 16b94 175 0 __FrameHandler4::TryBlockMap::setBuffer(__FrameHandler4::TryBlo
 16c56 8c 897 64
 16ce2 17 895 64
 16cf9 10 899 64
-FUNC 16d68 3a 0 CreateFrameInfo(FrameInfo*, void*)
+FUNC 16d68 3a 0 _CreateFrameInfo(FrameInfo*, void*)
 16d68 9 536 81
 16d71 3 537 81
 16d74 1c 538 81
 16d90 9 539 81
 16d99 3 540 81
 16d9c 6 541 81
-FUNC 16db0 53 0 FindAndUnlinkFrame(FrameInfo*)
+FUNC 16db0 53 0 _FindAndUnlinkFrame(FrameInfo*)
 16db0 d 552 81
 16dbd b 553 81
 16dc8 b 555 81
@@ -4384,27 +4384,27 @@ FUNC 16db0 53 0 FindAndUnlinkFrame(FrameInfo*)
 16de6 8 560 81
 16dee f 567 81
 16dfd 6 553 81
-FUNC 16e18 12 0 GetImageBase()
+FUNC 16e18 12 0 _GetImageBase()
 16e18 4 29 81
 16e1c 9 30 81
 16e25 5 31 81
-FUNC 16e30 12 0 GetThrowImageBase()
+FUNC 16e30 12 0 _GetThrowImageBase()
 16e30 4 45 81
 16e34 9 46 81
 16e3d 5 47 81
-FUNC 16e48 18 0 SetImageBase(unsigned long long)
+FUNC 16e48 18 0 _SetImageBase(unsigned long long)
 16e48 9 34 81
 16e51 9 35 81
 16e5a 6 36 81
-FUNC 16e68 18 0 SetThrowImageBase(unsigned long long)
+FUNC 16e68 18 0 _SetThrowImageBase(unsigned long long)
 16e68 9 50 81
 16e71 9 51 81
 16e7a 6 52 81
-FUNC 16e88 5 0 _CxxFrameHandler(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
+FUNC 16e88 5 0 __CxxFrameHandler(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
 16e88 5 318 81
-FUNC 16e90 5 0 _CxxFrameHandler2(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
+FUNC 16e90 5 0 __CxxFrameHandler2(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
 16e90 5 308 81
-FUNC 16e98 7d 0 _CxxFrameHandler3(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
+FUNC 16e98 7d 0 __CxxFrameHandler3(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
 16e98 12 260 81
 16eaa b 263 81
 16eb5 d 265 81
@@ -4412,7 +4412,7 @@ FUNC 16e98 7d 0 _CxxFrameHandler3(EHExceptionRecord*, unsigned long long, _CONTE
 16ecf 9 269 81
 16ed8 2d 270 81
 16f05 10 272 81
-FUNC 16f34 a1 0 _CxxFrameHandler4(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
+FUNC 16f34 a1 0 __CxxFrameHandler4(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*)
 16f34 10 279 81
 16f44 4 280 81
 16f48 3 279 81
@@ -5607,15 +5607,15 @@ FUNC 1b4b8 39 0 __FrameHandler4::HandlerMap::setBuffer(unsigned int)
 FUNC 1b500 12 0 std::exception::what() const
 1b500 11 91 39
 1b511 1 92 39
-FUNC 1b518 5 0 _BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 1b518 5 0 __BuildCatchObject(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 1b518 5 2017 84
-FUNC 1b520 5 0 _BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
+FUNC 1b520 5 0 __BuildCatchObjectHelper(EHExceptionRecord*, void*, _s_HandlerType const*, _s_CatchableType const*)
 1b520 5 1906 84
-FUNC 1b528 5 0 _TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
+FUNC 1b528 5 0 __TypeMatch(_s_HandlerType const*, _s_CatchableType const*, _s_ThrowInfo const*)
 1b528 5 968 84
-FUNC 1b530 7 0 _vcrt_EncodePointer(void* const)
+FUNC 1b530 7 0 __vcrt_EncodePointer(void* const)
 1b530 7 332 23
-FUNC 1b550 40 0 CallSettingFrame()
+FUNC 1b550 40 0 _CallSettingFrame()
 1b550 4 38 85
 1b554 5 42 85
 1b559 5 43 85
@@ -5632,7 +5632,7 @@ FUNC 1b550 40 0 CallSettingFrame()
 1b586 5 56 85
 1b58b 4 57 85
 1b58f 1 58 85
-FUNC 1b5a0 47 0 CallSettingFrameEncoded()
+FUNC 1b5a0 47 0 _CallSettingFrameEncoded()
 1b5a0 4 88 85
 1b5a4 5 92 85
 1b5a9 5 93 85
@@ -5677,7 +5677,7 @@ FUNC 1b670 1b 0 __crt_unique_heap_ptr<char,__crt_public_free_policy>::release()
 1b679 8 395 28
 1b681 4 396 28
 1b685 6 397 28
-FUNC 1b694 8d 0 _std_exception_copy(__std_exception_data const*, __std_exception_data*)
+FUNC 1b694 8d 0 __std_exception_copy(__std_exception_data const*, __std_exception_data*)
 1b694 15 17 86
 1b6a9 14 20 86
 1b6bd d 27 86
@@ -5691,13 +5691,13 @@ FUNC 1b694 8d 0 _std_exception_copy(__std_exception_data const*, __std_exception
 1b701 6 22 86
 1b707 4 23 86
 1b70b 16 38 86
-FUNC 1b744 25 0 _std_exception_destroy(__std_exception_data*)
+FUNC 1b744 25 0 __std_exception_destroy(__std_exception_data*)
 1b744 6 43 86
 1b74a 9 44 86
 1b753 8 46 86
 1b75b 8 50 86
 1b763 6 51 86
-FUNC 1b774 bf 0 CxxThrowException(void*, _s__ThrowInfo const*)
+FUNC 1b774 bf 0 _CxxThrowException(void*, _s__ThrowInfo const*)
 1b774 12 59 87
 1b786 32 76 87
 1b7b8 a 79 87
@@ -5738,7 +5738,7 @@ FUNC 1b93c 3 0 __crt_state_management::get_current_state_index()
 FUNC 1b940 4 0 __crt_state_management::dual_state_global<void (__cdecl*)(wchar_t const *,wchar_t const *,wchar_t const *,unsigned int,unsigned __int64)>::value()
 1b940 3 147 184
 1b943 1 148 184
-FUNC 1b944 15b 0 _acrt_call_reportfault(int, unsigned long, unsigned long)
+FUNC 1b944 15b 0 __acrt_call_reportfault(int, unsigned long, unsigned long)
 1b944 35 143 126
 1b979 5 145 126
 1b97e 5 147 126
@@ -5758,19 +5758,19 @@ FUNC 1b944 15b 0 _acrt_call_reportfault(int, unsigned long, unsigned long)
 1ba64 d 202 126
 1ba71 7 204 126
 1ba78 27 206 126
-FUNC 1baf8 8 0 _acrt_initialize_invalid_parameter_handler(void*)
+FUNC 1baf8 8 0 __acrt_initialize_invalid_parameter_handler(void*)
 1baf8 7 80 126
 1baff 1 81 126
-FUNC 1bb04 17 0 get_invalid_parameter_handler()
+FUNC 1bb04 17 0 _get_invalid_parameter_handler()
 1bb04 16 273 126
 1bb1a 1 274 126
-FUNC 1bb20 1a 0 get_thread_local_invalid_parameter_handler()
+FUNC 1bb20 1a 0 _get_thread_local_invalid_parameter_handler()
 1bb20 4 288 126
 1bb24 5 289 126
 1bb29 5 290 126
 1bb2e 7 295 126
 1bb35 5 296 126
-FUNC 1bb40 ae 0 invalid_parameter(wchar_t const* const, wchar_t const* const, wchar_t const* const, const unsigned int, const unsigned long long)
+FUNC 1bb40 ae 0 _invalid_parameter(wchar_t const* const, wchar_t const* const, wchar_t const* const, const unsigned int, const unsigned long long)
 1bb40 20 97 126
 1bb60 5 98 126
 1bb65 11 99 126
@@ -5785,15 +5785,15 @@ FUNC 1bb40 ae 0 invalid_parameter(wchar_t const* const, wchar_t const* const, wc
 1bbcc d 108 126
 1bbd9 2 109 126
 1bbdb 13 112 126
-FUNC 1bc1c 1e 0 invalid_parameter_noinfo()
+FUNC 1bc1c 1e 0 _invalid_parameter_noinfo()
 1bc1c 4 116 126
 1bc20 15 117 126
 1bc35 5 118 126
-FUNC 1bc44 2f 0 invalid_parameter_noinfo_noreturn()
+FUNC 1bc44 2f 0 _invalid_parameter_noinfo_noreturn()
 1bc44 4 124 126
 1bc48 15 125 126
 1bc5d 16 126 126
-FUNC 1bc80 47 0 invoke_watson(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
+FUNC 1bc80 47 0 _invoke_watson(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
 1bc80 4 215 126
 1bc84 f 222 126
 1bc93 7 224 126
@@ -5801,7 +5801,7 @@ FUNC 1bc80 47 0 invoke_watson(wchar_t const*, wchar_t const*, wchar_t const*, un
 1bcae e 233 126
 1bcbc 4 234 126
 1bcc0 7 233 126
-FUNC 1bcd8 34 0 set_invalid_parameter_handler(void (*)(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long))
+FUNC 1bcd8 34 0 _set_invalid_parameter_handler(void (*)(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long))
 1bcd8 a 265 126
 1bce2 b 267 126
 1bced a 266 126
@@ -5811,20 +5811,20 @@ FUNC 1bcd8 34 0 set_invalid_parameter_handler(void (*)(wchar_t const*, wchar_t c
 1bd01 3 266 126
 1bd04 7 267 126
 1bd0b 1 269 126
-FUNC 1bd1c 25 0 set_thread_local_invalid_parameter_handler(void (*)(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long))
+FUNC 1bd1c 25 0 _set_thread_local_invalid_parameter_handler(void (*)(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long))
 1bd1c 9 279 126
 1bd25 8 280 126
 1bd2d 7 282 126
 1bd34 7 283 126
 1bd3b 6 285 126
-FUNC 1bd4c 64 0 initterm(void (**)(), void (**)())
+FUNC 1bd4c 64 0 _initterm(void (**)(), void (**)())
 1bd4c 14 15 259
 1bd60 21 16 259
 1bd81 8 18 259
 1bd89 6 21 259
 1bd8f c 16 259
 1bd9b 15 23 259
-FUNC 1bdcc 3d 0 initterm_e(int (**)(), int (**)())
+FUNC 1bdcc 3d 0 _initterm_e(int (**)(), int (**)())
 1bdcc 10 34 259
 1bddc 3 35 259
 1bddf a 37 259
@@ -5845,12 +5845,12 @@ FUNC 1be30 1d 0 xcptlookup(const unsigned long, __crt_signal_action_t* const)
 1be48 1 70 261
 1be49 3 66 261
 1be4c 1 70 261
-FUNC 1be54 13 0 seh_filter_dll(unsigned long, _EXCEPTION_POINTERS*)
+FUNC 1be54 13 0 _seh_filter_dll(unsigned long, _EXCEPTION_POINTERS*)
 1be54 9 80 261
 1be5d 2 81 261
 1be5f 1 84 261
 1be60 7 83 261
-FUNC 1be6c 182 0 seh_filter_exe(unsigned long, _EXCEPTION_POINTERS*)
+FUNC 1be6c 182 0 _seh_filter_exe(unsigned long, _EXCEPTION_POINTERS*)
 1be6c 19 124 261
 1be85 5 127 261
 1be8a f 128 261
@@ -6021,21 +6021,21 @@ FUNC 1c4e4 5b 0 try_cor_exit_process(const unsigned int)
 1c51c 5 94 279
 1c521 8 97 279
 1c529 16 98 279
-FUNC 1c558 c 0 Exit(int)
+FUNC 1c558 c 0 _Exit(int)
 1c558 c 303 279
-FUNC 1c568 8 0 _acrt_initialize_thread_local_exit_callback(void*)
+FUNC 1c568 8 0 __acrt_initialize_thread_local_exit_callback(void*)
 1c568 7 163 279
 1c56f 1 164 279
-FUNC 1c574 10 0 c_exit()
+FUNC 1c574 10 0 _c_exit()
 1c574 10 318 279
-FUNC 1c588 d 0 cexit()
+FUNC 1c588 d 0 _cexit()
 1c588 d 313 279
-FUNC 1c598 c 0 exit(int)
+FUNC 1c598 c 0 _exit(int)
 1c598 c 298 279
-FUNC 1c5a8 7 0 is_c_termination_complete()
+FUNC 1c5a8 7 0 _is_c_termination_complete()
 1c5a8 6 286 279
 1c5ae 1 287 279
-FUNC 1c5b0 3c 0 register_thread_local_exe_atexit_callback(void (*)(void*, unsigned long, void*))
+FUNC 1c5b0 3c 0 _register_thread_local_exe_atexit_callback(void (*)(void*, unsigned long, void*))
 1c5b0 4 169 279
 1c5b4 7 171 279
 1c5bb 3 169 279
@@ -6350,7 +6350,7 @@ FUNC 1d044 16 0 should_copy_another_character(const char)
 FUNC 1d060 3 0 should_copy_another_character(wchar_t)
 1d060 2 91 325
 1d062 1 92 325
-FUNC 1d064 5d 0 _acrt_allocate_buffer_for_argv(unsigned long long, unsigned long long, unsigned long long)
+FUNC 1d064 5d 0 __acrt_allocate_buffer_for_argv(unsigned long long, unsigned long long, unsigned long long)
 1d064 6 271 325
 1d06a 12 272 325
 1d07c e 275 325
@@ -6364,21 +6364,21 @@ FUNC 1d064 5d 0 _acrt_allocate_buffer_for_argv(unsigned long long, unsigned long
 1d0af a 289 325
 1d0b9 2 282 325
 1d0bb 6 290 325
-FUNC 1d0d8 186 0 configure_narrow_argv(_crt_argv_mode)
+FUNC 1d0d8 186 0 _configure_narrow_argv(_crt_argv_mode)
 1d0d8 13 397 325
 1d0eb 2 398 325
 1d0ed 3 397 325
 1d0f0 15b 398 325
 1d24b 13 399 325
-FUNC 1d2c0 182 0 configure_wide_argv(_crt_argv_mode)
+FUNC 1d2c0 182 0 _configure_wide_argv(_crt_argv_mode)
 1d2c0 13 402 325
 1d2d3 2 403 325
 1d2d5 3 402 325
 1d2d8 157 403 325
 1d42f 13 404 325
-FUNC 1d4a4 8 0 set_pgmptr(char*)
+FUNC 1d4a4 8 0 _set_pgmptr(char*)
 1d4a4 8 229 205
-FUNC 1d4b0 8 0 set_wpgmptr(wchar_t*)
+FUNC 1d4b0 8 0 _set_wpgmptr(wchar_t*)
 1d4b0 8 230 205
 FUNC 1d4bc 8 0 __crt_internal_free_policy::operator()<wchar_t>(wchar_t const* const) const
 1d4bc 8 335 103
@@ -6656,19 +6656,19 @@ FUNC 1e090 4 0 __crt_state_management::dual_state_global<char * *>::value()
 FUNC 1e094 4 0 __crt_state_management::dual_state_global<wchar_t * *>::value()
 1e094 3 147 184
 1e097 1 148 184
-FUNC 1e098 3b 0 _dcrt_get_or_create_narrow_environment_nolock()
+FUNC 1e098 3b 0 __dcrt_get_or_create_narrow_environment_nolock()
 1e098 4 307 333
 1e09c 15 308 333
 1e0b1 4 309 333
 1e0b5 19 308 333
 1e0ce 5 309 333
-FUNC 1e0e4 3b 0 _dcrt_get_or_create_wide_environment_nolock()
+FUNC 1e0e4 3b 0 __dcrt_get_or_create_wide_environment_nolock()
 1e0e4 4 312 333
 1e0e8 15 313 333
 1e0fd 4 314 333
 1e101 19 313 333
 1e11a 5 314 333
-FUNC 1e130 38 0 _dcrt_uninitialize_environments_nolock()
+FUNC 1e130 38 0 __dcrt_uninitialize_environments_nolock()
 1e130 4 217 333
 1e134 c 218 333
 1e140 c 219 333
@@ -6676,23 +6676,23 @@ FUNC 1e130 38 0 _dcrt_uninitialize_environments_nolock()
 1e158 7 222 333
 1e15f 4 223 333
 1e163 5 222 333
-FUNC 1e178 8 0 _p__environ()
+FUNC 1e178 8 0 __p__environ()
 1e178 8 30 333
-FUNC 1e184 8 0 _p__wenviron()
+FUNC 1e184 8 0 __p__wenviron()
 1e184 8 31 333
-FUNC 1e190 4e 0 get_initial_narrow_environment()
+FUNC 1e190 4e 0 _get_initial_narrow_environment()
 1e190 4 329 333
 1e194 45 330 333
 1e1d9 5 331 333
-FUNC 1e1f4 4e 0 get_initial_wide_environment()
+FUNC 1e1f4 4e 0 _get_initial_wide_environment()
 1e1f4 4 334 333
 1e1f8 45 335 333
 1e23d 5 336 333
-FUNC 1e258 5 0 initialize_narrow_environment()
+FUNC 1e258 5 0 _initialize_narrow_environment()
 1e258 5 194 333
-FUNC 1e260 5 0 initialize_wide_environment()
+FUNC 1e260 5 0 _initialize_wide_environment()
 1e260 5 199 333
-FUNC 1e268 31 0 invoke_watson_if_error(int, wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
+FUNC 1e268 31 0 _invoke_watson_if_error(int, wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
 1e268 4 1586 205
 1e26c 6 1592 205
 1e272 27 1591 205
@@ -6833,15 +6833,15 @@ FUNC 1e7fc 1b 0 __crt_unique_heap_ptr<void (__cdecl*)(void),__crt_internal_free_
 1e805 8 395 103
 1e80d 4 396 103
 1e811 6 397 103
-FUNC 1e820 f 0 crt_at_quick_exit(void (*)())
+FUNC 1e820 f 0 _crt_at_quick_exit(void (*)())
 1e820 f 48 337
-FUNC 1e834 f 0 crt_atexit(void (*)())
+FUNC 1e834 f 0 _crt_atexit(void (*)())
 1e834 f 43 337
-FUNC 1e848 3a 0 execute_onexit_table(_onexit_table_t*)
+FUNC 1e848 3a 0 _execute_onexit_table(_onexit_table_t*)
 1e848 b 159 337
 1e853 2a 160 337
 1e87d 5 231 337
-FUNC 1e890 27 0 initialize_onexit_table(_onexit_table_t*)
+FUNC 1e890 27 0 _initialize_onexit_table(_onexit_table_t*)
 1e890 5 55 337
 1e895 3 57 337
 1e898 1 75 337
@@ -6851,7 +6851,7 @@ FUNC 1e890 27 0 initialize_onexit_table(_onexit_table_t*)
 1e8ac 4 71 337
 1e8b0 4 72 337
 1e8b4 3 75 337
-FUNC 1e8c0 48 0 register_onexit_function(_onexit_table_t*, int (*)())
+FUNC 1e8c0 48 0 _register_onexit_function(_onexit_table_t*, int (*)())
 1e8c0 12 83 337
 1e8d2 30 84 337
 1e902 6 149 337
@@ -6930,18 +6930,18 @@ FUNC 1eb8c 27 0 __crt_state_management::dual_state_global<__crt_locale_data *>::
 1eb8c 5 156 184
 1eb91 1c 157 184
 1ebad 6 161 184
-FUNC 1ebbc 13 0 _acrt_initialize()
+FUNC 1ebbc 13 0 __acrt_initialize()
 1ebbc 13 287 340
-FUNC 1ebd4 14 0 _acrt_thread_attach()
+FUNC 1ebd4 14 0 __acrt_thread_attach()
 1ebd4 4 328 340
 1ebd8 b 332 340
 1ebe3 5 336 340
-FUNC 1ebf0 10 0 _acrt_thread_detach()
+FUNC 1ebf0 10 0 __acrt_thread_detach()
 1ebf0 4 339 340
 1ebf4 5 341 340
 1ebf9 2 342 340
 1ebfb 5 343 340
-FUNC 1ec04 35 0 _acrt_uninitialize(bool)
+FUNC 1ec04 35 0 __acrt_uninitialize(bool)
 1ec04 4 294 340
 1ec08 4 300 340
 1ec0c a 302 340
@@ -6951,7 +6951,7 @@ FUNC 1ec04 35 0 _acrt_uninitialize(bool)
 1ec22 e 310 340
 1ec30 4 314 340
 1ec34 5 310 340
-FUNC 1ec48 10 0 _acrt_uninitialize_critical(bool)
+FUNC 1ec48 10 0 __acrt_uninitialize_critical(bool)
 1ec48 4 317 340
 1ec4c 5 318 340
 1ec51 2 324 340
@@ -6959,7 +6959,7 @@ FUNC 1ec48 10 0 _acrt_uninitialize_critical(bool)
 FUNC 1ec5c 12 0 get_terminate_or_default(__acrt_ptd const* const)
 1ec5c 11 17 348
 1ec6d 1 18 348
-FUNC 1ec74 22 0 get_terminate()
+FUNC 1ec74 22 0 _get_terminate()
 1ec74 4 21 348
 1ec78 19 22 348
 1ec91 5 23 348
@@ -14818,93 +14818,93 @@ FUNC 3c43c 103 0 __crt_stdio_output::output_adapter_common<wchar_t,__crt_stdio_o
 3c510 2 94 357
 3c512 3 98 357
 3c515 2a 105 357
-FUNC 3c580 21 0 _acrt_isleadbyte_l_noupdate(const int, __crt_locale_pointers* const)
+FUNC 3c580 21 0 __acrt_isleadbyte_l_noupdate(const int, __crt_locale_pointers* const)
 3c580 1d 810 205
 3c59d 1 811 205
 3c59e 2 810 205
 3c5a0 1 811 205
-FUNC 3c5ac b 0 _acrt_locale_changed()
+FUNC 3c5ac b 0 __acrt_locale_changed()
 3c5ac a 746 205
 3c5b6 1 747 205
-FUNC 3c5bc 18 0 _acrt_locale_get_ctype_array_value(unsigned short const* const, const int, const int)
+FUNC 3c5bc 18 0 __acrt_locale_get_ctype_array_value(unsigned short const* const, const int, const int)
 3c5bc a 91 222
 3c5c6 a 93 222
 3c5d0 1 97 222
 3c5d1 2 96 222
 3c5d3 1 97 222
-FUNC 3c5dc 8b 0 _stdio_common_vfprintf(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
+FUNC 3c5dc 8b 0 __stdio_common_vfprintf(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
 3c5dc 9 60 354
 3c5e5 1d 61 354
 3c602 15 62 354
 3c617 4a 61 354
 3c661 6 62 354
-FUNC 3c68c 8b 0 _stdio_common_vfprintf_p(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
+FUNC 3c68c 8b 0 __stdio_common_vfprintf_p(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
 3c68c 9 104 354
 3c695 1d 105 354
 3c6b2 15 106 354
 3c6c7 4a 105 354
 3c711 6 106 354
-FUNC 3c73c 8b 0 _stdio_common_vfprintf_s(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
+FUNC 3c73c 8b 0 __stdio_common_vfprintf_s(unsigned long long, _iobuf*, char const*, __crt_locale_pointers*, char*)
 3c73c 9 82 354
 3c745 1d 83 354
 3c762 15 84 354
 3c777 4a 83 354
 3c7c1 6 84 354
-FUNC 3c7ec 8b 0 _stdio_common_vfwprintf(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3c7ec 8b 0 __stdio_common_vfwprintf(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
 3c7ec 9 71 354
 3c7f5 1d 72 354
 3c812 15 73 354
 3c827 4a 72 354
 3c871 6 73 354
-FUNC 3c89c 8b 0 _stdio_common_vfwprintf_p(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3c89c 8b 0 __stdio_common_vfwprintf_p(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
 3c89c 9 115 354
 3c8a5 1d 116 354
 3c8c2 15 117 354
 3c8d7 4a 116 354
 3c921 6 117 354
-FUNC 3c94c 8b 0 _stdio_common_vfwprintf_s(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3c94c 8b 0 __stdio_common_vfwprintf_s(unsigned long long, _iobuf*, wchar_t const*, __crt_locale_pointers*, char*)
 3c94c 9 93 354
 3c955 1d 94 354
 3c972 15 95 354
 3c987 4a 94 354
 3c9d1 6 95 354
-FUNC 3c9fc 134 0 _stdio_common_vsnprintf_s(unsigned long long, char*, unsigned long long, unsigned long long, char const*, __crt_locale_pointers*, char*)
+FUNC 3c9fc 134 0 __stdio_common_vsnprintf_s(unsigned long long, char*, unsigned long long, unsigned long long, char const*, __crt_locale_pointers*, char*)
 3c9fc 18 390 354
 3ca14 6 391 354
 3ca1a c 390 354
 3ca26 ef 391 354
 3cb15 1b 392 354
-FUNC 3cb80 143 0 _stdio_common_vsnwprintf_s(unsigned long long, wchar_t*, unsigned long long, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3cb80 143 0 __stdio_common_vsnwprintf_s(unsigned long long, wchar_t*, unsigned long long, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
 3cb80 1d 403 354
 3cb9d 3 404 354
 3cba0 c 403 354
 3cbac f6 404 354
 3cca2 21 405 354
-FUNC 3cd14 5 0 _stdio_common_vsprintf(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
+FUNC 3cd14 5 0 __stdio_common_vsprintf(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
 3cd14 5 239 354
-FUNC 3cd1c 5 0 _stdio_common_vsprintf_p(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
+FUNC 3cd1c 5 0 __stdio_common_vsprintf_p(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
 3cd1c 5 416 354
-FUNC 3cd24 63 0 _stdio_common_vsprintf_s(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
+FUNC 3cd24 63 0 __stdio_common_vsprintf_s(unsigned long long, char*, unsigned long long, char const*, __crt_locale_pointers*, char*)
 3cd24 9 295 354
 3cd2d 41 296 354
 3cd6e 19 297 354
-FUNC 3cda0 5 0 _stdio_common_vswprintf(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3cda0 5 0 __stdio_common_vswprintf(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
 3cda0 5 251 354
-FUNC 3cda8 5 0 _stdio_common_vswprintf_p(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3cda8 5 0 __stdio_common_vswprintf_p(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
 3cda8 5 428 354
-FUNC 3cdb0 6e 0 _stdio_common_vswprintf_s(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
+FUNC 3cdb0 6e 0 __stdio_common_vswprintf_s(unsigned long long, wchar_t*, unsigned long long, wchar_t const*, __crt_locale_pointers*, char*)
 3cdb0 a 307 354
 3cdba 2 308 354
 3cdbc 3 307 354
 3cdbf 41 308 354
 3ce00 1e 309 354
-FUNC 3ce3c 13 0 ctype_fast_check_internal(const unsigned char, const int, __crt_locale_pointers* const)
+FUNC 3ce3c 13 0 _ctype_fast_check_internal(const unsigned char, const int, __crt_locale_pointers* const)
 3ce3c 12 1549 205
 3ce4e 1 1550 205
-FUNC 3ce54 14 0 isdigit_fast_internal(const unsigned char, __crt_locale_pointers* const)
+FUNC 3ce54 14 0 _isdigit_fast_internal(const unsigned char, __crt_locale_pointers* const)
 3ce54 13 1557 205
 3ce67 1 1558 205
-FUNC 3ce70 11 0 tolower_fast_internal(const unsigned char, __crt_locale_pointers* const)
+FUNC 3ce70 11 0 _tolower_fast_internal(const unsigned char, __crt_locale_pointers* const)
 3ce70 10 1479 205
 3ce80 1 1480 205
 FUNC 3ce88 24 0 __crt_strtox::is_overflow_condition<unsigned long>(const unsigned int, const unsigned long)
@@ -15279,57 +15279,57 @@ FUNC 3ed64 1a0 0 __crt_strtox::wide_character_to_digit(const wchar_t)
 3eef2 e 85 361
 3ef00 3 88 361
 3ef03 1 89 361
-FUNC 3ef6c 4 0 _acrt_get_locale_data_prefix(void const* const)
+FUNC 3ef6c 4 0 __acrt_get_locale_data_prefix(void const* const)
 3ef6c 3 206 222
 3ef6f 1 207 222
-FUNC 3ef70 19 0 _ascii_iswalpha(const int)
+FUNC 3ef70 19 0 __ascii_iswalpha(const int)
 3ef70 12 167 222
 3ef82 1 168 222
 3ef83 5 167 222
 3ef88 1 168 222
-FUNC 3ef90 e 0 _ascii_toupper(const int)
+FUNC 3ef90 e 0 __ascii_toupper(const int)
 3ef90 6 158 222
 3ef96 5 160 222
 3ef9b 2 162 222
 3ef9d 1 163 222
-FUNC 3efa4 d 0 _ascii_towupper(const int)
+FUNC 3efa4 d 0 __ascii_towupper(const int)
 3efa4 c 182 222
 3efb0 1 183 222
-FUNC 3efb4 29 0 atoi64(char const*)
+FUNC 3efb4 29 0 _atoi64(char const*)
 3efb4 4 51 360
 3efb8 20 52 360
 3efd8 5 53 360
-FUNC 3efe8 2d 0 atoi64_l(char const*, __crt_locale_pointers*)
+FUNC 3efe8 2d 0 _atoi64_l(char const*, __crt_locale_pointers*)
 3efe8 4 56 360
 3efec 6 57 360
 3eff2 3 56 360
 3eff5 1b 57 360
 3f010 5 58 360
-FUNC 3f020 2d 0 atoi_l(char const*, __crt_locale_pointers*)
+FUNC 3f020 2d 0 _atoi_l(char const*, __crt_locale_pointers*)
 3f020 4 26 360
 3f024 6 27 360
 3f02a 3 26 360
 3f02d 1b 27 360
 3f048 5 28 360
-FUNC 3f058 2d 0 atol_l(char const*, __crt_locale_pointers*)
+FUNC 3f058 2d 0 _atol_l(char const*, __crt_locale_pointers*)
 3f058 4 36 360
 3f05c 6 37 360
 3f062 3 36 360
 3f065 1b 37 360
 3f080 5 38 360
-FUNC 3f090 2d 0 atoll_l(char const*, __crt_locale_pointers*)
+FUNC 3f090 2d 0 _atoll_l(char const*, __crt_locale_pointers*)
 3f090 4 46 360
 3f094 6 47 360
 3f09a 3 46 360
 3f09d 1b 47 360
 3f0b8 5 48 360
-FUNC 3f0c8 61 0 chvalidchk_l(const int, const int, __crt_locale_pointers* const)
+FUNC 3f0c8 61 0 _chvalidchk_l(const int, const int, __crt_locale_pointers* const)
 3f0c8 17 218 222
 3f0df c 222 222
 3f0eb 14 224 222
 3f0ff 11 227 222
 3f110 19 229 222
-FUNC 3f144 76 0 ischartype_l(const int, const int, __crt_locale_pointers* const)
+FUNC 3f144 76 0 _ischartype_l(const int, const int, __crt_locale_pointers* const)
 3f144 17 239 222
 3f15b c 240 222
 3f167 b 241 222
@@ -15339,41 +15339,41 @@ FUNC 3f144 76 0 ischartype_l(const int, const int, __crt_locale_pointers* const)
 3f18c 4 251 222
 3f190 15 254 222
 3f1a5 15 255 222
-FUNC 3f1d8 29 0 wtoi(wchar_t const*)
+FUNC 3f1d8 29 0 _wtoi(wchar_t const*)
 3f1d8 4 68 360
 3f1dc 20 70 360
 3f1fc 5 71 360
-FUNC 3f20c 29 0 wtoi64(wchar_t const*)
+FUNC 3f20c 29 0 _wtoi64(wchar_t const*)
 3f20c 4 99 360
 3f210 20 100 360
 3f230 5 101 360
-FUNC 3f240 2d 0 wtoi64_l(wchar_t const*, __crt_locale_pointers*)
+FUNC 3f240 2d 0 _wtoi64_l(wchar_t const*, __crt_locale_pointers*)
 3f240 4 104 360
 3f244 6 105 360
 3f24a 3 104 360
 3f24d 1b 105 360
 3f268 5 106 360
-FUNC 3f278 2d 0 wtoi_l(wchar_t const*, __crt_locale_pointers*)
+FUNC 3f278 2d 0 _wtoi_l(wchar_t const*, __crt_locale_pointers*)
 3f278 4 74 360
 3f27c 6 75 360
 3f282 3 74 360
 3f285 1b 75 360
 3f2a0 5 76 360
-FUNC 3f2b0 29 0 wtol(wchar_t const*)
+FUNC 3f2b0 29 0 _wtol(wchar_t const*)
 3f2b0 4 79 360
 3f2b4 20 80 360
 3f2d4 5 81 360
-FUNC 3f2e4 2d 0 wtol_l(wchar_t const*, __crt_locale_pointers*)
+FUNC 3f2e4 2d 0 _wtol_l(wchar_t const*, __crt_locale_pointers*)
 3f2e4 4 84 360
 3f2e8 6 85 360
 3f2ee 3 84 360
 3f2f1 1b 85 360
 3f30c 5 86 360
-FUNC 3f31c 29 0 wtoll(wchar_t const*)
+FUNC 3f31c 29 0 _wtoll(wchar_t const*)
 3f31c 4 89 360
 3f320 20 90 360
 3f340 5 91 360
-FUNC 3f350 2d 0 wtoll_l(wchar_t const*, __crt_locale_pointers*)
+FUNC 3f350 2d 0 _wtoll_l(wchar_t const*, __crt_locale_pointers*)
 3f350 4 94 360
 3f354 6 95 360
 3f35a 3 94 360
@@ -15429,7 +15429,7 @@ FUNC 3f440 7d 0 strncmp()
 3f4b5 3 120 363
 3f4b8 4 121 363
 3f4bc 1 122 363
-FUNC 3f4e0 1c 0 set_abort_behavior(unsigned int, unsigned int)
+FUNC 3f4e0 1c 0 _set_abort_behavior(unsigned int, unsigned int)
 3f4e0 6 111 367
 3f4e6 15 112 367
 3f4fb 1 114 367
@@ -15682,19 +15682,19 @@ FUNC 400b4 20 0 try_get_ptd_head()
 FUNC 400dc 4 0 __crt_state_management::dual_state_global<__crt_locale_data *>::value()
 400dc 3 147 184
 400df 1 148 184
-FUNC 400e0 41 0 _acrt_freeptd()
+FUNC 400e0 41 0 __acrt_freeptd()
 400e0 6 306 370
 400e6 18 307 370
 400fe d 313 370
 4010b 10 314 370
 4011b 6 315 370
-FUNC 40134 d4 0 _acrt_getptd()
+FUNC 40134 d4 0 __acrt_getptd()
 40134 f 282 370
 40143 9c 283 370
 401df 13 284 370
 401f2 10 290 370
 40202 6 286 370
-FUNC 40240 a7 0 _acrt_getptd_head()
+FUNC 40240 a7 0 __acrt_getptd_head()
 40240 6 293 370
 40246 59 294 370
 4029f 7 297 370
@@ -15703,11 +15703,11 @@ FUNC 40240 a7 0 _acrt_getptd_head()
 402d8 3 300 370
 402db 6 301 370
 402e1 6 297 370
-FUNC 40310 cc 0 _acrt_getptd_noexit()
+FUNC 40310 cc 0 __acrt_getptd_noexit()
 40310 f 277 370
 4031f a4 278 370
 403c3 19 279 370
-FUNC 40410 39 0 _acrt_initialize_ptd()
+FUNC 40410 39 0 __acrt_initialize_ptd()
 40410 4 28 370
 40414 12 29 370
 40426 5 30 370
@@ -15717,26 +15717,26 @@ FUNC 40410 39 0 _acrt_initialize_ptd()
 40440 2 38 370
 40442 2 41 370
 40444 5 42 370
-FUNC 40458 22 0 _acrt_uninitialize_ptd(bool)
+FUNC 40458 22 0 __acrt_uninitialize_ptd(bool)
 40458 4 45 370
 4045c b 46 370
 40467 5 48 370
 4046c 7 49 370
 40473 2 52 370
 40475 5 53 370
-FUNC 40484 7 0 _threadhandle()
+FUNC 40484 7 0 __threadhandle()
 40484 7 327 370
-FUNC 4048c 7 0 _threadid()
+FUNC 4048c 7 0 __threadid()
 4048c 7 322 370
 FUNC 40494 8 0 select_heap(void* const)
 40494 7 84 371
 4049b 1 85 371
-FUNC 404a0 3d 0 free_base(void*)
+FUNC 404a0 3d 0 _free_base(void*)
 404a0 a 100 371
 404aa 16 105 371
 404c0 17 107 371
 404d7 6 109 371
-FUNC 404ec 48 0 _acrt_initialize_locks()
+FUNC 404ec 48 0 __acrt_initialize_locks()
 404ec 6 26 372
 404f2 2 27 372
 404f4 20 29 372
@@ -15745,9 +15745,9 @@ FUNC 404ec 48 0 _acrt_initialize_locks()
 40525 7 31 372
 4052c 2 32 372
 4052e 6 39 372
-FUNC 40548 19 0 _acrt_lock(__acrt_lock_id)
+FUNC 40548 19 0 __acrt_lock(__acrt_lock_id)
 40548 19 54 372
-FUNC 40568 37 0 _acrt_uninitialize_locks(bool)
+FUNC 40568 37 0 __acrt_uninitialize_locks(bool)
 40568 6 42 372
 4056e 8 43 372
 40576 17 45 372
@@ -15755,15 +15755,15 @@ FUNC 40568 37 0 _acrt_uninitialize_locks(bool)
 40593 4 43 372
 40597 2 49 372
 40599 6 50 372
-FUNC 405ac 19 0 _acrt_unlock(__acrt_lock_id)
+FUNC 405ac 19 0 __acrt_unlock(__acrt_lock_id)
 405ac 19 59 372
-FUNC 405cc 1b 0 lock_locales()
+FUNC 405cc 1b 0 _lock_locales()
 405cc 4 63 372
 405d0 5 64 372
 405d5 7 65 372
 405dc 4 66 372
 405e0 7 65 372
-FUNC 405f0 e 0 unlock_locales()
+FUNC 405f0 e 0 _unlock_locales()
 405f0 e 70 372
 FUNC 40604 4c 0 get_cached_win_policy<`__acrt_get_begin_thread_init_policy'::`2'::begin_thread_init_policy_properties>(AppPolicyThreadInitializationType)
 40604 6 31 373
@@ -15828,23 +15828,23 @@ FUNC 407dc 27 0 `__acrt_get_windowing_model_policy'::`2'::windowing_model_policy
 407fc 1 176 373
 407fd 5 167 373
 40802 1 176 373
-FUNC 4080c 51 0 _acrt_get_begin_thread_init_policy()
+FUNC 4080c 51 0 __acrt_get_begin_thread_init_policy()
 4080c 6 89 373
 40812 45 115 373
 40857 6 116 373
-FUNC 40874 51 0 _acrt_get_developer_information_policy()
+FUNC 40874 51 0 __acrt_get_developer_information_policy()
 40874 6 120 373
 4087a 45 146 373
 408bf 6 147 373
-FUNC 408dc 3c 0 _acrt_get_process_end_policy()
+FUNC 408dc 3c 0 __acrt_get_process_end_policy()
 408dc 6 60 373
 408e2 30 84 373
 40912 6 85 373
-FUNC 40928 6c 0 _acrt_get_windowing_model_policy()
+FUNC 40928 6c 0 __acrt_get_windowing_model_policy()
 40928 6 151 373
 4092e 60 184 373
 4098e 6 185 373
-FUNC 409b0 45 0 _acrt_errno_from_os_error(unsigned long)
+FUNC 409b0 45 0 __acrt_errno_from_os_error(unsigned long)
 409b0 10 98 374
 409c0 4 100 374
 409c4 a 98 374
@@ -15855,38 +15855,38 @@ FUNC 409b0 45 0 _acrt_errno_from_os_error(unsigned long)
 409ee 1 119 374
 409ef 5 101 374
 409f4 1 119 374
-FUNC 40a08 4e 0 _acrt_errno_map_os_error(unsigned long)
+FUNC 40a08 4e 0 __acrt_errno_map_os_error(unsigned long)
 40a08 c 90 374
 40a14 19 91 374
 40a2d 1e 92 374
 40a4b b 93 374
-FUNC 40a6c 20 0 _doserrno()
+FUNC 40a6c 20 0 __doserrno()
 40a6c 4 182 374
 40a70 5 183 374
 40a75 5 184 374
 40a7a 9 185 374
 40a83 4 187 374
 40a87 5 188 374
-FUNC 40a94 20 0 errno()
+FUNC 40a94 20 0 _errno()
 40a94 4 173 374
 40a98 5 174 374
 40a9d 5 175 374
 40aa2 9 176 374
 40aab 4 178 374
 40aaf 5 179 374
-FUNC 40abc 3b 0 get_doserrno(unsigned long*)
+FUNC 40abc 3b 0 _get_doserrno(unsigned long*)
 40abc 9 157 374
 40ac5 f 158 374
 40ad4 1b 161 374
 40aef 2 162 374
 40af1 6 163 374
-FUNC 40b08 3b 0 get_errno(int*)
+FUNC 40b08 3b 0 _get_errno(int*)
 40b08 9 135 374
 40b11 f 136 374
 40b20 1b 139 374
 40b3b 2 140 374
 40b3d 6 141 374
-FUNC 40b54 3a 0 set_doserrno(unsigned long)
+FUNC 40b54 3a 0 _set_doserrno(unsigned long)
 40b54 8 147 374
 40b5c 5 148 374
 40b61 5 149 374
@@ -15894,7 +15894,7 @@ FUNC 40b54 3a 0 set_doserrno(unsigned long)
 40b6d 19 152 374
 40b86 2 153 374
 40b88 6 154 374
-FUNC 40b9c 3a 0 set_errno(int)
+FUNC 40b9c 3a 0 _set_errno(int)
 40b9c 8 125 374
 40ba4 5 126 374
 40ba9 5 127 374
@@ -15902,7 +15902,7 @@ FUNC 40b9c 3a 0 set_errno(int)
 40bb5 19 130 374
 40bce 2 131 374
 40bd0 6 132 374
-FUNC 40be4 75 0 calloc_base(unsigned long long, unsigned long long)
+FUNC 40be4 75 0 _calloc_base(unsigned long long, unsigned long long)
 40be4 c 23 375
 40bf0 13 25 375
 40c03 4 28 375
@@ -16479,9 +16479,9 @@ FUNC 4317c 5 0 strpbrk(char* const, char const* const)
 4317c 5 512 241
 FUNC 43184 5 0 wcspbrk(wchar_t*, wchar_t const*)
 43184 5 547 189
-FUNC 4318c 5 0 _acrt_expand_narrow_argv_wildcards(char**, char***)
+FUNC 4318c 5 0 __acrt_expand_narrow_argv_wildcards(char**, char***)
 4318c 5 385 379
-FUNC 43194 5 0 _acrt_expand_wide_argv_wildcards(wchar_t**, wchar_t***)
+FUNC 43194 5 0 __acrt_expand_wide_argv_wildcards(wchar_t**, wchar_t***)
 43194 5 390 379
 FUNC 4319c 119 0 __acrt_convert_wcs_mbs_cp<wchar_t,char,<lambda_f788ae46380686e8b737efdd8c720d07>,__crt_win32_buffer_no_resizing>(wchar_t const* const, __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>&, __acrt_wcs_to_mbs_cp::__l2::<lambda_f788ae46380686e8b737efdd8c720d07> const&, const unsigned int)
 4319c 14 494 327
@@ -16560,7 +16560,7 @@ FUNC 43560 5 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::size(uns
 FUNC 43568 5 0 __crt_win32_buffer<char,__crt_win32_buffer_no_resizing>::size() const
 43568 4 258 327
 4356c 1 259 327
-FUNC 43570 11e 0 _acrt_GetModuleFileNameA(HINSTANCE__*, char*, unsigned long)
+FUNC 43570 11e 0 __acrt_GetModuleFileNameA(HINSTANCE__*, char*, unsigned long)
 43570 31 16 384
 435a1 11 20 384
 435b2 4 26 384
@@ -16763,7 +16763,7 @@ FUNC 44344 4 0 __crt_state_management::dual_state_global<unsigned char *>::value
 FUNC 44348 4 0 __crt_state_management::dual_state_global<__crt_multibyte_data *>::value()
 44348 3 147 184
 4434b 1 148 184
-FUNC 4434c 60 0 _acrt_initialize_multibyte()
+FUNC 4434c 60 0 __acrt_initialize_multibyte()
 4434c 4 895 388
 44350 9 907 388
 44359 e 913 388
@@ -16776,29 +16776,29 @@ FUNC 4434c 60 0 _acrt_initialize_multibyte()
 4439e 7 923 388
 443a5 2 926 388
 443a7 5 927 388
-FUNC 443c4 1c 0 _acrt_update_thread_multibyte_data()
+FUNC 443c4 1c 0 __acrt_update_thread_multibyte_data()
 443c4 4 361 388
 443c8 f 362 388
 443d7 4 363 388
 443db 5 362 388
-FUNC 443e8 8 0 _p__mbcasemap()
+FUNC 443e8 8 0 __p__mbcasemap()
 443e8 7 239 388
 443ef 1 240 388
-FUNC 443f4 8 0 _p__mbctype()
+FUNC 443f4 8 0 __p__mbctype()
 443f4 7 234 388
 443fb 1 235 388
-FUNC 44400 3a 0 getmbcp()
+FUNC 44400 3a 0 _getmbcp()
 44400 4 871 388
 44404 c 873 388
 44410 10 874 388
 44420 15 877 388
 44435 5 878 388
-FUNC 44448 25 0 setmbcp(int)
+FUNC 44448 25 0 _setmbcp(int)
 44448 8 688 388
 44450 13 689 388
 44463 5 690 388
 44468 5 689 388
-FUNC 44478 2b9 0 setmbcp_nolock(int, __crt_multibyte_data*)
+FUNC 44478 2b9 0 _setmbcp_nolock(int, __crt_multibyte_data*)
 44478 26 693 388
 4449e 5 700 388
 444a3 c 703 388
@@ -16860,98 +16860,98 @@ FUNC 44888 75 0 x_ismbbtype_l(__crt_locale_pointers*, unsigned int, int, int)
 4489c 10 224 389
 448ac 41 231 389
 448ed 10 233 389
-FUNC 4491c 15 0 ismbbalnum(unsigned int)
+FUNC 4491c 15 0 _ismbbalnum(unsigned int)
 4491c 15 114 389
-FUNC 44938 19 0 ismbbalnum_l(unsigned int, __crt_locale_pointers*)
+FUNC 44938 19 0 _ismbbalnum_l(unsigned int, __crt_locale_pointers*)
 44938 3 107 389
 4493b 16 109 389
-FUNC 44958 15 0 ismbbalpha(unsigned int)
+FUNC 44958 15 0 _ismbbalpha(unsigned int)
 44958 15 124 389
-FUNC 44974 19 0 ismbbalpha_l(unsigned int, __crt_locale_pointers*)
+FUNC 44974 19 0 _ismbbalpha_l(unsigned int, __crt_locale_pointers*)
 44974 3 117 389
 44977 16 119 389
-FUNC 44994 1c 0 ismbbblank(unsigned int)
+FUNC 44994 1c 0 _ismbbblank(unsigned int)
 44994 8 164 389
 4499c 1 165 389
 4499d 13 164 389
-FUNC 449b8 20 0 ismbbblank_l(unsigned int, __crt_locale_pointers*)
+FUNC 449b8 20 0 _ismbbblank_l(unsigned int, __crt_locale_pointers*)
 449b8 3 157 389
 449bb 8 159 389
 449c3 1 160 389
 449c4 14 159 389
-FUNC 449e0 15 0 ismbbgraph(unsigned int)
+FUNC 449e0 15 0 _ismbbgraph(unsigned int)
 449e0 15 134 389
-FUNC 449fc 19 0 ismbbgraph_l(unsigned int, __crt_locale_pointers*)
+FUNC 449fc 19 0 _ismbbgraph_l(unsigned int, __crt_locale_pointers*)
 449fc 3 127 389
 449ff 16 129 389
-FUNC 44a1c 12 0 ismbbkalnum(unsigned int)
+FUNC 44a1c 12 0 _ismbbkalnum(unsigned int)
 44a1c 12 81 389
-FUNC 44a34 16 0 ismbbkalnum_l(unsigned int, __crt_locale_pointers*)
+FUNC 44a34 16 0 _ismbbkalnum_l(unsigned int, __crt_locale_pointers*)
 44a34 3 74 389
 44a37 13 76 389
-FUNC 44a50 7 0 ismbbkana(unsigned int)
+FUNC 44a50 7 0 _ismbbkana(unsigned int)
 44a50 7 211 389
-FUNC 44a58 65 0 ismbbkana_l(unsigned int, __crt_locale_pointers*)
+FUNC 44a58 65 0 _ismbbkana_l(unsigned int, __crt_locale_pointers*)
 44a58 f 198 389
 44a67 a 200 389
 44a71 13 201 389
 44a84 17 204 389
 44a9b 15 206 389
 44ab0 d 207 389
-FUNC 44ad8 12 0 ismbbkprint(unsigned int)
+FUNC 44ad8 12 0 _ismbbkprint(unsigned int)
 44ad8 12 91 389
-FUNC 44af0 16 0 ismbbkprint_l(unsigned int, __crt_locale_pointers*)
+FUNC 44af0 16 0 _ismbbkprint_l(unsigned int, __crt_locale_pointers*)
 44af0 3 84 389
 44af3 13 86 389
-FUNC 44b0c 12 0 ismbbkpunct(unsigned int)
+FUNC 44b0c 12 0 _ismbbkpunct(unsigned int)
 44b0c 12 101 389
-FUNC 44b24 16 0 ismbbkpunct_l(unsigned int, __crt_locale_pointers*)
+FUNC 44b24 16 0 _ismbbkpunct_l(unsigned int, __crt_locale_pointers*)
 44b24 3 94 389
 44b27 13 96 389
-FUNC 44b40 12 0 ismbblead(unsigned int)
+FUNC 44b40 12 0 _ismbblead(unsigned int)
 44b40 12 180 389
-FUNC 44b58 16 0 ismbblead_l(unsigned int, __crt_locale_pointers*)
+FUNC 44b58 16 0 _ismbblead_l(unsigned int, __crt_locale_pointers*)
 44b58 3 171 389
 44b5b 13 174 389
-FUNC 44b74 15 0 ismbbprint(unsigned int)
+FUNC 44b74 15 0 _ismbbprint(unsigned int)
 44b74 15 144 389
-FUNC 44b90 19 0 ismbbprint_l(unsigned int, __crt_locale_pointers*)
+FUNC 44b90 19 0 _ismbbprint_l(unsigned int, __crt_locale_pointers*)
 44b90 3 137 389
 44b93 16 139 389
-FUNC 44bb0 13 0 ismbbpunct(unsigned int)
+FUNC 44bb0 13 0 _ismbbpunct(unsigned int)
 44bb0 13 154 389
-FUNC 44bc8 17 0 ismbbpunct_l(unsigned int, __crt_locale_pointers*)
+FUNC 44bc8 17 0 _ismbbpunct_l(unsigned int, __crt_locale_pointers*)
 44bc8 3 147 389
 44bcb 14 149 389
-FUNC 44be4 12 0 ismbbtrail(unsigned int)
+FUNC 44be4 12 0 _ismbbtrail(unsigned int)
 44be4 12 192 389
-FUNC 44bfc 16 0 ismbbtrail_l(unsigned int, __crt_locale_pointers*)
+FUNC 44bfc 16 0 _ismbbtrail_l(unsigned int, __crt_locale_pointers*)
 44bfc 3 183 389
 44bff 13 186 389
-FUNC 44c18 25 0 _acrt_initialize_command_line()
+FUNC 44c18 25 0 __acrt_initialize_command_line()
 44c18 4 62 390
 44c1c d 63 390
 44c29 d 64 390
 44c36 2 65 390
 44c38 5 66 390
-FUNC 44c48 3 0 _acrt_uninitialize_command_line(bool)
+FUNC 44c48 3 0 __acrt_uninitialize_command_line(bool)
 44c48 2 70 390
 44c4a 1 71 390
-FUNC 44c4c 8 0 _p___argc()
+FUNC 44c4c 8 0 __p___argc()
 44c4c 8 32 390
-FUNC 44c58 8 0 _p___argv()
+FUNC 44c58 8 0 __p___argv()
 44c58 8 33 390
-FUNC 44c64 8 0 _p___wargv()
+FUNC 44c64 8 0 __p___wargv()
 44c64 8 34 390
-FUNC 44c70 8 0 _p__acmdln()
+FUNC 44c70 8 0 __p__acmdln()
 44c70 8 37 390
-FUNC 44c7c 8 0 _p__pgmptr()
+FUNC 44c7c 8 0 __p__pgmptr()
 44c7c 8 35 390
-FUNC 44c88 8 0 _p__wcmdln()
+FUNC 44c88 8 0 __p__wcmdln()
 44c88 8 38 390
-FUNC 44c94 8 0 _p__wpgmptr()
+FUNC 44c94 8 0 __p__wpgmptr()
 44c94 8 36 390
-FUNC 44ca0 36 0 get_pgmptr(char**)
+FUNC 44ca0 36 0 _get_pgmptr(char**)
 44ca0 4 50 390
 44ca4 5 51 390
 44ca9 17 55 390
@@ -16959,7 +16959,7 @@ FUNC 44ca0 36 0 get_pgmptr(char**)
 44ccc 3 53 390
 44ccf 2 54 390
 44cd1 5 55 390
-FUNC 44ce4 36 0 get_wpgmptr(wchar_t**)
+FUNC 44ce4 36 0 _get_wpgmptr(wchar_t**)
 44ce4 4 41 390
 44ce8 5 42 390
 44ced 17 47 390
@@ -16990,7 +16990,7 @@ FUNC 44e30 55 0 filter_mbtowcs_flags(const unsigned int, const unsigned long)
 44e57 28 41 392
 44e7f 3 85 392
 44e82 3 90 392
-FUNC 44e9c 5a 0 _acrt_MultiByteToWideChar(unsigned int, unsigned long, char const*, int, wchar_t*, int)
+FUNC 44e9c 5a 0 __acrt_MultiByteToWideChar(unsigned int, unsigned long, char const*, int, wchar_t*, int)
 44e9c 53 101 392
 44eef 7 103 392
 FUNC 44f0c 44 0 filter_wcstomb_flags(const unsigned int, const unsigned long)
@@ -16999,7 +16999,7 @@ FUNC 44f0c 44 0 filter_wcstomb_flags(const unsigned int, const unsigned long)
 44f4c 1 89 393
 44f4d 2 84 393
 44f4f 1 89 393
-FUNC 44f64 96 0 _acrt_WideCharToMultiByte(unsigned int, unsigned long, wchar_t const*, int, char*, int, char const*, int*)
+FUNC 44f64 96 0 __acrt_WideCharToMultiByte(unsigned int, unsigned long, wchar_t const*, int, char*, int, char const*, int*)
 44f64 2 101 393
 44f66 10 102 393
 44f76 58 103 393
@@ -17042,7 +17042,7 @@ FUNC 450d4 3 0 `anonymous namespace'::environment_strings_traits::get_invalid_va
 FUNC 450d8 8 0 __crt_unique_handle_t<`anonymous namespace'::environment_strings_traits>::is_valid() const
 450d8 7 1152 205
 450df 1 1153 205
-FUNC 450e4 101 0 _dcrt_get_narrow_environment_from_os()
+FUNC 450e4 101 0 __dcrt_get_narrow_environment_from_os()
 450e4 19 76 394
 450fd 6 80 394
 45103 3 81 394
@@ -17057,7 +17057,7 @@ FUNC 450e4 101 0 _dcrt_get_narrow_environment_from_os()
 4519d 4 117 394
 451a1 26 120 394
 451c7 1e 121 394
-FUNC 45228 9f 0 _dcrt_get_wide_environment_from_os()
+FUNC 45228 9f 0 __dcrt_get_wide_environment_from_os()
 45228 14 53 394
 4523c 6 54 394
 45242 2 55 394
@@ -17300,13 +17300,13 @@ FUNC 4600c 5 0 strchr(char* const, const int)
 4600c 5 506 241
 FUNC 46014 5 0 wcschr(wchar_t*, wchar_t)
 46014 5 541 189
-FUNC 4601c 5 0 _dcrt_set_variable_in_narrow_environment_nolock(char*, int)
+FUNC 4601c 5 0 __dcrt_set_variable_in_narrow_environment_nolock(char*, int)
 4601c 5 364 395
-FUNC 46024 5 0 _dcrt_set_variable_in_wide_environment_nolock(wchar_t*, int)
+FUNC 46024 5 0 __dcrt_set_variable_in_wide_environment_nolock(wchar_t*, int)
 46024 5 372 395
-FUNC 4602c 5 0 recalloc(void*, unsigned long long, unsigned long long)
+FUNC 4602c 5 0 _recalloc(void*, unsigned long long, unsigned long long)
 4602c 5 68 396
-FUNC 46034 95 0 recalloc_base(void*, unsigned long long, unsigned long long)
+FUNC 46034 95 0 _recalloc_base(void*, unsigned long long, unsigned long long)
 46034 1d 27 396
 46051 22 29 396
 46073 11 31 396
@@ -17499,7 +17499,7 @@ FUNC 46f38 73 0 try_load_library_from_system_directory(wchar_t const* const)
 FUNC 46fc8 8 0 GetCurrentThreadEffectiveToken()
 46fc8 7 490 238
 46fcf 1 491 238
-FUNC 46fd4 4e 0 _acrt_AppPolicyGetProcessTerminationMethodInternal(AppPolicyProcessTerminationMethod*)
+FUNC 46fd4 4e 0 __acrt_AppPolicyGetProcessTerminationMethodInternal(AppPolicyProcessTerminationMethod*)
 46fd4 9 736 397
 46fdd 24 737 397
 47001 a 739 397
@@ -17507,7 +17507,7 @@ FUNC 46fd4 4e 0 _acrt_AppPolicyGetProcessTerminationMethodInternal(AppPolicyProc
 47010 7 739 397
 47017 5 742 397
 4701c 6 743 397
-FUNC 47038 4e 0 _acrt_AppPolicyGetShowDeveloperDiagnosticInternal(AppPolicyShowDeveloperDiagnostic*)
+FUNC 47038 4e 0 __acrt_AppPolicyGetShowDeveloperDiagnosticInternal(AppPolicyShowDeveloperDiagnostic*)
 47038 9 756 397
 47041 24 757 397
 47065 a 759 397
@@ -17515,7 +17515,7 @@ FUNC 47038 4e 0 _acrt_AppPolicyGetShowDeveloperDiagnosticInternal(AppPolicyShowD
 47074 7 759 397
 4707b 5 762 397
 47080 6 763 397
-FUNC 4709c 4e 0 _acrt_AppPolicyGetThreadInitializationTypeInternal(AppPolicyThreadInitializationType*)
+FUNC 4709c 4e 0 __acrt_AppPolicyGetThreadInitializationTypeInternal(AppPolicyThreadInitializationType*)
 4709c 9 746 397
 470a5 24 747 397
 470c9 a 749 397
@@ -17523,7 +17523,7 @@ FUNC 4709c 4e 0 _acrt_AppPolicyGetThreadInitializationTypeInternal(AppPolicyThre
 470d8 7 749 397
 470df 5 752 397
 470e4 6 753 397
-FUNC 47100 4e 0 _acrt_AppPolicyGetWindowingModelInternal(AppPolicyWindowingModel*)
+FUNC 47100 4e 0 __acrt_AppPolicyGetWindowingModelInternal(AppPolicyWindowingModel*)
 47100 9 766 397
 47109 24 767 397
 4712d a 769 397
@@ -17531,14 +17531,14 @@ FUNC 47100 4e 0 _acrt_AppPolicyGetWindowingModelInternal(AppPolicyWindowingModel
 4713c 7 769 397
 47143 5 772 397
 47148 6 773 397
-FUNC 47164 3a 0 _acrt_AreFileApisANSI()
+FUNC 47164 3a 0 __acrt_AreFileApisANSI()
 47164 4 383 397
 47168 21 384 397
 47189 4 392 397
 4718d 7 386 397
 47194 5 391 397
 47199 5 392 397
-FUNC 471ac dc 0 _acrt_CompareStringEx(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t const*, int, _nlsversioninfo*, void*, long long)
+FUNC 471ac dc 0 __acrt_CompareStringEx(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t const*, int, _nlsversioninfo*, void*, long long)
 471ac 1c 405 397
 471c8 7 406 397
 471cf 3 405 397
@@ -17546,13 +17546,13 @@ FUNC 471ac dc 0 _acrt_CompareStringEx(wchar_t const*, unsigned long, wchar_t con
 471ef 52 408 397
 47241 32 411 397
 47273 15 412 397
-FUNC 472c0 95 0 _acrt_EnumSystemLocalesEx(int (*)(wchar_t*, unsigned long, long long), unsigned long, long long, void*)
+FUNC 472c0 95 0 __acrt_EnumSystemLocalesEx(int (*)(wchar_t*, unsigned long, long long), unsigned long, long long, void*)
 472c0 1c 438 397
 472dc 24 439 397
 47300 15 441 397
 47315 30 444 397
 47345 10 448 397
-FUNC 4737c 48 0 _acrt_FlsAlloc(void (*)(void*))
+FUNC 4737c 48 0 __acrt_FlsAlloc(void (*)(void*))
 4737c 9 451 397
 47385 24 452 397
 473a9 3 454 397
@@ -17560,21 +17560,21 @@ FUNC 4737c 48 0 _acrt_FlsAlloc(void (*)(void*))
 473b1 7 454 397
 473b8 5 458 397
 473bd 7 457 397
-FUNC 473d8 46 0 _acrt_FlsFree(unsigned long)
+FUNC 473d8 46 0 __acrt_FlsFree(unsigned long)
 473d8 8 461 397
 473e0 26 462 397
 47406 5 468 397
 4740b 7 464 397
 47412 5 468 397
 47417 7 467 397
-FUNC 47430 46 0 _acrt_FlsGetValue(unsigned long)
+FUNC 47430 46 0 __acrt_FlsGetValue(unsigned long)
 47430 8 471 397
 47438 26 472 397
 4745e 5 478 397
 47463 7 474 397
 4746a 5 478 397
 4746f 7 477 397
-FUNC 47488 51 0 _acrt_FlsSetValue(unsigned long, void*)
+FUNC 47488 51 0 __acrt_FlsSetValue(unsigned long, void*)
 47488 d 481 397
 47495 7 482 397
 4749c 2 481 397
@@ -17582,7 +17582,7 @@ FUNC 47488 51 0 _acrt_FlsSetValue(unsigned long, void*)
 474c0 8 484 397
 474c8 6 487 397
 474ce b 488 397
-FUNC 474f0 b6 0 _acrt_GetDateFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME const*, wchar_t const*, wchar_t*, int, wchar_t const*)
+FUNC 474f0 b6 0 __acrt_GetDateFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME const*, wchar_t const*, wchar_t*, int, wchar_t const*)
 474f0 1c 499 397
 4750c 7 500 397
 47513 3 499 397
@@ -17590,13 +17590,13 @@ FUNC 474f0 b6 0 _acrt_GetDateFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME
 47533 32 502 397
 47565 2c 505 397
 47591 15 506 397
-FUNC 475d4 39 0 _acrt_GetEnabledXStateFeatures()
+FUNC 475d4 39 0 __acrt_GetEnabledXStateFeatures()
 475d4 4 509 397
 475d8 24 510 397
 475fc 4 516 397
 47600 7 512 397
 47607 6 515 397
-FUNC 4761c 82 0 _acrt_GetLocaleInfoEx(wchar_t const*, unsigned long, wchar_t*, int)
+FUNC 4761c 82 0 __acrt_GetLocaleInfoEx(wchar_t const*, unsigned long, wchar_t*, int)
 4761c 1c 524 397
 47638 7 525 397
 4763f 3 524 397
@@ -17604,14 +17604,14 @@ FUNC 4761c 82 0 _acrt_GetLocaleInfoEx(wchar_t const*, unsigned long, wchar_t*, i
 47662 10 527 397
 47672 17 530 397
 47689 15 531 397
-FUNC 476c0 48 0 _acrt_GetSystemTimePreciseAsFileTime(_FILETIME*)
+FUNC 476c0 48 0 __acrt_GetSystemTimePreciseAsFileTime(_FILETIME*)
 476c0 9 534 397
 476c9 27 535 397
 476f0 5 541 397
 476f5 7 537 397
 476fc 5 541 397
 47701 7 540 397
-FUNC 4771c ab 0 _acrt_GetTimeFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME const*, wchar_t const*, wchar_t*, int)
+FUNC 4771c ab 0 __acrt_GetTimeFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME const*, wchar_t const*, wchar_t*, int)
 4771c 1c 551 397
 47738 7 552 397
 4773f 3 551 397
@@ -17619,7 +17619,7 @@ FUNC 4771c ab 0 _acrt_GetTimeFormatEx(wchar_t const*, unsigned long, _SYSTEMTIME
 4775f 27 554 397
 47786 2c 557 397
 477b2 15 558 397
-FUNC 477f4 61 0 _acrt_GetUserDefaultLocaleName(wchar_t*, int)
+FUNC 477f4 61 0 __acrt_GetUserDefaultLocaleName(wchar_t*, int)
 477f4 c 564 397
 47800 7 565 397
 47807 3 564 397
@@ -17627,7 +17627,7 @@ FUNC 477f4 61 0 _acrt_GetUserDefaultLocaleName(wchar_t*, int)
 47827 d 567 397
 47834 16 570 397
 4784a b 571 397
-FUNC 47870 51 0 _acrt_GetXStateFeaturesMask(_CONTEXT*, unsigned long long*)
+FUNC 47870 51 0 __acrt_GetXStateFeaturesMask(_CONTEXT*, unsigned long long*)
 47870 d 577 397
 4787d 7 578 397
 47884 3 577 397
@@ -17636,7 +17636,7 @@ FUNC 47870 51 0 _acrt_GetXStateFeaturesMask(_CONTEXT*, unsigned long long*)
 478aa a 584 397
 478b4 7 580 397
 478bb 6 583 397
-FUNC 478d8 61 0 _acrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsigned long, unsigned long)
+FUNC 478d8 61 0 __acrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsigned long, unsigned long)
 478d8 12 591 397
 478ea 7 592 397
 478f1 2 591 397
@@ -17646,7 +17646,7 @@ FUNC 478d8 61 0 _acrt_InitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsign
 47918 b 594 397
 47923 6 597 397
 47929 10 598 397
-FUNC 47954 56 0 _acrt_IsValidLocaleName(wchar_t const*)
+FUNC 47954 56 0 __acrt_IsValidLocaleName(wchar_t const*)
 47954 9 601 397
 4795d 27 602 397
 47984 5 608 397
@@ -17654,7 +17654,7 @@ FUNC 47954 56 0 _acrt_IsValidLocaleName(wchar_t const*)
 47990 e 607 397
 4799e 5 608 397
 479a3 7 607 397
-FUNC 479c0 70 0 _acrt_LCIDToLocaleName(unsigned long, wchar_t*, int, unsigned long)
+FUNC 479c0 70 0 __acrt_LCIDToLocaleName(unsigned long, wchar_t*, int, unsigned long)
 479c0 1d 636 397
 479dd 7 637 397
 479e4 2 636 397
@@ -17662,7 +17662,7 @@ FUNC 479c0 70 0 _acrt_LCIDToLocaleName(unsigned long, wchar_t*, int, unsigned lo
 47a0b b 639 397
 47a16 5 642 397
 47a1b 15 643 397
-FUNC 47a4c dc 0 _acrt_LCMapStringEx(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t*, int, _nlsversioninfo*, void*, long long)
+FUNC 47a4c dc 0 __acrt_LCMapStringEx(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t*, int, _nlsversioninfo*, void*, long long)
 47a4c 1c 621 397
 47a68 7 622 397
 47a6f 3 621 397
@@ -17670,7 +17670,7 @@ FUNC 47a4c dc 0 _acrt_LCMapStringEx(wchar_t const*, unsigned long, wchar_t const
 47a8f 52 624 397
 47ae1 32 627 397
 47b13 15 628 397
-FUNC 47b60 50 0 _acrt_LocaleNameToLCID(wchar_t const*, unsigned long)
+FUNC 47b60 50 0 __acrt_LocaleNameToLCID(wchar_t const*, unsigned long)
 47b60 c 649 397
 47b6c 7 650 397
 47b73 3 649 397
@@ -17678,7 +17678,7 @@ FUNC 47b60 50 0 _acrt_LocaleNameToLCID(wchar_t const*, unsigned long)
 47b96 a 652 397
 47ba0 5 655 397
 47ba5 b 656 397
-FUNC 47bc4 5f 0 _acrt_LocateXStateFeature(_CONTEXT*, unsigned long, unsigned long*)
+FUNC 47bc4 5f 0 __acrt_LocateXStateFeature(_CONTEXT*, unsigned long, unsigned long*)
 47bc4 12 663 397
 47bd6 7 664 397
 47bdd 2 663 397
@@ -17689,7 +17689,7 @@ FUNC 47bc4 5f 0 _acrt_LocateXStateFeature(_CONTEXT*, unsigned long, unsigned lon
 47c07 f 670 397
 47c16 7 666 397
 47c1d 6 669 397
-FUNC 47c3c 71 0 _acrt_MessageBoxA(HWND__*, char const*, char const*, unsigned int)
+FUNC 47c3c 71 0 __acrt_MessageBoxA(HWND__*, char const*, char const*, unsigned int)
 47c3c 1d 678 397
 47c59 7 679 397
 47c60 3 678 397
@@ -17697,7 +17697,7 @@ FUNC 47c3c 71 0 _acrt_MessageBoxA(HWND__*, char const*, char const*, unsigned in
 47c80 12 681 397
 47c92 15 685 397
 47ca7 6 684 397
-FUNC 47ccc 71 0 _acrt_MessageBoxW(HWND__*, wchar_t const*, wchar_t const*, unsigned int)
+FUNC 47ccc 71 0 __acrt_MessageBoxW(HWND__*, wchar_t const*, wchar_t const*, unsigned int)
 47ccc 1d 693 397
 47ce9 7 694 397
 47cf0 3 693 397
@@ -17705,19 +17705,19 @@ FUNC 47ccc 71 0 _acrt_MessageBoxW(HWND__*, wchar_t const*, wchar_t const*, unsig
 47d10 12 696 397
 47d22 15 700 397
 47d37 6 699 397
-FUNC 47d5c 40 0 _acrt_RoInitialize(RO_INIT_TYPE)
+FUNC 47d5c 40 0 __acrt_RoInitialize(RO_INIT_TYPE)
 47d5c 8 716 397
 47d64 24 717 397
 47d88 2 719 397
 47d8a 5 723 397
 47d8f 7 719 397
 47d96 6 723 397
-FUNC 47dac 33 0 _acrt_RoUninitialize()
+FUNC 47dac 33 0 __acrt_RoUninitialize()
 47dac 4 726 397
 47db0 24 727 397
 47dd4 6 729 397
 47dda 5 733 397
-FUNC 47dec 4f 0 _acrt_RtlGenRandom(void*, unsigned long)
+FUNC 47dec 4f 0 __acrt_RtlGenRandom(void*, unsigned long)
 47dec c 706 397
 47df8 7 707 397
 47dff 3 706 397
@@ -17726,28 +17726,28 @@ FUNC 47dec 4f 0 _acrt_RtlGenRandom(void*, unsigned long)
 47e24 a 713 397
 47e2e 7 709 397
 47e35 6 712 397
-FUNC 47e50 42 0 _acrt_SetThreadStackGuarantee(unsigned long*)
+FUNC 47e50 42 0 __acrt_SetThreadStackGuarantee(unsigned long*)
 47e50 9 776 397
 47e59 24 777 397
 47e7d 3 779 397
 47e80 5 783 397
 47e85 7 779 397
 47e8c 6 783 397
-FUNC 47ea4 6d 0 _acrt_can_show_message_box()
+FUNC 47ea4 6d 0 __acrt_can_show_message_box()
 47ea4 a 788 397
 47eae 2 789 397
 47eb0 54 792 397
 47f04 2 796 397
 47f06 b 797 397
-FUNC 47f2c 2e 0 _acrt_can_use_vista_locale_apis()
+FUNC 47f2c 2e 0 __acrt_can_use_vista_locale_apis()
 47f2c 4 800 397
 47f30 25 801 397
 47f55 5 802 397
-FUNC 47f68 2e 0 _acrt_can_use_xstate_apis()
+FUNC 47f68 2e 0 __acrt_can_use_xstate_apis()
 47f68 4 824 397
 47f6c 25 825 397
 47f91 5 826 397
-FUNC 47fa4 15a 0 _acrt_eagerly_load_locale_apis()
+FUNC 47fa4 15a 0 __acrt_eagerly_load_locale_apis()
 47fa4 4 809 397
 47fa8 1c 810 397
 47fc4 1f 811 397
@@ -17762,7 +17762,7 @@ FUNC 47fa4 15a 0 _acrt_eagerly_load_locale_apis()
 480db 1a 820 397
 480f5 4 821 397
 480f9 5 820 397
-FUNC 48154 78 0 _acrt_get_parent_window()
+FUNC 48154 78 0 __acrt_get_parent_window()
 48154 6 829 397
 4815a 1f 830 397
 48179 5 831 397
@@ -17776,11 +17776,11 @@ FUNC 48154 78 0 _acrt_get_parent_window()
 481bd 7 848 397
 481c4 2 839 397
 481c6 6 849 397
-FUNC 481ec 31 0 _acrt_initialize_winapi_thunks()
+FUNC 481ec 31 0 __acrt_initialize_winapi_thunks()
 481ec 5 153 397
 481f1 24 154 397
 48215 8 162 397
-FUNC 4822c c6 0 _acrt_is_interactive()
+FUNC 4822c c6 0 __acrt_is_interactive()
 4822c 19 852 397
 48245 22 853 397
 48267 5 854 397
@@ -17794,7 +17794,7 @@ FUNC 4822c c6 0 _acrt_is_interactive()
 482d4 4 879 397
 482d8 2 882 397
 482da 18 883 397
-FUNC 48324 41 0 _acrt_uninitialize_winapi_thunks(bool)
+FUNC 48324 41 0 __acrt_uninitialize_winapi_thunks(bool)
 48324 6 165 397
 4832a 4 167 397
 4832e 7 172 397
@@ -17805,19 +17805,19 @@ FUNC 48324 41 0 _acrt_uninitialize_winapi_thunks(bool)
 4834d 10 172 397
 4835d 2 185 397
 4835f 6 186 397
-FUNC 48378 8 0 _acrt_getheap()
+FUNC 48378 8 0 __acrt_getheap()
 48378 7 51 400
 4837f 1 52 400
-FUNC 48384 1c 0 _acrt_initialize_heap()
+FUNC 48384 1c 0 __acrt_initialize_heap()
 48384 4 22 400
 48388 6 23 400
 4838e d 24 400
 4839b 5 28 400
-FUNC 483a8 b 0 _acrt_uninitialize_heap(bool)
+FUNC 483a8 b 0 __acrt_uninitialize_heap(bool)
 483a8 8 34 400
 483b0 2 35 400
 483b2 1 36 400
-FUNC 483b8 8 0 get_heap_handle()
+FUNC 483b8 8 0 _get_heap_handle()
 483b8 7 43 400
 483bf 1 44 400
 FUNC 483c4 1b 0 get_std_handle_id(const int)
@@ -17869,7 +17869,7 @@ FUNC 48510 10c 0 initialize_stdio_handles_nolock()
 485e7 b 183 401
 485f2 f 125 401
 48601 1b 186 401
-FUNC 48660 3b 0 _acrt_initialize_lowio()
+FUNC 48660 3b 0 __acrt_initialize_lowio()
 48660 6 225 401
 48666 a 226 401
 48670 2 227 401
@@ -17880,7 +17880,7 @@ FUNC 48660 3b 0 _acrt_initialize_lowio()
 48689 a 243 401
 48693 2 246 401
 48695 6 247 401
-FUNC 486ac 40 0 _acrt_uninitialize_lowio(bool)
+FUNC 486ac 40 0 __acrt_uninitialize_lowio(bool)
 486ac a 254 401
 486b6 2 255 401
 486b8 10 257 401
@@ -17888,7 +17888,7 @@ FUNC 486ac 40 0 _acrt_uninitialize_lowio(bool)
 486cd 5 261 401
 486d2 d 255 401
 486df d 265 401
-FUNC 486fc 80 0 _acrt_execute_initializers(__acrt_initializer const*, __acrt_initializer const*)
+FUNC 486fc 80 0 __acrt_execute_initializers(__acrt_initializer const*, __acrt_initializer const*)
 486fc 15 14 402
 48711 5 15 402
 48716 3 19 402
@@ -17903,7 +17903,7 @@ FUNC 486fc 80 0 _acrt_execute_initializers(__acrt_initializer const*, __acrt_ini
 48766 4 46 402
 4876a 2 31 402
 4876c 10 47 402
-FUNC 4879c 3c 0 _acrt_execute_uninitializers(__acrt_initializer const*, __acrt_initializer const*)
+FUNC 4879c 3c 0 __acrt_execute_uninitializers(__acrt_initializer const*, __acrt_initializer const*)
 4879c 10 53 402
 487ac 5 54 402
 487b1 9 60 402
@@ -17928,24 +17928,24 @@ FUNC 48848 27 0 __crt_state_management::dual_state_global<int (__cdecl*)(unsigne
 FUNC 48878 4 0 __crt_state_management::dual_state_global<int (__cdecl*)(unsigned __int64)>::value()
 48878 3 147 184
 4887b 1 148 184
-FUNC 4887c 8 0 _acrt_initialize_new_handler(void*)
+FUNC 4887c 8 0 __acrt_initialize_new_handler(void*)
 4887c 7 20 403
 48883 1 21 403
-FUNC 48888 2f 0 callnewh(unsigned long long)
+FUNC 48888 2f 0 _callnewh(unsigned long long)
 48888 9 76 403
 48891 5 77 403
 48896 12 79 403
 488a8 7 82 403
 488af 2 80 403
 488b1 6 83 403
-FUNC 488c4 34 0 query_new_handler()
+FUNC 488c4 34 0 _query_new_handler()
 488c4 6 56 403
 488ca 8 59 403
 488d2 16 62 403
 488e8 7 66 403
 488ef 3 69 403
 488f2 6 70 403
-FUNC 48908 59 0 set_new_handler(int (*)(unsigned long long))
+FUNC 48908 59 0 _set_new_handler(int (*)(unsigned long long))
 48908 d 25 403
 48915 8 28 403
 4891d 1b 31 403
@@ -18044,21 +18044,21 @@ FUNC 48c24 27 0 signal_failed(const int)
 FUNC 48c54 4 0 __crt_state_management::dual_state_global<void (__cdecl*)(int)>::value()
 48c54 3 147 184
 48c57 1 148 184
-FUNC 48c58 2e 0 _acrt_get_sigabrt_handler()
+FUNC 48c58 2e 0 __acrt_get_sigabrt_handler()
 48c58 7 562 404
 48c5f 22 563 404
 48c81 5 567 404
-FUNC 48c94 1d 0 _acrt_initialize_signal_handlers(void*)
+FUNC 48c94 1d 0 __acrt_initialize_signal_handlers(void*)
 48c94 7 47 404
 48c9b 7 48 404
 48ca2 7 49 404
 48ca9 7 50 404
 48cb0 1 51 404
-FUNC 48cb8 12 0 _fpecode()
+FUNC 48cb8 12 0 __fpecode()
 48cb8 4 571 404
 48cbc 9 572 404
 48cc5 5 573 404
-FUNC 48cd0 12 0 _pxcptinfoptrs()
+FUNC 48cd0 12 0 __pxcptinfoptrs()
 48cd0 4 577 404
 48cd4 9 578 404
 48cdd 5 579 404
@@ -18167,13 +18167,13 @@ FUNC 49284 27 0 __crt_state_management::dual_state_global<int (__cdecl*)(_except
 FUNC 492b4 4 0 __crt_state_management::dual_state_global<int (__cdecl*)(_exception *)>::value()
 492b4 3 147 184
 492b7 1 148 184
-FUNC 492b8 1d 0 _acrt_has_user_matherr()
+FUNC 492b8 1d 0 __acrt_has_user_matherr()
 492b8 1c 34 405
 492d4 1 35 405
-FUNC 492dc 8 0 _acrt_initialize_user_matherr(void*)
+FUNC 492dc 8 0 __acrt_initialize_user_matherr(void*)
 492dc 7 29 405
 492e3 1 30 405
-FUNC 492e8 2e 0 _acrt_invoke_user_matherr(_exception*)
+FUNC 492e8 2e 0 __acrt_invoke_user_matherr(_exception*)
 492e8 7 41 405
 492ef 3 38 405
 492f2 f 41 405
@@ -18181,7 +18181,7 @@ FUNC 492e8 2e 0 _acrt_invoke_user_matherr(_exception*)
 49306 2 43 405
 49308 1 46 405
 49309 d 45 405
-FUNC 49324 25 0 _setusermatherr(int (*)(_exception*))
+FUNC 49324 25 0 __setusermatherr(int (*)(_exception*))
 49324 7 24 405
 4932b 3 23 405
 4932e 1a 24 405
@@ -18316,7 +18316,7 @@ FUNC 49980 1e 0 __crt_stdio_stream::set_flags(const long) const
 49980 1e 209 341
 FUNC 499a8 25 0 __crt_stdio_stream::unset_flags(const long) const
 499a8 25 210 341
-FUNC 499d8 7a 0 _acrt_stdio_flush_nolock(_iobuf*)
+FUNC 499d8 7a 0 __acrt_stdio_flush_nolock(_iobuf*)
 499d8 12 218 406
 499ea 10 221 406
 499fa 5 226 406
@@ -18330,7 +18330,7 @@ FUNC 499d8 7a 0 _acrt_stdio_flush_nolock(_iobuf*)
 49a3b 5 246 406
 49a40 2 249 406
 49a42 10 250 406
-FUNC 49a70 4b 0 fflush_nolock(_iobuf*)
+FUNC 49a70 4b 0 _fflush_nolock(_iobuf*)
 49a70 9 185 406
 49a79 5 189 406
 49a7e 5 210 406
@@ -18341,7 +18341,7 @@ FUNC 49a70 4b 0 fflush_nolock(_iobuf*)
 49aae 4 209 406
 49ab2 3 205 406
 49ab5 6 210 406
-FUNC 49ad0 7 0 flushall()
+FUNC 49ad0 7 0 _flushall()
 49ad0 7 258 406
 FUNC 49ad8 66 0 fflush(_iobuf*)
 49ad8 4 158 406
@@ -18352,7 +18352,7 @@ FUNC 49ad8 66 0 fflush(_iobuf*)
 49b03 4 173 406
 49b07 32 176 406
 49b39 5 180 406
-FUNC 49b58 30 0 _p___mb_cur_max()
+FUNC 49b58 30 0 __p___mb_cur_max()
 49b58 4 18 407
 49b5c 5 19 407
 49b61 19 22 407
@@ -18376,7 +18376,7 @@ FUNC 49bd8 1b 0 __crt_unique_heap_ptr<__crt_stdio_stream_data *,__crt_internal_f
 49be1 8 395 103
 49be9 4 396 103
 49bed 6 397 103
-FUNC 49bfc 11f 0 _acrt_initialize_stdio()
+FUNC 49bfc 11f 0 __acrt_initialize_stdio()
 49bfc 19 60 408
 49c15 11 65 408
 49c26 7 67 408
@@ -18395,10 +18395,10 @@ FUNC 49bfc 11f 0 _acrt_initialize_stdio()
 49ce9 15 92 408
 49cfe 2 112 408
 49d00 1b 113 408
-FUNC 49d64 11 0 _acrt_iob_func(unsigned int)
+FUNC 49d64 11 0 __acrt_iob_func(unsigned int)
 49d64 10 24 408
 49d74 1 25 408
-FUNC 49d7c 5b 0 _acrt_uninitialize_stdio()
+FUNC 49d7c 5b 0 __acrt_uninitialize_stdio()
 49d7c 6 121 408
 49d82 5 122 408
 49d87 7 123 408
@@ -18407,7 +18407,7 @@ FUNC 49d7c 5b 0 _acrt_uninitialize_stdio()
 49dbd c 131 408
 49dc9 8 132 408
 49dd1 6 133 408
-FUNC 49df0 47 0 get_stream_buffer_pointers(_iobuf*, char***, char***, int**)
+FUNC 49df0 47 0 _get_stream_buffer_pointers(_iobuf*, char***, char***, int**)
 49df0 4 159 408
 49df4 1c 160 408
 49e10 5 163 408
@@ -18418,9 +18418,9 @@ FUNC 49df0 47 0 get_stream_buffer_pointers(_iobuf*, char***, char***, int**)
 49e29 7 175 408
 49e30 2 178 408
 49e32 5 179 408
-FUNC 49e48 b 0 lock_file(_iobuf*)
+FUNC 49e48 b 0 _lock_file(_iobuf*)
 49e48 b 140 408
-FUNC 49e58 b 0 unlock_file(_iobuf*)
+FUNC 49e58 b 0 _unlock_file(_iobuf*)
 49e58 b 148 408
 FUNC 49e68 10 0 __crt_stdio_stream::has_any_buffer() const
 49e68 10 221 341
@@ -18428,7 +18428,7 @@ FUNC 49e7c c 0 __crt_stdio_stream::has_any_of(const long) const
 49e7c c 206 341
 FUNC 49e8c c 0 __crt_stdio_stream::has_temporary_buffer() const
 49e8c c 218 341
-FUNC 49e9c cf 0 _acrt_stdio_begin_temporary_buffering_nolock(_iobuf*)
+FUNC 49e9c cf 0 __acrt_stdio_begin_temporary_buffering_nolock(_iobuf*)
 49e9c d 37 409
 49ea9 14 43 409
 49ebd f 47 409
@@ -18452,7 +18452,7 @@ FUNC 49e9c cf 0 _acrt_stdio_begin_temporary_buffering_nolock(_iobuf*)
 49f5c 2 81 409
 49f5e 2 52 409
 49f60 b 82 409
-FUNC 49fa0 39 0 _acrt_stdio_end_temporary_buffering_nolock(bool, _iobuf*)
+FUNC 49fa0 39 0 __acrt_stdio_end_temporary_buffering_nolock(bool, _iobuf*)
 49fa0 9 96 409
 49fa9 3 99 409
 49fac 3 93 409
@@ -18462,7 +18462,7 @@ FUNC 49fa0 39 0 _acrt_stdio_end_temporary_buffering_nolock(bool, _iobuf*)
 49fc6 9 105 409
 49fcf 4 106 409
 49fd3 6 114 409
-FUNC 49fe8 5e 0 malloc_base(unsigned long long)
+FUNC 49fe8 5e 0 _malloc_base(unsigned long long)
 49fe8 9 24 410
 49ff1 6 26 410
 49ff7 c 29 410
@@ -18524,113 +18524,113 @@ FUNC 4a234 2e 0 __crt_strtox::parse_integer_from_string<unsigned __int64,wchar_t
 4a23d 3 1823 361
 4a240 1d 1824 361
 4a25d 5 1829 361
-FUNC 4a270 2a 0 strtoi64(char const*, char**, int)
+FUNC 4a270 2a 0 _strtoi64(char const*, char**, int)
 4a270 4 114 411
 4a274 21 115 411
 4a295 5 116 411
-FUNC 4a2a4 2e 0 strtoi64_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 4a2a4 2e 0 _strtoi64_l(char const*, char**, int, __crt_locale_pointers*)
 4a2a4 4 144 411
 4a2a8 5 145 411
 4a2ad 3 144 411
 4a2b0 1d 145 411
 4a2cd 5 146 411
-FUNC 4a2e0 2e 0 strtoimax_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 4a2e0 2e 0 _strtoimax_l(char const*, char**, int, __crt_locale_pointers*)
 4a2e0 4 164 411
 4a2e4 5 165 411
 4a2e9 3 164 411
 4a2ec 1d 165 411
 4a309 5 166 411
-FUNC 4a31c 2e 0 strtol_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 4a31c 2e 0 _strtol_l(char const*, char**, int, __crt_locale_pointers*)
 4a31c 4 77 411
 4a320 5 78 411
 4a325 3 77 411
 4a328 1d 78 411
 4a345 5 79 411
-FUNC 4a358 2e 0 strtoll_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 4a358 2e 0 _strtoll_l(char const*, char**, int, __crt_locale_pointers*)
 4a358 4 154 411
 4a35c 5 155 411
 4a361 3 154 411
 4a364 1d 155 411
 4a381 5 156 411
-FUNC 4a394 2a 0 strtoui64(char const*, char**, int)
+FUNC 4a394 2a 0 _strtoui64(char const*, char**, int)
 4a394 4 175 411
 4a398 21 176 411
 4a3b9 5 177 411
-FUNC 4a3c8 2e 0 strtoui64_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 4a3c8 2e 0 _strtoui64_l(char const*, char**, int, __crt_locale_pointers*)
 4a3c8 4 205 411
 4a3cc 5 206 411
 4a3d1 3 205 411
 4a3d4 1d 206 411
 4a3f1 5 207 411
-FUNC 4a404 2e 0 strtoul_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 4a404 2e 0 _strtoul_l(char const*, char**, int, __crt_locale_pointers*)
 4a404 4 98 411
 4a408 5 99 411
 4a40d 3 98 411
 4a410 1d 99 411
 4a42d 5 100 411
-FUNC 4a440 2e 0 strtoull_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 4a440 2e 0 _strtoull_l(char const*, char**, int, __crt_locale_pointers*)
 4a440 4 215 411
 4a444 5 216 411
 4a449 3 215 411
 4a44c 1d 216 411
 4a469 5 217 411
-FUNC 4a47c 2e 0 strtoumax_l(char const*, char**, int, __crt_locale_pointers*)
+FUNC 4a47c 2e 0 _strtoumax_l(char const*, char**, int, __crt_locale_pointers*)
 4a47c 4 225 411
 4a480 5 226 411
 4a485 3 225 411
 4a488 1d 226 411
 4a4a5 5 227 411
-FUNC 4a4b8 2a 0 wcstoi64(wchar_t const*, wchar_t**, int)
+FUNC 4a4b8 2a 0 _wcstoi64(wchar_t const*, wchar_t**, int)
 4a4b8 4 286 411
 4a4bc 21 287 411
 4a4dd 5 288 411
-FUNC 4a4ec 2e 0 wcstoi64_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 4a4ec 2e 0 _wcstoi64_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 4a4ec 4 316 411
 4a4f0 5 317 411
 4a4f5 3 316 411
 4a4f8 1d 317 411
 4a515 5 318 411
-FUNC 4a528 2e 0 wcstoimax_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 4a528 2e 0 _wcstoimax_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 4a528 4 336 411
 4a52c 5 337 411
 4a531 3 336 411
 4a534 1d 337 411
 4a551 5 338 411
-FUNC 4a564 2e 0 wcstol_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 4a564 2e 0 _wcstol_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 4a564 4 251 411
 4a568 5 252 411
 4a56d 3 251 411
 4a570 1d 252 411
 4a58d 5 253 411
-FUNC 4a5a0 2e 0 wcstoll_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 4a5a0 2e 0 _wcstoll_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 4a5a0 4 326 411
 4a5a4 5 327 411
 4a5a9 3 326 411
 4a5ac 1d 327 411
 4a5c9 5 328 411
-FUNC 4a5dc 2a 0 wcstoui64(wchar_t const*, wchar_t**, int)
+FUNC 4a5dc 2a 0 _wcstoui64(wchar_t const*, wchar_t**, int)
 4a5dc 4 347 411
 4a5e0 21 348 411
 4a601 5 349 411
-FUNC 4a610 2e 0 wcstoui64_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 4a610 2e 0 _wcstoui64_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 4a610 4 377 411
 4a614 5 378 411
 4a619 3 377 411
 4a61c 1d 378 411
 4a639 5 379 411
-FUNC 4a64c 2e 0 wcstoul_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 4a64c 2e 0 _wcstoul_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 4a64c 4 270 411
 4a650 5 271 411
 4a655 3 270 411
 4a658 1d 271 411
 4a675 5 272 411
-FUNC 4a688 2e 0 wcstoull_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 4a688 2e 0 _wcstoull_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 4a688 4 387 411
 4a68c 5 388 411
 4a691 3 387 411
 4a694 1d 388 411
 4a6b1 5 389 411
-FUNC 4a6c4 2e 0 wcstoumax_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
+FUNC 4a6c4 2e 0 _wcstoumax_l(wchar_t const*, wchar_t**, int, __crt_locale_pointers*)
 4a6c4 4 397 411
 4a6c8 5 398 411
 4a6cd 3 397 411
@@ -18684,7 +18684,7 @@ FUNC 4a93c 2a 0 wcstoumax(wchar_t const*, wchar_t**, int)
 4a93c 4 365 411
 4a940 21 366 411
 4a961 5 367 411
-FUNC 4a970 17e 0 mbtowc_l(wchar_t*, char const*, unsigned long long, __crt_locale_pointers*)
+FUNC 4a970 17e 0 _mbtowc_l(wchar_t*, char const*, unsigned long long, __crt_locale_pointers*)
 4a970 14 50 413
 4a984 1d 52 413
 4a9a1 5 60 413
@@ -18709,14 +18709,14 @@ FUNC 4a970 17e 0 mbtowc_l(wchar_t*, char const*, unsigned long long, __crt_local
 4aad7 17 129 413
 FUNC 4ab50 8 0 mbtowc(wchar_t*, char const*, unsigned long long)
 4ab50 8 137 413
-FUNC 4ab5c 72 0 wctomb_l(char*, wchar_t, __crt_locale_pointers*)
+FUNC 4ab5c 72 0 _wctomb_l(char*, wchar_t, __crt_locale_pointers*)
 4ab5c 10 161 419
 4ab6c d 162 419
 4ab79 29 165 419
 4aba2 c 172 419
 4abae 13 175 419
 4abc1 d 176 419
-FUNC 4abec 19c 0 wctomb_s_l(int*, char*, unsigned long long, wchar_t, __crt_locale_pointers*)
+FUNC 4abec 19c 0 _wctomb_s_l(int*, char*, unsigned long long, wchar_t, __crt_locale_pointers*)
 4abec 1e 36 419
 4ac0a a 38 419
 4ac14 5 41 419
@@ -18976,12 +18976,12 @@ FUNC 4bcb0 1d6 0 wcsnlen(wchar_t const*, unsigned long long)
 4bcb6 6 208 420
 4bcbc 1c9 209 420
 4be85 1 210 420
-FUNC 4befc 31 0 _acrt_update_locale_info(__acrt_ptd* const, __crt_locale_data** const)
+FUNC 4befc 31 0 __acrt_update_locale_info(__acrt_ptd* const, __crt_locale_data** const)
 4befc 6 15 423
 4bf02 1d 16 423
 4bf1f 8 18 423
 4bf27 6 20 423
-FUNC 4bf3c 31 0 _acrt_update_multibyte_info(__acrt_ptd* const, __crt_multibyte_data** const)
+FUNC 4bf3c 31 0 __acrt_update_multibyte_info(__acrt_ptd* const, __crt_multibyte_data** const)
 4bf3c 6 26 423
 4bf42 1d 27 423
 4bf5f 8 29 423
@@ -19185,7 +19185,7 @@ FUNC 4cc54 30 0 shift_bytes(char* const, const unsigned long long, char* const, 
 4cc7f 5 38 424
 FUNC 4cc90 5 0 strrchr(char* const, const int)
 4cc90 5 518 241
-FUNC 4cc98 304 0 _acrt_fp_format(double const*, char*, unsigned long long, char*, unsigned long long, int, int, unsigned long long, __crt_locale_pointers*)
+FUNC 4cc98 304 0 __acrt_fp_format(double const*, char*, unsigned long long, char*, unsigned long long, int, int, unsigned long long, __crt_locale_pointers*)
 4cc98 20 693 424
 4ccb8 5 694 424
 4ccbd 18 741 424
@@ -19211,7 +19211,7 @@ FUNC 4d060 1c 0 fputwc_binary_nolock(const wchar_t, const __crt_stdio_stream)
 4d06e 6 23 425
 4d074 7 25 425
 4d07b 1 26 425
-FUNC 4d084 17c 0 fputwc_nolock(wchar_t, _iobuf*)
+FUNC 4d084 17c 0 _fputwc_nolock(wchar_t, _iobuf*)
 4d084 21 31 425
 4d0a5 3 35 425
 4d0a8 6 31 425
@@ -19227,12 +19227,12 @@ FUNC 4d084 17c 0 fputwc_nolock(wchar_t, _iobuf*)
 4d1b7 2 68 425
 4d1b9 7 65 425
 4d1c0 40 69 425
-FUNC 4d260 23 0 fputwchar(wchar_t)
+FUNC 4d260 23 0 _fputwchar(wchar_t)
 4d260 9 113 425
 4d269 10 114 425
 4d279 5 115 425
 4d27e 5 114 425
-FUNC 4d28c 5 0 putwc_nolock(wchar_t, _iobuf*)
+FUNC 4d28c 5 0 _putwc_nolock(wchar_t, _iobuf*)
 4d28c 5 75 425
 FUNC 4d294 5e 0 fputwc(wchar_t, _iobuf*)
 4d294 15 83 425
@@ -19248,23 +19248,23 @@ FUNC 4d314 5 0 putwchar(wchar_t)
 4d314 5 122 425
 FUNC 4d31c 7 0 __crt_stdio_stream::lowio_handle() const
 4d31c 7 225 341
-FUNC 4d324 26 0 fileno(_iobuf*)
+FUNC 4d324 26 0 _fileno(_iobuf*)
 4d324 4 14 426
 4d328 1a 17 426
 4d342 3 18 426
 4d345 5 19 426
-FUNC 4d354 16 0 fputc_nolock(int, _iobuf*)
+FUNC 4d354 16 0 _fputc_nolock(int, _iobuf*)
 4d354 4 16 427
 4d358 6 20 427
 4d35e 8 27 427
 4d366 3 28 427
 4d369 1 29 427
-FUNC 4d370 21 0 fputchar(int)
+FUNC 4d370 21 0 _fputchar(int)
 4d370 8 73 427
 4d378 f 74 427
 4d387 5 75 427
 4d38c 5 74 427
-FUNC 4d39c 16 0 putc_nolock(int, _iobuf*)
+FUNC 4d39c 16 0 _putc_nolock(int, _iobuf*)
 4d39c 15 33 427
 4d3b1 1 34 427
 FUNC 4d3b8 124 0 fputc(int, _iobuf*)
@@ -19280,10 +19280,10 @@ FUNC 4d528 5 0 putc(int, _iobuf*)
 4d528 5 66 427
 FUNC 4d530 5 0 putchar(int)
 4d530 5 82 427
-FUNC 4d538 18 0 get_printf_count_output()
+FUNC 4d538 18 0 _get_printf_count_output()
 4d538 17 34 428
 4d54f 1 35 428
-FUNC 4d558 27 0 set_printf_count_output(int)
+FUNC 4d558 27 0 _set_printf_count_output(int)
 4d558 17 23 428
 4d56f f 24 428
 4d57e 1 26 428
@@ -19503,7 +19503,7 @@ FUNC 4e01c 1b 0 __crt_unique_heap_ptr<__crt_locale_pointers,__crt_internal_free_
 4e025 8 395 103
 4e02d 4 396 103
 4e031 6 397 103
-FUNC 4e040 82 0 _acrt_copy_locale_name(wchar_t const*)
+FUNC 4e040 82 0 __acrt_copy_locale_name(wchar_t const*)
 4e040 12 1398 429
 4e052 5 1402 429
 4e057 d 1405 429
@@ -19514,22 +19514,22 @@ FUNC 4e040 82 0 _acrt_copy_locale_name(wchar_t const*)
 4e09a 2 1410 429
 4e09c 10 1414 429
 4e0ac 16 1412 429
-FUNC 4e0e4 c 0 _acrt_set_locale_changed()
+FUNC 4e0e4 c 0 __acrt_set_locale_changed()
 4e0e4 b 56 429
 4e0ef 1 57 429
-FUNC 4e0f4 2e 0 _acrt_uninitialize_locale()
+FUNC 4e0f4 2e 0 __acrt_uninitialize_locale()
 4e0f4 7 117 429
 4e0fb 22 118 429
 4e11d 5 130 429
-FUNC 4e130 e 0 _ascii_tolower(const int)
+FUNC 4e130 e 0 __ascii_tolower(const int)
 4e130 6 149 222
 4e136 5 151 222
 4e13b 2 153 222
 4e13d 1 154 222
-FUNC 4e144 d 0 _ascii_towlower(const int)
+FUNC 4e144 d 0 __ascii_towlower(const int)
 4e144 c 177 222
 4e150 1 178 222
-FUNC 4e154 a2 0 _lc_lctowcs(wchar_t*, unsigned long long, __crt_locale_strings const*)
+FUNC 4e154 a2 0 __lc_lctowcs(wchar_t*, unsigned long long, __crt_locale_strings const*)
 4e154 1d 1388 429
 4e171 b 1389 429
 4e17c c 1390 429
@@ -19538,7 +19538,7 @@ FUNC 4e154 a2 0 _lc_lctowcs(wchar_t*, unsigned long long, __crt_locale_strings c
 4e1af 1d 1393 429
 4e1cc 15 1394 429
 4e1e1 15 1389 429
-FUNC 4e220 166 0 _lc_wcstolc(__crt_locale_strings*, wchar_t const*)
+FUNC 4e220 166 0 __lc_wcstolc(__crt_locale_strings*, wchar_t const*)
 4e220 1b 1323 429
 4e23b 10 1328 429
 4e24b 9 1330 429
@@ -19563,7 +19563,7 @@ FUNC 4e220 166 0 _lc_wcstolc(__crt_locale_strings*, wchar_t const*)
 4e355 3 1369 429
 4e358 19 1384 429
 4e371 15 1366 429
-FUNC 4e3e0 69 0 configthreadlocale(int)
+FUNC 4e3e0 69 0 _configthreadlocale(int)
 4e3e0 8 72 429
 4e3e8 5 86 429
 4e3ed 11 87 429
@@ -19583,7 +19583,7 @@ FUNC 4e464 be 0 _copytlocinfo_nolock(__crt_locale_data*, __crt_locale_data*)
 4e514 4 281 429
 4e518 5 282 429
 4e51d 5 284 429
-FUNC 4e554 76 0 create_locale(int, char const*)
+FUNC 4e554 76 0 _create_locale(int, char const*)
 4e554 1d 377 429
 4e571 a 381 429
 4e57b 26 384 429
@@ -19638,7 +19638,7 @@ FUNC 4e5e8 47f 0 _expandlocale(wchar_t const*, wchar_t*, unsigned long long, wch
 4ea35 5 1300 429
 4ea3a 18 1196 429
 4ea52 15 1276 429
-FUNC 4eb88 a2 0 free_locale(__crt_locale_pointers*)
+FUNC 4eb88 a2 0 _free_locale(__crt_locale_pointers*)
 4eb88 e 152 429
 4eb96 3 151 429
 4eb99 b 154 429
@@ -19653,7 +19653,7 @@ FUNC 4eb88 a2 0 free_locale(__crt_locale_pointers*)
 4ec12 a 189 429
 4ec1c 8 193 429
 4ec24 6 195 429
-FUNC 4ec54 bb 0 get_current_locale()
+FUNC 4ec54 bb 0 _get_current_locale()
 4ec54 b 209 429
 4ec5f 5 210 429
 4ec64 10 212 429
@@ -19672,7 +19672,7 @@ FUNC 4ec54 bb 0 get_current_locale()
 4eccc 26 231 429
 4ecf2 15 236 429
 4ed07 8 237 429
-FUNC 4ed40 148 0 wcreate_locale(int, wchar_t const*)
+FUNC 4ed40 148 0 _wcreate_locale(int, wchar_t const*)
 4ed40 23 339 429
 4ed63 14 340 429
 4ed77 12 343 429
@@ -19693,7 +19693,7 @@ FUNC 4ed40 148 0 wcreate_locale(int, wchar_t const*)
 4ee4a 1d 366 429
 4ee67 2 341 429
 4ee69 1f 367 429
-FUNC 4eedc 65 0 wcscats(wchar_t*, unsigned long long, int, <NoType>)
+FUNC 4eedc 65 0 _wcscats(wchar_t*, unsigned long long, int, <NoType>)
 4eedc 5 1312 429
 4eee1 12 1306 429
 4eef3 5 1310 429
@@ -19702,7 +19702,7 @@ FUNC 4eedc 65 0 wcscats(wchar_t*, unsigned long long, int, <NoType>)
 4ef1a 8 1312 429
 4ef22 9 1317 429
 4ef2b 16 1314 429
-FUNC 4ef5c a1 0 wsetlocale(int, wchar_t const*)
+FUNC 4ef5c a1 0 _wsetlocale(int, wchar_t const*)
 4ef5c 11 440 429
 4ef6d 5 441 429
 4ef72 5 442 429
@@ -19930,16 +19930,16 @@ FUNC 50100 29 0 sync_legacy_variables_lk()
 50115 a 296 429
 5011f 9 297 429
 50128 1 298 429
-FUNC 50134 2f 0 _pctype_func()
+FUNC 50134 2f 0 __pctype_func()
 50134 4 20 430
 50138 5 22 430
 5013d 19 25 430
 50156 8 26 430
 5015e 5 27 430
-FUNC 50170 8 0 _pwctype_func()
+FUNC 50170 8 0 __pwctype_func()
 50170 7 16 430
 50177 1 17 430
-FUNC 5017c 5 0 iswctype_l(unsigned short, unsigned short, __crt_locale_pointers*)
+FUNC 5017c 5 0 _iswctype_l(unsigned short, unsigned short, __crt_locale_pointers*)
 5017c 5 37 431
 FUNC 50184 6f 0 iswctype(unsigned short, unsigned short)
 50184 a 41 431
@@ -19952,11 +19952,11 @@ FUNC 50184 6f 0 iswctype(unsigned short, unsigned short)
 501df 7 54 431
 501e6 2 52 431
 501e8 b 55 431
-FUNC 50210 30 0 isctype(int, int)
+FUNC 50210 30 0 _isctype(int, int)
 50210 10 110 432
 50220 1f 115 432
 5023f 1 116 432
-FUNC 5024c 108 0 isctype_l(int, int, __crt_locale_pointers*)
+FUNC 5024c 108 0 _isctype_l(int, int, __crt_locale_pointers*)
 5024c 2d 63 432
 50279 c 64 432
 50285 c 66 432
@@ -19972,10 +19972,10 @@ FUNC 5024c 108 0 isctype_l(int, int, __crt_locale_pointers*)
 50305 14 102 432
 50319 4 105 432
 5031d 37 106 432
-FUNC 50398 18 0 isleadbyte_fast_internal(const unsigned char, __crt_locale_pointers* const)
+FUNC 50398 18 0 _isleadbyte_fast_internal(const unsigned char, __crt_locale_pointers* const)
 50398 17 1565 205
 503af 1 1566 205
-FUNC 503b8 8b 0 _acrt_add_locale_ref(__crt_locale_data*)
+FUNC 503b8 8b 0 __acrt_add_locale_ref(__crt_locale_data*)
 503b8 4 24 433
 503bc c 26 433
 503c8 3 28 433
@@ -19991,7 +19991,7 @@ FUNC 503b8 8b 0 _acrt_add_locale_ref(__crt_locale_data*)
 5042a 3 57 433
 5042d a 46 433
 50437 c 61 433
-FUNC 50468 176 0 _acrt_free_locale(__crt_locale_data*)
+FUNC 50468 176 0 __acrt_free_locale(__crt_locale_data*)
 50468 14 126 433
 5047c 2c 132 433
 504a8 11 135 433
@@ -20017,25 +20017,25 @@ FUNC 50468 176 0 _acrt_free_locale(__crt_locale_data*)
 505c2 3 188 433
 505c5 14 189 433
 505d9 5 188 433
-FUNC 5063c 27 0 _acrt_locale_add_lc_time_reference(__crt_lc_time_data const*)
+FUNC 5063c 27 0 __acrt_locale_add_lc_time_reference(__crt_lc_time_data const*)
 5063c 11 317 433
 5064d f 322 433
 5065c 1 323 433
 5065d 5 319 433
 50662 1 323 433
-FUNC 5066c 36 0 _acrt_locale_free_lc_time_if_unreferenced(__crt_lc_time_data const*)
+FUNC 5066c 36 0 __acrt_locale_free_lc_time_if_unreferenced(__crt_lc_time_data const*)
 5066c 19 341 433
 50685 a 346 433
 5068f 5 351 433
 50694 8 352 433
 5069c 6 353 433
-FUNC 506b0 25 0 _acrt_locale_release_lc_time_reference(__crt_lc_time_data const*)
+FUNC 506b0 25 0 __acrt_locale_release_lc_time_reference(__crt_lc_time_data const*)
 506b0 11 329 433
 506c1 d 334 433
 506ce 1 335 433
 506cf 5 331 433
 506d4 1 335 433
-FUNC 506e0 a8 0 _acrt_release_locale_ref(__crt_locale_data*)
+FUNC 506e0 a8 0 __acrt_release_locale_ref(__crt_locale_data*)
 506e0 4 72 433
 506e4 9 73 433
 506ed 9 76 433
@@ -20054,7 +20054,7 @@ FUNC 506e0 a8 0 _acrt_release_locale_ref(__crt_locale_data*)
 5076d a 90 433
 50777 c 105 433
 50783 5 106 433
-FUNC 507b4 6c 0 _acrt_update_thread_locale_data()
+FUNC 507b4 6c 0 __acrt_update_thread_locale_data()
 507b4 a 268 433
 507be 5 270 433
 507c3 1d 272 433
@@ -20065,7 +20065,7 @@ FUNC 507b4 6c 0 _acrt_update_thread_locale_data()
 5080c 3 294 433
 5080f b 295 433
 5081a 6 291 433
-FUNC 5083c 65 0 updatetlocinfoEx_nolock(__crt_locale_data**, __crt_locale_data*)
+FUNC 5083c 65 0 _updatetlocinfoEx_nolock(__crt_locale_data**, __crt_locale_data*)
 5083c d 204 433
 50849 a 205 433
 50853 3 208 433
@@ -20083,10 +20083,10 @@ FUNC 5083c 65 0 updatetlocinfoEx_nolock(__crt_locale_data**, __crt_locale_data*)
 FUNC 508bc 4 0 __crt_state_management::dual_state_global<long>::value()
 508bc 3 147 184
 508bf 1 148 184
-FUNC 508c0 7 0 query_new_mode()
+FUNC 508c0 7 0 _query_new_mode()
 508c0 6 30 434
 508c6 1 31 434
-FUNC 508c8 2b 0 set_new_mode(int)
+FUNC 508c8 2b 0 _set_new_mode(int)
 508c8 4 20 434
 508cc 1a 22 434
 508e6 8 24 434
@@ -20388,9 +20388,9 @@ FUNC 51410 3e0 0 strpbrk(char const*, char const*)
 51700 c 492 441
 5170c 2 499 441
 5170e e2 501 441
-FUNC 518e8 8 0 mbsdec(unsigned char const*, unsigned char const*)
+FUNC 518e8 8 0 _mbsdec(unsigned char const*, unsigned char const*)
 518e8 8 108 442
-FUNC 518f4 94 0 mbsdec_l(unsigned char const*, unsigned char const*, __crt_locale_pointers*)
+FUNC 518f4 94 0 _mbsdec_l(unsigned char const*, unsigned char const*, __crt_locale_pointers*)
 518f4 10 44 442
 51904 5 48 442
 51909 14 101 442
@@ -20413,17 +20413,17 @@ FUNC 519c0 22 0 __crt_scoped_stack_ptr<wchar_t>::~__crt_scoped_stack_ptr<wchar_t
 519dd 5 457 103
 FUNC 519ec 4 0 __crt_scoped_stack_ptr<wchar_t>::get() const
 519ec 4 459 103
-FUNC 519f0 e 0 MallocaComputeSize(unsigned long long)
+FUNC 519f0 e 0 _MallocaComputeSize(unsigned long long)
 519f0 4 104 135
 519f4 9 105 135
 519fd 1 106 135
-FUNC 51a04 f 0 MarkAllocaS(void*, unsigned int)
+FUNC 51a04 f 0 _MarkAllocaS(void*, unsigned int)
 51a04 5 94 135
 51a09 2 96 135
 51a0b 4 97 135
 51a0f 3 99 135
 51a12 1 100 135
-FUNC 51a18 18d 0 _acrt_GetStringTypeA(__crt_locale_pointers*, unsigned long, char const*, int, unsigned short*, int, int)
+FUNC 51a18 18d 0 __acrt_GetStringTypeA(__crt_locale_pointers*, unsigned long, char const*, int, unsigned short*, int, int)
 51a18 33 52 443
 51a4b f 53 443
 51a5a 11 64 443
@@ -20438,7 +20438,7 @@ FUNC 51a18 18d 0 _acrt_GetStringTypeA(__crt_locale_pointers*, unsigned long, cha
 51b36 4 96 443
 51b3a 45 99 443
 51b7f 26 100 443
-FUNC 51c08 1f 0 freea_crt(void*)
+FUNC 51c08 1f 0 _freea_crt(void*)
 51c08 4 308 103
 51c0c 5 309 103
 51c11 4 313 103
@@ -20481,7 +20481,7 @@ FUNC 51c3c 315 0 __acrt_LCMapStringA_stat(__crt_locale_pointers*, wchar_t const*
 51f2f f 194 444
 51f3e 11 205 444
 51f4f 2 207 444
-FUNC 52018 96 0 _acrt_LCMapStringA(__crt_locale_pointers*, wchar_t const*, unsigned long, char const*, int, char*, int, int, int)
+FUNC 52018 96 0 __acrt_LCMapStringA(__crt_locale_pointers*, wchar_t const*, unsigned long, char const*, int, char*, int, int, int)
 52018 15 221 444
 5202d 10 222 444
 5203d 5f 224 444
@@ -20490,7 +20490,7 @@ FUNC 520d4 17 0 initialize_multibyte()
 520d4 4 16 446
 520d8 e 17 446
 520e6 5 18 446
-FUNC 520f0 4f 0 wcsnicoll(wchar_t const*, wchar_t const*, unsigned long long)
+FUNC 520f0 4f 0 _wcsnicoll(wchar_t const*, wchar_t const*, unsigned long long)
 520f0 4 89 447
 520f4 9 90 447
 520fd 5 93 447
@@ -20502,7 +20502,7 @@ FUNC 520f0 4f 0 wcsnicoll(wchar_t const*, wchar_t const*, unsigned long long)
 52133 3 101 447
 52136 4 103 447
 5213a 5 101 447
-FUNC 52154 f0 0 wcsnicoll_l(wchar_t const*, wchar_t const*, unsigned long long, __crt_locale_pointers*)
+FUNC 52154 f0 0 _wcsnicoll_l(wchar_t const*, wchar_t const*, unsigned long long, __crt_locale_pointers*)
 52154 1d 49 447
 52171 5 52 447
 52176 7 54 447
@@ -20517,10 +20517,10 @@ FUNC 52154 f0 0 wcsnicoll_l(wchar_t const*, wchar_t const*, unsigned long long, 
 5220a d 77 447
 52217 16 81 447
 5222d 17 82 447
-FUNC 52280 15 0 strnicoll(char const*, char const*, unsigned long long)
+FUNC 52280 15 0 _strnicoll(char const*, char const*, unsigned long long)
 52280 d 85 448
 5228d 8 91 448
-FUNC 5229c 100 0 strnicoll_l(char const*, char const*, unsigned long long, __crt_locale_pointers*)
+FUNC 5229c 100 0 _strnicoll_l(char const*, char const*, unsigned long long, __crt_locale_pointers*)
 5229c 1a 47 448
 522b6 f 49 448
 522c5 c 51 448
@@ -20563,7 +20563,7 @@ FUNC 525b4 25 0 <lambda_7c9dea7b4ca7285d2cdb541a38da6275>::operator()(const unsi
 525b4 4 630 327
 525b8 1c 632 327
 525d4 5 640 327
-FUNC 525e4 197 0 _acrt_SetEnvironmentVariableA(char const*, char const*)
+FUNC 525e4 197 0 __acrt_SetEnvironmentVariableA(char const*, char const*)
 525e4 1f 15 449
 52603 3 16 449
 52606 6 15 449
@@ -20581,16 +20581,16 @@ FUNC 525e4 197 0 _acrt_SetEnvironmentVariableA(char const*, char const*)
 52723 8 35 449
 5272b 31 39 449
 5275c 1f 40 449
-FUNC 527e0 5 0 msize(void*)
+FUNC 527e0 5 0 _msize(void*)
 527e0 5 40 450
-FUNC 527e8 39 0 msize_base(void*)
+FUNC 527e8 39 0 _msize_base(void*)
 527e8 4 21 450
 527ec 19 23 450
 52805 5 26 450
 5280a c 25 450
 52816 4 26 450
 5281a 7 25 450
-FUNC 52830 7a 0 realloc_base(void*, unsigned long long)
+FUNC 52830 7a 0 _realloc_base(void*, unsigned long long)
 52830 10 28 451
 52840 5 30 451
 52845 a 31 451
@@ -20625,7 +20625,7 @@ FUNC 52928 87 0 GetTableIndexFromLocaleName(wchar_t const*)
 52989 5 523 452
 5298e 8 515 452
 52996 19 524 452
-FUNC 529d0 f4 0 _acrt_DownlevelLCIDToLocaleName(unsigned long, wchar_t*, int)
+FUNC 529d0 f4 0 __acrt_DownlevelLCIDToLocaleName(unsigned long, wchar_t*, int)
 529d0 1d 571 452
 529ed 14 577 452
 52a01 15 583 452
@@ -20640,7 +20640,7 @@ FUNC 529d0 f4 0 _acrt_DownlevelLCIDToLocaleName(unsigned long, wchar_t*, int)
 52a97 2 580 452
 52a99 15 604 452
 52aae 16 600 452
-FUNC 52b04 af 0 _acrt_DownlevelLocaleNameToLCID(wchar_t const*)
+FUNC 52b04 af 0 __acrt_DownlevelLocaleNameToLCID(wchar_t const*)
 52b04 1b 552 452
 52b1f 5 555 452
 52b24 5a 558 452
@@ -20675,7 +20675,7 @@ FUNC 52c40 1b 0 __crt_unique_heap_ptr<__crt_lowio_handle_data,__crt_internal_fre
 52c49 8 395 103
 52c51 4 396 103
 52c55 6 397 103
-FUNC 52c64 a5 0 _acrt_lowio_create_handle_array()
+FUNC 52c64 a5 0 __acrt_lowio_create_handle_array()
 52c64 14 14 453
 52c78 d 15 453
 52c85 2 19 453
@@ -20694,14 +20694,14 @@ FUNC 52c64 a5 0 _acrt_lowio_create_handle_array()
 52cda d 24 453
 52ce7 a 43 453
 52cf1 18 44 453
-FUNC 52d34 50 0 _acrt_lowio_destroy_handle_array(__crt_lowio_handle_data*)
+FUNC 52d34 50 0 __acrt_lowio_destroy_handle_array(__crt_lowio_handle_data*)
 52d34 14 48 453
 52d48 a 52 453
 52d52 8 53 453
 52d5a 12 55 453
 52d6c 8 58 453
 52d74 10 59 453
-FUNC 52d98 a8 0 _acrt_lowio_ensure_fh_exists(int)
+FUNC 52d98 a8 0 __acrt_lowio_ensure_fh_exists(int)
 52d98 17 67 453
 52daf 1b 68 453
 52dca 16 98 453
@@ -20718,9 +20718,9 @@ FUNC 52d98 a8 0 _acrt_lowio_ensure_fh_exists(int)
 52e2d 5 75 453
 52e32 a 94 453
 52e3c 4 97 453
-FUNC 52e6c 27 0 _acrt_lowio_lock_fh(int)
+FUNC 52e6c 27 0 __acrt_lowio_lock_fh(int)
 52e6c 27 339 453
-FUNC 52e9c bf 0 _acrt_lowio_set_os_handle(int, long long)
+FUNC 52e9c bf 0 __acrt_lowio_set_os_handle(int, long long)
 52e9c 1f 194 453
 52ebb 30 196 453
 52eeb a 199 453
@@ -20734,9 +20734,9 @@ FUNC 52e9c bf 0 _acrt_lowio_set_os_handle(int, long long)
 52f35 8 216 453
 52f3d 3 217 453
 52f40 1b 219 453
-FUNC 52f8c 27 0 _acrt_lowio_unlock_fh(int)
+FUNC 52f8c 27 0 __acrt_lowio_unlock_fh(int)
 52f8c 27 347 453
-FUNC 52fbc 13e 0 alloc_osfhnd()
+FUNC 52fbc 13e 0 _alloc_osfhnd()
 52fbc 19 116 453
 52fd5 a 117 453
 52fdf 4 118 453
@@ -20767,7 +20767,7 @@ FUNC 52fbc 13e 0 alloc_osfhnd()
 530d3 a 184 453
 530dd 3 186 453
 530e0 1a 187 453
-FUNC 5314c ba 0 free_osfhnd(int)
+FUNC 5314c ba 0 _free_osfhnd(int)
 5314c 18 226 453
 53164 37 229 453
 5319b a 232 453
@@ -20781,14 +20781,14 @@ FUNC 5314c ba 0 free_osfhnd(int)
 531e5 8 248 453
 531ed 3 249 453
 531f0 16 251 453
-FUNC 53234 75 0 get_osfhandle(int)
+FUNC 53234 75 0 _get_osfhandle(int)
 53234 4 258 453
 53238 1a 259 453
 53252 c 260 453
 5325e 23 261 453
 53281 7 263 453
 53288 21 264 453
-FUNC 532c8 101 0 open_osfhandle(long long, int)
+FUNC 532c8 101 0 _open_osfhandle(long long, int)
 532c8 12 272 453
 532da 7 276 453
 532e1 7 279 453
@@ -20849,7 +20849,7 @@ FUNC 53590 7 0 <lambda_99fb1378e971ab6e7edea83e3a7a83a2>::operator()() const
 53590 7 223 342
 FUNC 53598 7 0 <lambda_a37b2b86f63e897a80ea819b0eb08c01>::operator()() const
 53598 7 221 342
-FUNC 535a0 91 0 commit(int)
+FUNC 535a0 91 0 _commit(int)
 535a0 b 16 454
 535ab 12 17 454
 535bd c 18 454
@@ -21017,10 +21017,10 @@ FUNC 540f8 170 0 write_text_utf8_nolock(const int, char const* const, const unsi
 54219 8 581 455
 54221 10 585 455
 54231 37 589 455
-FUNC 542c4 e 0 utf8_no_of_trailbytes(const unsigned char)
+FUNC 542c4 e 0 _utf8_no_of_trailbytes(const unsigned char)
 542c4 d 47 342
 542d1 1 48 342
-FUNC 542d8 eb 0 write(int, void const*, unsigned int)
+FUNC 542d8 eb 0 _write(int, void const*, unsigned int)
 542d8 24 47 455
 542fc 1d 48 455
 54319 c 49 455
@@ -21035,7 +21035,7 @@ FUNC 542d8 eb 0 write(int, void const*, unsigned int)
 54385 7 68 455
 5438c 4 70 455
 54390 33 71 455
-FUNC 54400 2da 0 write_nolock(int, void const*, unsigned int)
+FUNC 54400 2da 0 _write_nolock(int, void const*, unsigned int)
 54400 20 612 455
 54420 9 614 455
 54429 5 618 455
@@ -21085,7 +21085,7 @@ FUNC 54790 33 0 localeconv()
 FUNC 547d0 c 0 __crt_stdio_stream::is_in_use() const
 547d0 b 179 341
 547db 1 180 341
-FUNC 547e0 b1 0 fcloseall()
+FUNC 547e0 b1 0 _fcloseall()
 547e0 a 16 457
 547ea 5 17 457
 547ef b 19 457
@@ -21103,7 +21103,7 @@ FUNC 547e0 b1 0 fcloseall()
 54886 b 44 457
 FUNC 548c0 c 0 __crt_stdio_stream::has_crt_buffer() const
 548c0 c 216 341
-FUNC 548d0 40 0 _acrt_stdio_free_buffer_nolock(_iobuf*)
+FUNC 548d0 40 0 __acrt_stdio_free_buffer_nolock(_iobuf*)
 548d0 6 16 458
 548d6 3 21 458
 548d9 3 16 458
@@ -21115,59 +21115,59 @@ FUNC 548d0 40 0 _acrt_stdio_free_buffer_nolock(_iobuf*)
 54904 3 31 458
 54907 3 32 458
 5490a 6 33 458
-FUNC 54920 5f 0 isatty(int)
+FUNC 54920 5f 0 _isatty(int)
 54920 4 15 460
 54924 12 16 460
 54936 c 17 460
 54942 26 19 460
 54968 10 17 460
 54978 7 20 460
-FUNC 54998 2c 0 _iswcsym(unsigned short)
+FUNC 54998 2c 0 __iswcsym(unsigned short)
 54998 6 158 461
 5499e 20 160 461
 549be 6 161 461
-FUNC 549d0 2c 0 _iswcsymf(unsigned short)
+FUNC 549d0 2c 0 __iswcsymf(unsigned short)
 549d0 6 168 461
 549d6 20 170 461
 549f6 6 171 461
-FUNC 54a08 4b 0 isleadbyte_l(int, __crt_locale_pointers*)
+FUNC 54a08 4b 0 _isleadbyte_l(int, __crt_locale_pointers*)
 54a08 9 17 461
 54a11 a 19 461
 54a1b 32 20 461
 54a4d 6 21 461
-FUNC 54a68 a 0 iswalnum_l(unsigned short, __crt_locale_pointers*)
+FUNC 54a68 a 0 _iswalnum_l(unsigned short, __crt_locale_pointers*)
 54a68 a 110 461
-FUNC 54a74 a 0 iswalpha_l(unsigned short, __crt_locale_pointers*)
+FUNC 54a74 a 0 _iswalpha_l(unsigned short, __crt_locale_pointers*)
 54a74 a 30 461
-FUNC 54a80 16 0 iswblank_l(unsigned short, __crt_locale_pointers*)
+FUNC 54a80 16 0 _iswblank_l(unsigned short, __crt_locale_pointers*)
 54a80 b 100 461
 54a8b 1 101 461
 54a8c a 100 461
-FUNC 54a9c a 0 iswcntrl_l(unsigned short, __crt_locale_pointers*)
+FUNC 54a9c a 0 _iswcntrl_l(unsigned short, __crt_locale_pointers*)
 54a9c a 140 461
-FUNC 54aa8 2c 0 iswcsym_l(unsigned short, __crt_locale_pointers*)
+FUNC 54aa8 2c 0 _iswcsym_l(unsigned short, __crt_locale_pointers*)
 54aa8 6 153 461
 54aae 20 155 461
 54ace 6 156 461
-FUNC 54ae0 2c 0 iswcsymf_l(unsigned short, __crt_locale_pointers*)
+FUNC 54ae0 2c 0 _iswcsymf_l(unsigned short, __crt_locale_pointers*)
 54ae0 6 163 461
 54ae6 20 165 461
 54b06 6 166 461
-FUNC 54b18 a 0 iswdigit_l(unsigned short, __crt_locale_pointers*)
+FUNC 54b18 a 0 _iswdigit_l(unsigned short, __crt_locale_pointers*)
 54b18 a 60 461
-FUNC 54b24 a 0 iswgraph_l(unsigned short, __crt_locale_pointers*)
+FUNC 54b24 a 0 _iswgraph_l(unsigned short, __crt_locale_pointers*)
 54b24 a 130 461
-FUNC 54b30 a 0 iswlower_l(unsigned short, __crt_locale_pointers*)
+FUNC 54b30 a 0 _iswlower_l(unsigned short, __crt_locale_pointers*)
 54b30 a 50 461
-FUNC 54b3c a 0 iswprint_l(unsigned short, __crt_locale_pointers*)
+FUNC 54b3c a 0 _iswprint_l(unsigned short, __crt_locale_pointers*)
 54b3c a 120 461
-FUNC 54b48 a 0 iswpunct_l(unsigned short, __crt_locale_pointers*)
+FUNC 54b48 a 0 _iswpunct_l(unsigned short, __crt_locale_pointers*)
 54b48 a 90 461
-FUNC 54b54 a 0 iswspace_l(unsigned short, __crt_locale_pointers*)
+FUNC 54b54 a 0 _iswspace_l(unsigned short, __crt_locale_pointers*)
 54b54 a 80 461
-FUNC 54b60 a 0 iswupper_l(unsigned short, __crt_locale_pointers*)
+FUNC 54b60 a 0 _iswupper_l(unsigned short, __crt_locale_pointers*)
 54b60 a 40 461
-FUNC 54b6c a 0 iswxdigit_l(unsigned short, __crt_locale_pointers*)
+FUNC 54b6c a 0 _iswxdigit_l(unsigned short, __crt_locale_pointers*)
 54b6c a 70 461
 FUNC 54b78 4d 0 isleadbyte(int)
 54b78 9 23 461
@@ -21383,34 +21383,34 @@ FUNC 5567c 1b 0 __crt_unique_heap_ptr<long,__crt_internal_free_policy>::release(
 55685 8 395 103
 5568d 4 396 103
 55691 6 397 103
-FUNC 556a0 2f 0 __lc_codepage_func()
+FUNC 556a0 2f 0 ___lc_codepage_func()
 556a0 4 297 463
 556a4 5 303 463
 556a9 19 306 463
 556c2 8 308 463
 556ca 5 309 463
-FUNC 556dc 2f 0 __lc_collate_cp_func()
+FUNC 556dc 2f 0 ___lc_collate_cp_func()
 556dc 4 312 463
 556e0 5 318 463
 556e5 19 321 463
 556fe 8 323 463
 55706 5 324 463
-FUNC 55718 32 0 __lc_locale_name_func()
+FUNC 55718 32 0 ___lc_locale_name_func()
 55718 4 327 463
 5571c 5 333 463
 55721 19 336 463
 5573a b 338 463
 55745 5 339 463
-FUNC 55758 2f 0 __mb_cur_max_func()
+FUNC 55758 2f 0 ___mb_cur_max_func()
 55758 4 275 463
 5575c 5 281 463
 55761 19 284 463
 5577a 8 286 463
 55782 5 287 463
-FUNC 55794 10 0 __mb_cur_max_l_func(__crt_locale_pointers*)
+FUNC 55794 10 0 ___mb_cur_max_l_func(__crt_locale_pointers*)
 55794 f 291 463
 557a3 1 294 463
-FUNC 557a8 661 0 _acrt_locale_initialize_ctype(__crt_locale_data*)
+FUNC 557a8 661 0 __acrt_locale_initialize_ctype(__crt_locale_data*)
 557a8 31 54 463
 557d9 28 76 463
 55801 11 80 463
@@ -21520,7 +21520,7 @@ FUNC 56090 1c 0 __crt_mbstring::return_illegal_sequence(_Mbstatet*)
 560a7 5 140 386
 FUNC 560b4 5 0 c32rtomb(char*, char32_t, _Mbstatet*)
 560b4 5 16 464
-FUNC 560bc e2 0 _acrt_fp_strflt_to_string(char*, unsigned long long, int, _strflt*)
+FUNC 560bc e2 0 __acrt_fp_strflt_to_string(char*, unsigned long long, int, _strflt*)
 560bc 10 28 465
 560cc 5 29 465
 560d1 18 87 465
@@ -21910,7 +21910,7 @@ FUNC 58cf0 14d 0 __crt_strtox::shift_left(__crt_strtox::big_integer&, const unsi
 58e05 1e 216 359
 58e23 2 217 359
 58e25 18 250 359
-FUNC 58e90 1231 0 _acrt_fltout(_CRT_DOUBLE, unsigned int, _strflt*, char*, unsigned long long)
+FUNC 58e90 1231 0 __acrt_fltout(_CRT_DOUBLE, unsigned int, _strflt*, char*, unsigned long long)
 58e90 35 271 466
 58ec5 5 275 466
 58eca f 271 466
@@ -22048,13 +22048,13 @@ FUNC 5aa94 79 0 stream_is_at_end_of_file_nolock(const __crt_stdio_stream)
 5aaf6 f 48 467
 5ab05 2 45 467
 5ab07 6 49 467
-FUNC 5ab2c ea 0 _acrt_stdio_flush_and_write_narrow_nolock(int, _iobuf*)
+FUNC 5ab2c ea 0 __acrt_stdio_flush_and_write_narrow_nolock(int, _iobuf*)
 5ab2c 14 195 467
 5ab40 1f 196 467
 5ab5f d 197 467
 5ab6c 9a 196 467
 5ac06 10 197 467
-FUNC 5ac50 eb 0 _acrt_stdio_flush_and_write_wide_nolock(int, _iobuf*)
+FUNC 5ac50 eb 0 __acrt_stdio_flush_and_write_wide_nolock(int, _iobuf*)
 5ac50 14 205 467
 5ac64 1f 206 467
 5ac83 f 207 467
@@ -22078,7 +22078,7 @@ FUNC 5adbc 1b 0 __crt_unique_heap_ptr<lconv,__crt_internal_free_policy>::release
 5adc5 8 395 103
 5adcd 4 396 103
 5add1 6 397 103
-FUNC 5ade0 10a 0 _acrt_locale_free_monetary(lconv*)
+FUNC 5ade0 10a 0 __acrt_locale_free_monetary(lconv*)
 5ade0 e 267 468
 5adee 3 266 468
 5adf1 d 270 468
@@ -22108,7 +22108,7 @@ FUNC 5ade0 10a 0 _acrt_locale_free_monetary(lconv*)
 5aecf 10 306 468
 5aedf 5 307 468
 5aee4 6 308 468
-FUNC 5af2c 533 0 _acrt_locale_initialize_monetary(__crt_locale_data*)
+FUNC 5af2c 533 0 __acrt_locale_initialize_monetary(__crt_locale_data*)
 5af2c 1f 64 468
 5af4b 3 69 468
 5af4e 4 72 468
@@ -22185,7 +22185,7 @@ FUNC 5b5ac 34 0 fix_grouping(char*)
 5b5ce 9 249 468
 5b5d7 7 250 468
 5b5de 2 254 468
-FUNC 5b5f0 6c 0 _acrt_locale_free_numeric(lconv*)
+FUNC 5b5f0 6c 0 __acrt_locale_free_numeric(lconv*)
 5b5f0 a 214 469
 5b5fa 3 213 469
 5b5fd c 217 469
@@ -22199,7 +22199,7 @@ FUNC 5b5f0 6c 0 _acrt_locale_free_numeric(lconv*)
 5b644 d 229 469
 5b651 5 230 469
 5b656 6 231 469
-FUNC 5b678 2e8 0 _acrt_locale_initialize_numeric(__crt_locale_data*)
+FUNC 5b678 2e8 0 __acrt_locale_initialize_numeric(__crt_locale_data*)
 5b678 1c 79 469
 5b694 d 88 469
 5b6a1 12 90 469
@@ -22338,7 +22338,7 @@ FUNC 5c01c 1b 0 __crt_unique_heap_ptr<__crt_lc_time_data,__crt_internal_free_pol
 5c025 8 395 103
 5c02d 4 396 103
 5c031 6 397 103
-FUNC 5c040 108 0 _acrt_locale_free_time(__crt_lc_time_data*)
+FUNC 5c040 108 0 __acrt_locale_free_time(__crt_lc_time_data*)
 5c040 18 151 470
 5c058 5 156 470
 5c05d 3 150 470
@@ -22360,7 +22360,7 @@ FUNC 5c040 108 0 _acrt_locale_free_time(__crt_lc_time_data*)
 5c120 c 174 470
 5c12c c 176 470
 5c138 10 177 470
-FUNC 5c18c 9c 0 _acrt_locale_initialize_time(__crt_locale_data*)
+FUNC 5c18c 9c 0 __acrt_locale_initialize_time(__crt_locale_data*)
 5c18c f 107 470
 5c19b 2 108 470
 5c19d 3 107 470
@@ -22557,7 +22557,7 @@ FUNC 5cffc 99 0 TranslateName(__crt_locale_string_table const*, int, wchar_t con
 5d06b 4 330 474
 5d06f 2 343 474
 5d071 24 344 474
-FUNC 5d0bc 263 0 _acrt_get_qualified_locale(__crt_locale_strings const*, unsigned int*, __crt_locale_strings*)
+FUNC 5d0bc 263 0 __acrt_get_qualified_locale(__crt_locale_strings const*, unsigned int*, __crt_locale_strings*)
 5d0bc 26 171 474
 5d0e2 5 173 474
 5d0e7 3 174 474
@@ -22751,7 +22751,7 @@ FUNC 5dddc 7f 0 TranslateName(__crt_locale_string_table const*, int, wchar_t con
 5de34 19 255 475
 5de4d a 245 475
 5de57 4 246 475
-FUNC 5de7c 27e 0 _acrt_get_qualified_locale_downlevel(__crt_locale_strings const*, unsigned int*, __crt_locale_strings*)
+FUNC 5de7c 27e 0 __acrt_get_qualified_locale_downlevel(__crt_locale_strings const*, unsigned int*, __crt_locale_strings*)
 5de7c 29 90 475
 5dea5 8 94 475
 5dead 9 100 475
@@ -22790,13 +22790,13 @@ FUNC 5de7c 27e 0 _acrt_get_qualified_locale_downlevel(__crt_locale_strings const
 5e0d6 7 209 475
 5e0dd 2 170 475
 5e0df 1b 210 475
-FUNC 5e19c 7 0 _acrt_GetStringTypeW(unsigned long, wchar_t const*, int, unsigned short*)
+FUNC 5e19c 7 0 __acrt_GetStringTypeW(unsigned long, wchar_t const*, int, unsigned short*)
 5e19c 7 46 477
-FUNC 5e1a4 15 0 _strncnt(char const*, unsigned long long)
+FUNC 5e1a4 15 0 __strncnt(char const*, unsigned long long)
 5e1a4 2 19 478
 5e1a6 12 21 478
 5e1b8 1 24 478
-FUNC 5e1c0 bd 0 _acrt_CompareStringW(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t const*, int)
+FUNC 5e1c0 bd 0 __acrt_CompareStringW(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t const*, int)
 5e1c0 24 43 479
 5e1e4 5 49 479
 5e1e9 e 50 479
@@ -22806,7 +22806,7 @@ FUNC 5e1c0 bd 0 _acrt_CompareStringW(wchar_t const*, unsigned long, wchar_t cons
 5e21e 2d 58 479
 5e24b 17 55 479
 5e262 1b 67 479
-FUNC 5e2ac 4b 0 _ascii_wcsnicmp(wchar_t const*, wchar_t const*, unsigned long long)
+FUNC 5e2ac 4b 0 __ascii_wcsnicmp(wchar_t const*, wchar_t const*, unsigned long long)
 5e2ac 6 92 480
 5e2b2 5 93 480
 5e2b7 2 95 480
@@ -22820,18 +22820,18 @@ FUNC 5e2ac 4b 0 _ascii_wcsnicmp(wchar_t const*, wchar_t const*, unsigned long lo
 5e2e1 8 109 480
 5e2e9 d 111 480
 5e2f6 1 114 480
-FUNC 5e30c 26 0 towlower_fast_internal(const unsigned char, __crt_locale_pointers* const)
+FUNC 5e30c 26 0 _towlower_fast_internal(const unsigned char, __crt_locale_pointers* const)
 5e30c 12 1522 205
 5e31e f 1524 205
 5e32d 1 1528 205
 5e32e 3 1527 205
 5e331 1 1528 205
-FUNC 5e33c 34 0 towlower_internal(const unsigned short, __crt_locale_pointers* const)
+FUNC 5e33c 34 0 _towlower_internal(const unsigned short, __crt_locale_pointers* const)
 5e33c a 1535 205
 5e346 24 1537 205
 5e36a 1 1541 205
 5e36b 5 1540 205
-FUNC 5e380 46 0 wcsnicmp(wchar_t const*, wchar_t const*, unsigned long long)
+FUNC 5e380 46 0 _wcsnicmp(wchar_t const*, wchar_t const*, unsigned long long)
 5e380 4 121 480
 5e384 9 122 480
 5e38d 5 125 480
@@ -22842,7 +22842,7 @@ FUNC 5e380 46 0 wcsnicmp(wchar_t const*, wchar_t const*, unsigned long long)
 5e3ba 3 131 480
 5e3bd 4 132 480
 5e3c1 5 131 480
-FUNC 5e3d8 150 0 wcsnicmp_l(wchar_t const*, wchar_t const*, unsigned long long, __crt_locale_pointers*)
+FUNC 5e3d8 150 0 _wcsnicmp_l(wchar_t const*, wchar_t const*, unsigned long long, __crt_locale_pointers*)
 5e3d8 26 50 480
 5e3fe 5 52 480
 5e403 1a 85 480
@@ -22859,7 +22859,7 @@ FUNC 5e3d8 150 0 wcsnicmp_l(wchar_t const*, wchar_t const*, unsigned long long, 
 5e4e4 10 82 480
 5e4f4 15 84 480
 5e509 1f 85 480
-FUNC 5e57c 49 0 _ascii_strnicmp(char const*, char const*, unsigned long long)
+FUNC 5e57c 49 0 __ascii_strnicmp(char const*, char const*, unsigned long long)
 5e57c 6 86 481
 5e582 5 87 481
 5e587 2 89 481
@@ -22873,7 +22873,7 @@ FUNC 5e57c 49 0 _ascii_strnicmp(char const*, char const*, unsigned long long)
 5e5af 8 103 481
 5e5b7 d 105 481
 5e5c4 1 108 481
-FUNC 5e5d8 4f 0 strnicmp(char const*, char const*, unsigned long long)
+FUNC 5e5d8 4f 0 _strnicmp(char const*, char const*, unsigned long long)
 5e5d8 4 117 481
 5e5dc 9 118 481
 5e5e5 5 121 481
@@ -22885,7 +22885,7 @@ FUNC 5e5d8 4f 0 strnicmp(char const*, char const*, unsigned long long)
 5e61b 3 128 481
 5e61e 4 129 481
 5e622 5 128 481
-FUNC 5e63c ad 0 strnicmp_l(char const*, char const*, unsigned long long, __crt_locale_pointers*)
+FUNC 5e63c ad 0 _strnicmp_l(char const*, char const*, unsigned long long, __crt_locale_pointers*)
 5e63c 18 47 481
 5e654 5 49 481
 5e659 17 76 481
@@ -22946,7 +22946,7 @@ FUNC 5e714 35d 0 InternalCompareStringA(__crt_locale_pointers*, wchar_t const*, 
 5ea4b 7 137 482
 5ea52 2 155 482
 5ea54 1d 207 482
-FUNC 5eb48 89 0 _acrt_CompareStringA(__crt_locale_pointers*, wchar_t const*, unsigned long, char const*, int, char const*, int, int)
+FUNC 5eb48 89 0 __acrt_CompareStringA(__crt_locale_pointers*, wchar_t const*, unsigned long, char const*, int, char const*, int, int)
 5eb48 15 219 482
 5eb5d 10 220 482
 5eb6d 54 222 482
@@ -22972,7 +22972,7 @@ FUNC 5ec30 a7 0 write_string_to_console(wchar_t const* const)
 5ec70 1e 137 483
 5ec8e 30 145 483
 5ecbe 19 146 483
-FUNC 5ed00 15d 0 _acrt_report_runtime_error(wchar_t const*)
+FUNC 5ed00 15d 0 __acrt_report_runtime_error(wchar_t const*)
 5ed00 1b 151 483
 5ed1b 26 159 483
 5ed41 27 172 483
@@ -22988,10 +22988,10 @@ FUNC 5ed00 15d 0 _acrt_report_runtime_error(wchar_t const*)
 5ee27 8 161 483
 5ee2f 19 198 483
 5ee48 15 172 483
-FUNC 5eeb4 7 0 query_app_type()
+FUNC 5eeb4 7 0 _query_app_type()
 5eeb4 6 87 483
 5eeba 1 88 483
-FUNC 5eebc 7 0 set_app_type(_crt_app_type)
+FUNC 5eebc 7 0 _set_app_type(_crt_app_type)
 5eebc 6 82 483
 5eec2 1 83 483
 FUNC 5eec4 eb 0 common_lseek<long>(const int, const long, const int)
@@ -23066,13 +23066,13 @@ FUNC 5f3d0 33 0 common_lseek_do_seek_nolock(void* const, const long long, const 
 5f3f3 6 60 484
 5f3f9 5 63 484
 5f3fe 5 64 484
-FUNC 5f410 5 0 lseek(int, long, int)
+FUNC 5f410 5 0 _lseek(int, long, int)
 5f410 5 130 484
-FUNC 5f418 5 0 lseek_nolock(int, long, int)
+FUNC 5f418 5 0 _lseek_nolock(int, long, int)
 5f418 5 140 484
-FUNC 5f420 5 0 lseeki64(int, long long, int)
+FUNC 5f420 5 0 _lseeki64(int, long long, int)
 5f420 5 135 484
-FUNC 5f428 5 0 lseeki64_nolock(int, long long, int)
+FUNC 5f428 5 0 _lseeki64_nolock(int, long long, int)
 5f428 5 145 484
 FUNC 5f430 40 0 __crt_seh_guarded_call<unsigned short>::operator()<<lambda_0384895ae1aa6ccbfe369a30d6ca2ef7>,<lambda_9e0b6ab72a5b3ae37ad997d08b519f50> &,<lambda_7e22f70504d73c22058e5832bde5914f> >(__acrt_lock_and_call::__l2::<lambda_0384895ae1aa6ccbfe369a30d6ca2ef7>&&, _putwch::__l2::<lambda_9e0b6ab72a5b3ae37ad997d08b519f50>&, __acrt_lock_and_call::__l2::<lambda_7e22f70504d73c22058e5832bde5914f>&&)
 5f430 15 198 103
@@ -23097,11 +23097,11 @@ FUNC 5f4d8 7 0 <lambda_7e22f70504d73c22058e5832bde5914f>::operator()() const
 5f4d8 7 974 205
 FUNC 5f4e0 b 0 <lambda_9e0b6ab72a5b3ae37ad997d08b519f50>::operator()() const
 5f4e0 b 17 485
-FUNC 5f4f0 3b 0 putwch(wchar_t)
+FUNC 5f4f0 3b 0 _putwch(wchar_t)
 5f4f0 c 14 485
 5f4fc 2a 15 485
 5f526 5 19 485
-FUNC 5f53c 3b 0 putwch_nolock(wchar_t)
+FUNC 5f53c 3b 0 _putwch_nolock(wchar_t)
 5f53c 9 22 485
 5f545 9 23 485
 5f54e 18 28 485
@@ -23250,7 +23250,7 @@ FUNC 5fd54 8f 0 translate_utf16_from_console_nolock(const int, wchar_t* const, c
 5fdb2 2 71 486
 5fdb4 21 73 486
 5fdd5 e 93 486
-FUNC 5fe08 119 0 read(int, void*, unsigned int)
+FUNC 5fe08 119 0 _read(int, void*, unsigned int)
 5fe08 25 378 486
 5fe2d 1d 379 486
 5fe4a 14 380 486
@@ -23266,7 +23266,7 @@ FUNC 5fe08 119 0 read(int, void*, unsigned int)
 5fee1 7 400 486
 5fee8 4 402 486
 5feec 35 403 486
-FUNC 5ff68 456 0 read_nolock(int, void*, unsigned int)
+FUNC 5ff68 456 0 _read_nolock(int, void*, unsigned int)
 5ff68 22 412 486
 5ff8a 1f 413 486
 5ffa9 17 414 486
@@ -23326,7 +23326,7 @@ FUNC 5ff68 456 0 read_nolock(int, void*, unsigned int)
 60381 7 584 486
 60388 4 420 486
 6038c 32 635 486
-FUNC 604d4 83 0 fclose_nolock(_iobuf*)
+FUNC 604d4 83 0 _fclose_nolock(_iobuf*)
 604d4 d 49 487
 604e1 1a 52 487
 604fb 3 56 487
@@ -23407,7 +23407,7 @@ FUNC 60850 179 0 InternalGetLocaleInfoA(__crt_locale_pointers* const, wchar_t co
 6092a 14 34 489
 6093e 65 38 489
 609a3 26 47 489
-FUNC 60a28 1c8 0 _acrt_GetLocaleInfoA(__crt_locale_pointers*, int, wchar_t const*, unsigned long, void*)
+FUNC 60a28 1c8 0 __acrt_GetLocaleInfoA(__crt_locale_pointers*, int, wchar_t const*, unsigned long, void*)
 60a28 2c 78 489
 60a54 e 79 489
 60a62 9 81 489
@@ -23738,7 +23738,7 @@ FUNC 60e50 5ab 0 log10()
 613f0 6 597 500
 613f6 4 598 500
 613fa 1 599 500
-FUNC 61568 66 0 _acrt_stdio_allocate_buffer_nolock(_iobuf*)
+FUNC 61568 66 0 __acrt_stdio_allocate_buffer_nolock(_iobuf*)
 61568 a 17 502
 61572 9 23 502
 6157b 17 27 502
@@ -23876,109 +23876,109 @@ FUNC 61b80 69 0 common_xtox_s<unsigned __int64,wchar_t>(const unsigned long long
 61bd8 7 120 503
 61bdf 5 121 503
 61be4 5 120 503
-FUNC 61c04 31 0 i64toa(long long, char*, int)
+FUNC 61c04 31 0 _i64toa(long long, char*, int)
 61c04 6 231 503
 61c0a 12 232 503
 61c1c 10 233 503
 61c2c 3 234 503
 61c2f 6 235 503
-FUNC 61c44 21 0 i64toa_s(long long, char*, unsigned long long, int)
+FUNC 61c44 21 0 _i64toa_s(long long, char*, unsigned long long, int)
 61c44 4 209 503
 61c48 f 210 503
 61c57 9 211 503
 61c60 5 212 503
-FUNC 61c70 31 0 i64tow(long long, wchar_t*, int)
+FUNC 61c70 31 0 _i64tow(long long, wchar_t*, int)
 61c70 6 355 503
 61c76 12 356 503
 61c88 10 357 503
 61c98 3 358 503
 61c9b 6 359 503
-FUNC 61cb0 21 0 i64tow_s(long long, wchar_t*, unsigned long long, int)
+FUNC 61cb0 21 0 _i64tow_s(long long, wchar_t*, unsigned long long, int)
 61cb0 4 333 503
 61cb4 f 334 503
 61cc3 9 335 503
 61ccc 5 336 503
-FUNC 61cdc 30 0 itoa(int, char*, int)
+FUNC 61cdc 30 0 _itoa(int, char*, int)
 61cdc 6 169 503
 61ce2 11 170 503
 61cf3 10 171 503
 61d03 3 172 503
 61d06 6 173 503
-FUNC 61d18 20 0 itoa_s(int, char*, unsigned long long, int)
+FUNC 61d18 20 0 _itoa_s(int, char*, unsigned long long, int)
 61d18 4 136 503
 61d1c e 137 503
 61d2a 9 138 503
 61d33 5 139 503
-FUNC 61d40 30 0 itow(int, wchar_t*, int)
+FUNC 61d40 30 0 _itow(int, wchar_t*, int)
 61d40 6 293 503
 61d46 11 294 503
 61d57 10 295 503
 61d67 3 296 503
 61d6a 6 297 503
-FUNC 61d7c 20 0 itow_s(int, wchar_t*, unsigned long long, int)
+FUNC 61d7c 20 0 _itow_s(int, wchar_t*, unsigned long long, int)
 61d7c 4 260 503
 61d80 e 261 503
 61d8e 9 262 503
 61d97 5 263 503
-FUNC 61da4 30 0 ltoa(long, char*, int)
+FUNC 61da4 30 0 _ltoa(long, char*, int)
 61da4 6 180 503
 61daa 11 181 503
 61dbb 10 182 503
 61dcb 3 183 503
 61dce 6 184 503
-FUNC 61de0 20 0 ltoa_s(long, char*, unsigned long long, int)
+FUNC 61de0 20 0 _ltoa_s(long, char*, unsigned long long, int)
 61de0 4 147 503
 61de4 e 148 503
 61df2 9 149 503
 61dfb 5 150 503
-FUNC 61e08 30 0 ltow(long, wchar_t*, int)
+FUNC 61e08 30 0 _ltow(long, wchar_t*, int)
 61e08 6 304 503
 61e0e 11 305 503
 61e1f 10 306 503
 61e2f 3 307 503
 61e32 6 308 503
-FUNC 61e44 20 0 ltow_s(long, wchar_t*, unsigned long long, int)
+FUNC 61e44 20 0 _ltow_s(long, wchar_t*, unsigned long long, int)
 61e44 4 271 503
 61e48 e 272 503
 61e56 9 273 503
 61e5f 5 274 503
-FUNC 61e6c 23 0 ui64toa(unsigned long long, char*, int)
+FUNC 61e6c 23 0 _ui64toa(unsigned long long, char*, int)
 61e6c 6 242 503
 61e72 14 243 503
 61e86 3 244 503
 61e89 6 245 503
-FUNC 61e98 13 0 ui64toa_s(unsigned long long, char*, unsigned long long, int)
+FUNC 61e98 13 0 _ui64toa_s(unsigned long long, char*, unsigned long long, int)
 61e98 4 220 503
 61e9c a 221 503
 61ea6 5 222 503
-FUNC 61eb0 23 0 ui64tow(unsigned long long, wchar_t*, int)
+FUNC 61eb0 23 0 _ui64tow(unsigned long long, wchar_t*, int)
 61eb0 6 366 503
 61eb6 14 367 503
 61eca 3 368 503
 61ecd 6 369 503
-FUNC 61edc 13 0 ui64tow_s(unsigned long long, wchar_t*, unsigned long long, int)
+FUNC 61edc 13 0 _ui64tow_s(unsigned long long, wchar_t*, unsigned long long, int)
 61edc 4 344 503
 61ee0 a 345 503
 61eea 5 346 503
-FUNC 61ef4 23 0 ultoa(unsigned long, char*, int)
+FUNC 61ef4 23 0 _ultoa(unsigned long, char*, int)
 61ef4 6 191 503
 61efa 14 192 503
 61f0e 3 193 503
 61f11 6 194 503
-FUNC 61f20 13 0 ultoa_s(unsigned long, char*, unsigned long long, int)
+FUNC 61f20 13 0 _ultoa_s(unsigned long, char*, unsigned long long, int)
 61f20 4 158 503
 61f24 a 159 503
 61f2e 5 160 503
-FUNC 61f38 23 0 ultow(unsigned long, wchar_t*, int)
+FUNC 61f38 23 0 _ultow(unsigned long, wchar_t*, int)
 61f38 6 315 503
 61f3e 14 316 503
 61f52 3 317 503
 61f55 6 318 503
-FUNC 61f64 13 0 ultow_s(unsigned long, wchar_t*, unsigned long long, int)
+FUNC 61f64 13 0 _ultow_s(unsigned long, wchar_t*, unsigned long long, int)
 61f64 4 282 503
 61f68 a 283 503
 61f72 5 284 503
-FUNC 61f7c 3e 0 _ascii_wcsicmp(wchar_t const*, wchar_t const*)
+FUNC 61f7c 3e 0 __ascii_wcsicmp(wchar_t const*, wchar_t const*)
 61f7c 6 79 504
 61f82 8 88 504
 61f8a 8 89 504
@@ -23989,7 +23989,7 @@ FUNC 61f7c 3e 0 _ascii_wcsicmp(wchar_t const*, wchar_t const*)
 61faa 8 90 504
 61fb2 7 92 504
 61fb9 1 95 504
-FUNC 61fcc 46 0 wcsicmp(wchar_t const*, wchar_t const*)
+FUNC 61fcc 46 0 _wcsicmp(wchar_t const*, wchar_t const*)
 61fcc 4 101 504
 61fd0 9 102 504
 61fd9 5 105 504
@@ -24000,7 +24000,7 @@ FUNC 61fcc 46 0 wcsicmp(wchar_t const*, wchar_t const*)
 62006 3 111 504
 62009 4 112 504
 6200d 5 111 504
-FUNC 62024 127 0 wcsicmp_l(wchar_t const*, wchar_t const*, __crt_locale_pointers*)
+FUNC 62024 127 0 _wcsicmp_l(wchar_t const*, wchar_t const*, __crt_locale_pointers*)
 62024 1e 44 504
 62042 5 46 504
 62047 1a 73 504
@@ -24020,7 +24020,7 @@ FUNC 62194 35 0 wcscmp(wchar_t const*, wchar_t const*)
 621a8 11 36 505
 621b9 f 39 505
 621c8 1 40 505
-FUNC 621d8 bb 0 towlower_l(unsigned short, __crt_locale_pointers*)
+FUNC 621d8 bb 0 _towlower_l(unsigned short, __crt_locale_pointers*)
 621d8 9 32 506
 621e1 e 35 506
 621ef a 40 506
@@ -24033,7 +24033,7 @@ FUNC 621d8 bb 0 towlower_l(unsigned short, __crt_locale_pointers*)
 6228e 5 69 506
 FUNC 622c4 7 0 towlower(unsigned short)
 622c4 7 93 506
-FUNC 622cc 40 0 set_error_mode(int)
+FUNC 622cc 40 0 _set_error_mode(int)
 622cc 4 50 507
 622d0 e 51 507
 622de 8 64 507
@@ -24088,13 +24088,13 @@ FUNC 62518 8 0 __crt_char_traits<char>::output_debug_string<char const * const &
 62518 8 109 326
 FUNC 62524 a 0 __crt_char_traits<wchar_t>::output_debug_string<wchar_t const * const &>(wchar_t const* const&)
 62524 a 124 326
-FUNC 62530 a3 0 _acrt_show_narrow_message_box(char const*, char const*, unsigned int)
+FUNC 62530 a3 0 __acrt_show_narrow_message_box(char const*, char const*, unsigned int)
 62530 1d 83 508
 6254d 50 84 508
 6259d 10 85 508
 625ad 11 84 508
 625be 15 85 508
-FUNC 625fc a4 0 _acrt_show_wide_message_box(wchar_t const*, wchar_t const*, unsigned int)
+FUNC 625fc a4 0 __acrt_show_wide_message_box(wchar_t const*, wchar_t const*, unsigned int)
 625fc 1d 92 508
 62619 51 93 508
 6266a 10 94 508
@@ -24122,18 +24122,18 @@ FUNC 627ec 3b 0 __dcrt_lowio_initialize_console_output()
 627ec 4 20 509
 627f0 32 21 509
 62822 5 29 509
-FUNC 62838 52 0 _dcrt_lowio_ensure_console_output_initialized()
+FUNC 62838 52 0 __dcrt_lowio_ensure_console_output_initialized()
 62838 6 32 509
 6283e f 33 509
 6284d 2e 35 509
 6287b 9 38 509
 62884 6 43 509
-FUNC 628a0 1c 0 _dcrt_terminate_console_output()
+FUNC 628a0 1c 0 __dcrt_terminate_console_output()
 628a0 4 47 509
 628a4 d 49 509
 628b1 6 51 509
 628b7 5 53 509
-FUNC 628c4 be 0 _dcrt_write_console(void const*, unsigned long, unsigned long*)
+FUNC 628c4 be 0 __dcrt_write_console(void const*, unsigned long, unsigned long*)
 628c4 14 72 509
 628d8 5 73 509
 628dd 3 72 509
@@ -24181,14 +24181,14 @@ FUNC 62b00 7e 0 close_os_handle_nolock(const int)
 62b69 8 38 510
 62b71 2 36 510
 62b73 b 39 510
-FUNC 62ba0 a1 0 close(int)
+FUNC 62ba0 a1 0 _close(int)
 62ba0 b 46 510
 62bab 1a 47 510
 62bc5 c 48 510
 62bd1 23 49 510
 62bf4 2d 51 510
 62c21 20 64 510
-FUNC 62c6c bd 0 close_nolock(int)
+FUNC 62c6c bd 0 _close_nolock(int)
 62c6c d 69 510
 62c79 d 70 510
 62c86 4 72 510
@@ -24490,24 +24490,24 @@ FUNC 6376c 30 0 translate_control_denormal_control_to_sse(const __acrt_fenv_abst
 63795 1 119 512
 63796 5 113 512
 6379b 1 119 512
-FUNC 637a8 17 0 _acrt_fenv_expand_round_control(__acrt_fenv_abstract_control)
+FUNC 637a8 17 0 __acrt_fenv_expand_round_control(__acrt_fenv_abstract_control)
 637a8 16 504 512
 637be 1 509 512
-FUNC 637c4 9 0 _acrt_fenv_get_common_round_control(__acrt_fenv_abstract_control)
+FUNC 637c4 9 0 __acrt_fenv_get_common_round_control(__acrt_fenv_abstract_control)
 637c4 8 527 512
 637cc 1 529 512
-FUNC 637d0 f1 0 _acrt_fenv_get_control()
+FUNC 637d0 f1 0 __acrt_fenv_get_control()
 637d0 da 449 512
 638aa 16 450 512
 638c0 1 451 512
-FUNC 63900 b 0 _acrt_fenv_get_fp_status_word_from_exception_mask(__acrt_fenv_abstract_status)
+FUNC 63900 b 0 __acrt_fenv_get_fp_status_word_from_exception_mask(__acrt_fenv_abstract_status)
 63900 a 490 512
 6390a 1 495 512
-FUNC 63910 53 0 _acrt_fenv_get_status()
+FUNC 63910 53 0 __acrt_fenv_get_status()
 63910 4b 438 512
 6395b 7 439 512
 63962 1 440 512
-FUNC 63978 147 0 _acrt_fenv_set_control(__acrt_fenv_abstract_control)
+FUNC 63978 147 0 __acrt_fenv_set_control(__acrt_fenv_abstract_control)
 63978 f 454 512
 63987 fc 455 512
 63a83 5 456 512
@@ -24517,7 +24517,7 @@ FUNC 63978 147 0 _acrt_fenv_set_control(__acrt_fenv_abstract_control)
 63a93 5 456 512
 63a98 26 455 512
 63abe 1 456 512
-FUNC 63b10 83 0 _acrt_fenv_set_status(__acrt_fenv_abstract_status)
+FUNC 63b10 83 0 __acrt_fenv_set_status(__acrt_fenv_abstract_status)
 63b10 2 443 512
 63b12 80 444 512
 63b92 1 445 512
@@ -24551,17 +24551,17 @@ FUNC 63cac 5b 0 _abstract_sw(unsigned int)
 63cfe 5 388 513
 63d03 3 391 513
 63d06 1 392 513
-FUNC 63d20 6e 0 clearfp(<NoType>)
+FUNC 63d20 6e 0 _clearfp(<NoType>)
 63d20 6 72 513
 63d26 7 75 513
 63d2d 5 76 513
 63d32 56 78 513
 63d88 6 79 513
-FUNC 63dac 5 0 control87(unsigned int, unsigned int)
+FUNC 63dac 5 0 _control87(unsigned int, unsigned int)
 63dac 5 143 513
-FUNC 63db4 9 0 controlfp(unsigned int, unsigned int)
+FUNC 63db4 9 0 _controlfp(unsigned int, unsigned int)
 63db4 9 165 513
-FUNC 63dc0 a 0 fpreset(<NoType>)
+FUNC 63dc0 a 0 _fpreset(<NoType>)
 63dc0 a 418 513
 FUNC 63dcc bf 0 _hw_cw(unsigned int)
 63dcc 3 295 513
@@ -24580,14 +24580,14 @@ FUNC 63dcc bf 0 _hw_cw(unsigned int)
 63e82 6 342 513
 63e88 2 350 513
 63e8a 1 351 513
-FUNC 63ebc 34 0 set_controlfp(unsigned int, unsigned int)
+FUNC 63ebc 34 0 _set_controlfp(unsigned int, unsigned int)
 63ebc 4 185 513
 63ec0 d 189 513
 63ecd 9 193 513
 63ed6 c 194 513
 63ee2 9 201 513
 63eeb 5 202 513
-FUNC 63f00 62 0 statusfp(<NoType>)
+FUNC 63f00 62 0 _statusfp(<NoType>)
 63f00 a 51 513
 63f0a 57 53 513
 63f61 1 54 513
@@ -24642,7 +24642,7 @@ FUNC 6436c ba 0 _exception_enabled(unsigned int, unsigned long long)
 64402 a 118 514
 6440c 3 119 514
 6440f 17 123 514
-FUNC 64454 127 0 handle_error(char*, int, unsigned long long, int, int, int, double, double, int)
+FUNC 64454 127 0 _handle_error(char*, int, unsigned long long, int, int, int, double, double, int)
 64454 2b 197 514
 6447f 15 202 514
 64494 2c 205 514
@@ -24655,7 +24655,7 @@ FUNC 64454 127 0 handle_error(char*, int, unsigned long long, int, int, int, dou
 6453d 7 229 514
 64544 15 231 514
 64559 22 232 514
-FUNC 645c4 133 0 handle_errorf(char*, int, unsigned long long, int, int, int, float, float, int)
+FUNC 645c4 133 0 _handle_errorf(char*, int, unsigned long long, int, int, int, float, float, int)
 645c4 2b 144 514
 645ef 15 149 514
 64604 2b 152 514
@@ -24668,15 +24668,15 @@ FUNC 645c4 133 0 handle_errorf(char*, int, unsigned long long, int, int, int, fl
 646b9 7 173 514
 646c0 15 175 514
 646d5 22 176 514
-FUNC 64744 19 0 handle_nan(unsigned long long)
+FUNC 64744 19 0 _handle_nan(unsigned long long)
 64744 d 181 514
 64751 b 182 514
 6475c 1 184 514
-FUNC 64764 f 0 handle_nanf(unsigned int)
+FUNC 64764 f 0 _handle_nanf(unsigned int)
 64764 4 128 514
 64768 a 129 514
 64772 1 131 514
-FUNC 64780 70 0 _acrt_initialize_fma3(<NoType>)
+FUNC 64780 70 0 __acrt_initialize_fma3(<NoType>)
 64780 6 32 517
 64786 3 37 517
 64789 15 40 517
@@ -24686,21 +24686,21 @@ FUNC 64780 70 0 _acrt_initialize_fma3(<NoType>)
 647e1 7 53 517
 647e8 2 54 517
 647ea 6 55 517
-FUNC 6480c 7 0 get_FMA3_enable(<NoType>)
+FUNC 6480c 7 0 _get_FMA3_enable(<NoType>)
 6480c 6 26 517
 64812 1 27 517
-FUNC 64814 17 0 set_FMA3_enable(int)
+FUNC 64814 17 0 _set_FMA3_enable(int)
 64814 16 16 517
 6482a 1 22 517
-FUNC 64830 20 0 log10_special(double, double, unsigned int)
+FUNC 64830 20 0 _log10_special(double, double, unsigned int)
 64830 4 141 518
 64834 17 142 518
 6484b 5 143 518
-FUNC 64858 20 0 log10f_special(float, float, unsigned int)
+FUNC 64858 20 0 _log10f_special(float, float, unsigned int)
 64858 4 109 518
 6485c 17 110 518
 64873 5 111 518
-FUNC 64880 20 0 log_special(double, double, unsigned int)
+FUNC 64880 20 0 _log_special(double, double, unsigned int)
 64880 4 136 518
 64884 17 137 518
 6489b 5 138 518
@@ -24711,7 +24711,7 @@ FUNC 648a8 96 0 _log_special_common(double, double, unsigned int, unsigned int, 
 648ec 2d 120 518
 64919 1b 132 518
 64934 a 133 518
-FUNC 64964 20 0 logf_special(float, float, unsigned int)
+FUNC 64964 20 0 _logf_special(float, float, unsigned int)
 64964 4 104 518
 64968 17 105 518
 6497f 5 106 518
@@ -24722,7 +24722,7 @@ FUNC 6498c 9c 0 _logf_special_common(float, float, unsigned int, unsigned int, c
 649d0 2d 88 518
 649fd 21 100 518
 64a1e a 101 518
-FUNC 64a50 87 0 _acrt_LCMapStringW(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t*, int)
+FUNC 64a50 87 0 __acrt_LCMapStringW(wchar_t const*, unsigned long, wchar_t const*, int, wchar_t*, int)
 64a50 1f 53 520
 64a6f 5 57 520
 64a74 b 59 520
@@ -24731,7 +24731,7 @@ FUNC 64a50 87 0 _acrt_LCMapStringW(wchar_t const*, unsigned long, wchar_t const*
 64a86 2 69 520
 64a88 3a 73 520
 64ac2 15 74 520
-FUNC 64af8 9c 0 _acrt_OutputDebugStringA(char const*)
+FUNC 64af8 9c 0 __acrt_OutputDebugStringA(char const*)
 64af8 20 14 521
 64b18 5 15 521
 64b1d 12 19 521
@@ -24740,23 +24740,23 @@ FUNC 64af8 9c 0 _acrt_OutputDebugStringA(char const*)
 64b57 1e 27 521
 64b75 9 29 521
 64b7e 16 31 521
-FUNC 64bd0 10 0 get_fpsr()
+FUNC 64bd0 10 0 _get_fpsr()
 64bd0 4 6 523
 64bd4 4 9 523
 64bd8 3 10 523
 64bdb 4 11 523
 64bdf 1 12 523
-FUNC 64be0 a 0 set_fpsr()
+FUNC 64be0 a 0 _set_fpsr()
 64be0 4 19 523
 64be4 5 20 523
 64be9 1 21 523
-FUNC 64bea 14 0 fclrf()
+FUNC 64bea 14 0 _fclrf()
 64bea 5 28 523
 64bef 5 29 523
 64bf4 4 30 523
 64bf8 5 31 523
 64bfd 1 32 523
-FUNC 64bfe 1f 0 frnd()
+FUNC 64bfe 1f 0 _frnd()
 64bfe 8 43 523
 64c06 2 44 523
 64c08 8 45 523
@@ -24764,7 +24764,7 @@ FUNC 64bfe 1f 0 frnd()
 64c12 5 47 523
 64c17 5 48 523
 64c1c 1 50 523
-FUNC 64c34 43 0 errcode(unsigned int)
+FUNC 64c34 43 0 _errcode(unsigned int)
 64c34 2 995 524
 64c36 5 998 524
 64c3b 5 999 524
@@ -24781,7 +24781,7 @@ FUNC 64c34 43 0 errcode(unsigned int)
 64c68 c 1010 524
 64c74 2 1019 524
 64c76 1 1020 524
-FUNC 64c88 f1 0 except1(int, int, double, double, unsigned long long)
+FUNC 64c88 f1 0 _except1(int, int, double, double, unsigned long long)
 64c88 27 251 524
 64caf 25 254 524
 64cd4 8 268 524
@@ -24793,7 +24793,7 @@ FUNC 64c88 f1 0 except1(int, int, double, double, unsigned long long)
 64d3c 7 288 524
 64d43 12 291 524
 64d55 24 292 524
-FUNC 64db8 106 0 except2(int, int, double, double, double, unsigned long long)
+FUNC 64db8 106 0 _except2(int, int, double, double, double, unsigned long long)
 64db8 2b 336 524
 64de3 23 339 524
 64e06 3 352 524
@@ -24817,7 +24817,7 @@ FUNC 64f00 31 0 _get_fname(unsigned int)
 64f24 1 974 524
 64f25 b 971 524
 64f30 1 974 524
-FUNC 64f40 267 0 handle_exc(unsigned int, double*, unsigned long long)
+FUNC 64f40 267 0 _handle_exc(unsigned int, double*, unsigned long long)
 64f40 14 662 524
 64f54 24 670 524
 64f78 9 676 524
@@ -24864,14 +24864,14 @@ FUNC 64f40 267 0 handle_exc(unsigned int, double*, unsigned long long)
 65177 a 802 524
 65181 3 803 524
 65184 23 807 524
-FUNC 65240 5 0 handle_qnan2(double, double)
+FUNC 65240 5 0 _handle_qnan2(double, double)
 65240 4 221 524
 65244 1 224 524
-FUNC 65248 27 0 raise_exc(_FPIEEE_RECORD*, unsigned long long*, int, int, double*, double*)
+FUNC 65248 27 0 _raise_exc(_FPIEEE_RECORD*, unsigned long long*, int, int, double*, double*)
 65248 4 630 524
 6524c 1e 631 524
 6526a 5 632 524
-FUNC 65278 30d 0 raise_exc_ex(_FPIEEE_RECORD*, unsigned long long*, int, int, void*, void*, int)
+FUNC 65278 30d 0 _raise_exc_ex(_FPIEEE_RECORD*, unsigned long long*, int, int, void*, void*, int)
 65278 21 415 524
 65299 a 423 524
 652a3 7 424 524
@@ -24948,17 +24948,17 @@ FUNC 65278 30d 0 raise_exc_ex(_FPIEEE_RECORD*, unsigned long long*, int, int, vo
 65567 2 620 524
 65569 7 621 524
 65570 15 623 524
-FUNC 65648 2a 0 raise_excf(_FPIEEE_RECORD*, unsigned long long*, int, int, float*, float*)
+FUNC 65648 2a 0 _raise_excf(_FPIEEE_RECORD*, unsigned long long*, int, int, float*, float*)
 65648 4 639 524
 6564c 21 640 524
 6566d 5 641 524
-FUNC 6567c 2e 0 set_errno_from_matherr(int)
+FUNC 6567c 2e 0 _set_errno_from_matherr(int)
 6567c 4 898 524
 65680 d 899 524
 6568d d 905 524
 6569a b 901 524
 656a5 5 908 524
-FUNC 656b8 d4 0 umatherr(int, unsigned int, double, double, double, unsigned long long)
+FUNC 656b8 d4 0 _umatherr(int, unsigned int, double, double, double, unsigned long long)
 656b8 11 844 524
 656c9 7 851 524
 656d0 2 844 524
@@ -24975,14 +24975,14 @@ FUNC 656b8 d4 0 umatherr(int, unsigned int, double, double, double, unsigned lon
 65776 7 873 524
 6577d 9 874 524
 65786 6 877 524
-FUNC 657c4 1d 0 clrfp(<NoType>)
+FUNC 657c4 1d 0 _clrfp(<NoType>)
 657c4 6 59 525
 657ca 7 62 525
 657d1 3 63 525
 657d4 5 64 525
 657d9 2 66 525
 657db 6 67 525
-FUNC 657e8 7c 0 ctrlfp(unsigned long long, unsigned long long)
+FUNC 657e8 7c 0 _ctrlfp(unsigned long long, unsigned long long)
 657e8 15 85 525
 657fd b 90 525
 65808 4 91 525
@@ -25000,14 +25000,14 @@ FUNC 657e8 7c 0 ctrlfp(unsigned long long, unsigned long long)
 6584d 5 106 525
 65852 2 109 525
 65854 10 110 525
-FUNC 65884 1f 0 set_statfp(unsigned long long)
+FUNC 65884 1f 0 _set_statfp(unsigned long long)
 65884 9 129 525
 6588d 5 132 525
 65892 5 134 525
 65897 2 136 525
 65899 5 138 525
 6589e 5 136 525
-FUNC 658ac 11 0 statfp(<NoType>)
+FUNC 658ac 11 0 _statfp(<NoType>)
 658ac 4 35 525
 658b0 5 38 525
 658b5 3 39 525
@@ -25044,9 +25044,9 @@ FUNC 658c4 200 0 _mbstowcs_l_helper(wchar_t*, char const*, unsigned long long, _
 65a86 d 168 527
 65a93 18 172 527
 65aab 19 176 527
-FUNC 65b44 5 0 mbstowcs_l(wchar_t*, char const*, unsigned long long, __crt_locale_pointers*)
+FUNC 65b44 5 0 _mbstowcs_l(wchar_t*, char const*, unsigned long long, __crt_locale_pointers*)
 65b44 5 187 527
-FUNC 65b4c 133 0 mbstowcs_s_l(unsigned long long*, wchar_t*, unsigned long long, char const*, unsigned long long, __crt_locale_pointers*)
+FUNC 65b4c 133 0 _mbstowcs_s_l(unsigned long long*, wchar_t*, unsigned long long, char const*, unsigned long long, __crt_locale_pointers*)
 65b4c 19 241 527
 65b65 12 243 527
 65b77 a 246 527
@@ -25086,11 +25086,11 @@ FUNC 65cec 1e 0 mbstowcs_s(unsigned long long*, wchar_t*, unsigned long long, ch
 65cec 4 313 527
 65cf0 15 314 527
 65d05 5 315 527
-FUNC 65d14 4e 0 add_exp(double, int)
+FUNC 65d14 4e 0 _add_exp(double, int)
 65d14 6 44 528
 65d1a 47 45 528
 65d61 1 46 528
-FUNC 65d78 12e 0 decomp(double, int*)
+FUNC 65d78 12e 0 _decomp(double, int*)
 65d78 f 89 528
 65d87 8 93 528
 65d8f 2 95 528
@@ -25118,22 +25118,22 @@ FUNC 65d78 12e 0 decomp(double, int*)
 65e96 c 118 528
 65ea2 3 121 528
 65ea5 1 123 528
-FUNC 65ef4 1d 0 get_exp(double)
+FUNC 65ef4 1d 0 _get_exp(double)
 65ef4 6 35 528
 65efa 11 37 528
 65f0b 5 39 528
 65f10 1 40 528
-FUNC 65f18 30 0 set_bexp(double, int)
+FUNC 65f18 30 0 _set_bexp(double, int)
 65f18 6 51 528
 65f1e 23 54 528
 65f41 6 55 528
 65f47 1 56 528
-FUNC 65f54 38 0 set_exp(double, int)
+FUNC 65f54 38 0 _set_exp(double, int)
 65f54 6 24 528
 65f5a 2b 29 528
 65f85 6 30 528
 65f8b 1 31 528
-FUNC 65f9c 74 0 sptype(double)
+FUNC 65f9c 74 0 _sptype(double)
 65f9c 6 60 528
 65fa2 18 61 528
 65fba 5 62 528
@@ -25149,7 +25149,7 @@ FUNC 65f9c 74 0 sptype(double)
 6600c 1 70 528
 6600d 2 69 528
 6600f 1 70 528
-FUNC 66030 44 0 FindPESection(unsigned char*, unsigned long long)
+FUNC 66030 44 0 _FindPESection(unsigned char*, unsigned long long)
 66030 4 91 529
 66034 e 100 529
 66042 11 101 529
@@ -25157,7 +25157,7 @@ FUNC 66030 44 0 FindPESection(unsigned char*, unsigned long long)
 66065 c 102 529
 66071 2 117 529
 66073 1 118 529
-FUNC 66090 4d 0 IsNonwritableInCurrentImage(void const*)
+FUNC 66090 4d 0 _IsNonwritableInCurrentImage(void const*)
 66090 d 143 529
 6609d 13 158 529
 660b0 3 168 529
@@ -25166,7 +25166,7 @@ FUNC 66090 4d 0 IsNonwritableInCurrentImage(void const*)
 660c3 d 179 529
 660d0 2 187 529
 660d2 b 189 529
-FUNC 660f0 2d 0 ValidateImageBase(unsigned char*)
+FUNC 660f0 2d 0 _ValidateImageBase(unsigned char*)
 660f0 a 44 529
 660fa 7 49 529
 66101 8 50 529
@@ -25179,12 +25179,12 @@ FUNC 66128 b 0 type_info::~type_info()
 66128 a 17 530
 66132 1 18 530
 FUNC 66138 2b 0 type_info::`scalar deleting destructor'(unsigned int)
-FUNC 66170 1d 0 _GSHandlerCheck(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
+FUNC 66170 1d 0 __GSHandlerCheck(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
 66170 4 74 531
 66174 f 82 531
 66183 5 93 531
 66188 5 94 531
-FUNC 66194 5b 0 _GSHandlerCheckCommon(void*, _DISPATCHER_CONTEXT*, _GS_HANDLER_DATA*)
+FUNC 66194 5b 0 __GSHandlerCheckCommon(void*, _DISPATCHER_CONTEXT*, _GS_HANDLER_DATA*)
 66194 2 128 531
 66196 d 142 531
 661a3 9 151 531
@@ -25197,14 +25197,14 @@ FUNC 66194 5b 0 _GSHandlerCheckCommon(void*, _DISPATCHER_CONTEXT*, _GS_HANDLER_D
 661e6 3 187 531
 661e9 1 188 531
 661ea 5 187 531
-FUNC 66208 85 0 _GSHandlerCheck_SEH(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
+FUNC 66208 85 0 __GSHandlerCheck_SEH(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
 66208 19 67 532
 66221 d 79 532
 6622e 1c 86 532
 6624a 17 99 532
 66261 11 103 532
 66272 1b 116 532
-FUNC 662c0 51 0 _chkstk()
+FUNC 662c0 51 0 __chkstk()
 662c0 4 71 533
 662c4 4 83 533
 662c8 5 84 533
@@ -25365,7 +25365,7 @@ FUNC 66620 149 0 strrchr(char const*, int)
 6675e 4 212 536
 66762 2 213 536
 66764 5 196 536
-FUNC 667bc 29 0 local_unwind(void*, void*)
+FUNC 667bc 29 0 _local_unwind(void*, void*)
 667bc e 28 537
 667ca 16 30 537
 667e0 5 31 537
@@ -25438,7 +25438,7 @@ FUNC 66800 c7 0 memcmp()
 668c3 3 178 538
 668c6 1 179 538
 PUBLIC 668fc 0 RtlUnwind
-FUNC 68460 2 0 guard_dispatch_icall_nop()
+FUNC 68460 2 0 _guard_dispatch_icall_nop()
 68460 2 59 52
 FUNC 69470 17 0 `dllmain_crt_process_attach'::`1'::fin$0
 69470 9 68 30

--- a/test_data/windows/dump_syms_regtest64.sym
+++ b/test_data/windows/dump_syms_regtest64.sym
@@ -455,12 +455,12 @@ FUNC 14a4 38 0 __CxxUnhandledExceptionFilter(_EXCEPTION_POINTERS*)
 14cf 2 42 304
 14d1 5 43 304
 14d6 6 39 304
-FUNC 14dc 17 0 _CxxSetUnhandledExceptionFilter()
+FUNC 14dc 17 0 __CxxSetUnhandledExceptionFilter()
 14dc 4 56 304
 14e0 c 60 304
 14ec 2 62 304
 14ee 5 63 304
-FUNC 14f4 1cc 0 XcptFilter(unsigned long, _EXCEPTION_POINTERS*)
+FUNC 14f4 1cc 0 _XcptFilter(unsigned long, _EXCEPTION_POINTERS*)
 14f4 19 195 195
 150d 5 202 195
 1512 f 203 195
@@ -505,7 +505,7 @@ FUNC 14f4 1cc 0 XcptFilter(unsigned long, _EXCEPTION_POINTERS*)
 16a4 5 374 195
 16a9 2 224 195
 16ab 15 376 195
-FUNC 16c0 133 0 freefls(void*)
+FUNC 16c0 133 0 _freefls(void*)
 16c0 13 381 270
 16d3 3 370 270
 16d6 9 382 270
@@ -536,14 +536,14 @@ FUNC 16c0 133 0 freefls(void*)
 17d6 a 430 270
 17e0 8 433 270
 17e8 b 436 270
-FUNC 17f4 24 0 getptd()
+FUNC 17f4 24 0 _getptd()
 17f4 6 336 270
 17fa 8 337 270
 1802 5 338 270
 1807 8 339 270
 180f 3 341 270
 1812 6 342 270
-FUNC 1818 82 0 getptd_noexit()
+FUNC 1818 82 0 _getptd_noexit()
 1818 a 270 270
 1822 6 274 270
 1828 15 277 270
@@ -558,7 +558,7 @@ FUNC 1818 82 0 getptd_noexit()
 1884 8 312 270
 188c 3 314 270
 188f b 315 270
-FUNC 189c c2 0 initptd(_tiddata*, threadlocaleinfostruct*)
+FUNC 189c c2 0 _initptd(_tiddata*, threadlocaleinfostruct*)
 189c 10 203 270
 18ac e 204 270
 18ba 4 205 270
@@ -578,7 +578,7 @@ FUNC 189c c2 0 initptd(_tiddata*, threadlocaleinfostruct*)
 193c d 245 270
 1949 a 248 270
 1953 b 250 270
-FUNC 1960 7f 0 mtinit()
+FUNC 1960 7f 0 _mtinit()
 1960 6 88 270
 1966 5 91 270
 196b 9 97 270
@@ -591,34 +591,34 @@ FUNC 1960 7f 0 mtinit()
 19d2 5 117 270
 19d7 2 118 270
 19d9 6 131 270
-FUNC 19e0 24 0 mtterm()
+FUNC 19e0 24 0 _mtterm()
 19e0 4 160 270
 19e4 b 167 270
 19ef 5 168 270
 19f4 7 169 270
 19fb 4 177 270
 19ff 5 176 270
-FUNC 1a04 41 0 _crtCorExitProcess(int)
+FUNC 1a04 41 0 __crtCorExitProcess(int)
 1a04 8 734 276
 1a0c 18 738 276
 1a24 12 739 276
 1a36 5 740 276
 1a3b 4 741 276
 1a3f 6 751 276
-FUNC 1a48 16 0 _crtExitProcess(int)
+FUNC 1a48 16 0 __crtExitProcess(int)
 1a48 8 757 276
 1a50 5 764 276
 1a55 9 774 276
-FUNC 1a60 26 0 amsg_exit(int)
+FUNC 1a60 26 0 _amsg_exit(int)
 1a60 8 485 276
 1a68 5 487 276
 1a6d 7 488 276
 1a74 12 490 276
-FUNC 1a88 f 0 c_exit()
+FUNC 1a88 f 0 _c_exit()
 1a88 f 455 276
-FUNC 1a98 d 0 cexit()
+FUNC 1a98 d 0 _cexit()
 1a98 d 448 276
-FUNC 1aa8 96 0 cinit(int)
+FUNC 1aa8 96 0 _cinit(int)
 1aa8 6 278 276
 1aae 1c 288 276
 1aca 8 290 276
@@ -631,9 +631,9 @@ FUNC 1aa8 96 0 cinit(int)
 1b27 f 323 276
 1b36 2 327 276
 1b38 6 328 276
-FUNC 1b40 c 0 exit(int)
+FUNC 1b40 c 0 _exit(int)
 1b40 c 433 276
-FUNC 1b4c 4b 0 init_pointers(<NoType>)
+FUNC 1b4c 4b 0 _init_pointers(<NoType>)
 1b4c 6 879 276
 1b52 8 880 276
 1b5a b 882 276
@@ -651,7 +651,7 @@ FUNC 1b98 60 0 _initterm(void (**)(), void (**)())
 1bd5 2 954 276
 1bd7 c 955 276
 1be3 15 957 276
-FUNC 1bf8 39 0 initterm_e(int (**)(), int (**)())
+FUNC 1bf8 39 0 _initterm_e(int (**)(), int (**)())
 1bf8 a 990 276
 1c02 8 991 276
 1c0a 9 999 276
@@ -659,9 +659,9 @@ FUNC 1bf8 39 0 initterm_e(int (**)(), int (**)())
 1c1b 2 1005 276
 1c1d 9 1006 276
 1c26 b 1010 276
-FUNC 1c34 a 0 lockexit()
+FUNC 1c34 a 0 _lockexit()
 1c34 a 826 276
-FUNC 1c40 a 0 unlockexit()
+FUNC 1c40 a 0 _unlockexit()
 1c40 a 852 276
 FUNC 1c4c 195 0 doexit(int, int, int)
 1c4c 24 552 276
@@ -698,11 +698,11 @@ FUNC 1c4c 195 0 doexit(int, int, int)
 1dc9 18 679 276
 FUNC 1de4 a 0 exit(int)
 1de4 a 417 276
-FUNC 1df0 20 0 heap_init()
+FUNC 1df0 20 0 _heap_init()
 1df0 4 40 127
 1df4 17 42 127
 1e0b 5 46 127
-FUNC 1e10 32d 0 ioinit()
+FUNC 1e10 32d 0 _ioinit()
 1e10 25 110 138
 1e35 b 125 138
 1e40 23 134 138
@@ -769,7 +769,7 @@ FUNC 1e10 32d 0 ioinit()
 210f a 326 138
 2119 2 329 138
 211b 22 330 138
-FUNC 2140 f3 0 setargv()
+FUNC 2140 f3 0 _setargv()
 2140 f 88 272
 214f 9 97 272
 2158 5 98 272
@@ -858,7 +858,7 @@ FUNC 2234 1c7 0 parse_cmdline(char*, char**, char*, int*, int*)
 23d4 4 388 272
 23d8 4 389 272
 23dc 1f 390 272
-FUNC 23fc 131 0 setenvp()
+FUNC 23fc 131 0 _setenvp()
 23fc 14 77 265
 2410 9 85 265
 2419 5 86 265
@@ -888,13 +888,13 @@ FUNC 23fc 131 0 setenvp()
 250a 8 130 265
 2512 5 131 265
 2517 16 133 265
-FUNC 2530 43 0 FF_MSGBANNER()
+FUNC 2530 43 0 _FF_MSGBANNER()
 2530 4 143 268
 2534 26 147 268
 255a a 149 268
 2564 a 150 268
 256e 5 152 268
-FUNC 2574 2f 0 GET_RTERRMSG(int)
+FUNC 2574 2f 0 _GET_RTERRMSG(int)
 2574 c 177 268
 2580 5 178 268
 2585 f 177 268
@@ -902,7 +902,7 @@ FUNC 2574 2f 0 GET_RTERRMSG(int)
 2596 1 182 268
 2597 b 179 268
 25a2 1 182 268
-FUNC 25a4 26f 0 NMSG_WRITE(int)
+FUNC 25a4 26f 0 _NMSG_WRITE(int)
 25a4 2f 205 268
 25d3 5 206 268
 25d8 e 208 268
@@ -931,10 +931,10 @@ FUNC 25a4 26f 0 NMSG_WRITE(int)
 27d6 15 295 268
 27eb 15 294 268
 2800 13 281 268
-FUNC 2814 7 0 _set_app_type(int)
+FUNC 2814 7 0 __set_app_type(int)
 2814 6 95 156
 281a 1 96 156
-FUNC 281c 40 0 set_error_mode(int)
+FUNC 281c 40 0 _set_error_mode(int)
 281c 4 49 156
 2820 e 52 156
 282e 6 60 156
@@ -944,7 +944,7 @@ FUNC 281c 40 0 set_error_mode(int)
 2842 2 66 156
 2844 13 63 156
 2857 5 67 156
-FUNC 285c ac 0 _security_init_cookie()
+FUNC 285c ac 0 __security_init_cookie()
 285c d 82 170
 2869 1b 99 170
 2884 a 112 170
@@ -957,21 +957,21 @@ FUNC 285c ac 0 _security_init_cookie()
 28db 11 157 170
 28ec 7 168 170
 28f3 15 171 170
-FUNC 2908 38 0 RTC_Initialize()
+FUNC 2908 38 0 _RTC_Initialize()
 2908 a 43 320
 2912 10 46 320
 2922 8 48 320
 292a 2 50 320
 292c 9 46 320
 2935 b 53 320
-FUNC 2940 38 0 RTC_Terminate()
+FUNC 2940 38 0 _RTC_Terminate()
 2940 a 57 320
 294a 10 60 320
 295a 8 62 320
 2962 2 64 320
 2964 9 60 320
 296d b 67 320
-FUNC 2978 f4 0 _crtGetEnvironmentStringsA()
+FUNC 2978 f4 0 __crtGetEnvironmentStringsA()
 2978 19 40 200
 2991 15 49 200
 29a6 3 53 200
@@ -988,7 +988,7 @@ FUNC 2978 f4 0 _crtGetEnvironmentStringsA()
 2a46 9 76 200
 2a4f 2 77 200
 2a51 1b 96 200
-FUNC 2a6c 1e1 0 _C_specific_handler(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
+FUNC 2a6c 1e1 0 __C_specific_handler(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
 2a6c 1c 91 5
 2a88 4 112 5
 2a8c 3 113 5
@@ -1024,26 +1024,26 @@ FUNC 2a6c 1e1 0 _C_specific_handler(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPA
 2c1e c 218 5
 2c2a 5 284 5
 2c2f 1e 285 5
-FUNC 2c50 20 0 _doserrno()
+FUNC 2c50 20 0 __doserrno()
 2c50 4 292 117
 2c54 5 293 117
 2c59 5 294 117
 2c5e 9 295 117
 2c67 4 297 117
 2c6b 5 299 117
-FUNC 2c70 4e 0 dosmaperr(unsigned long)
+FUNC 2c70 4e 0 _dosmaperr(unsigned long)
 2c70 c 110 117
 2c7c 19 111 117
 2c95 1e 113 117
 2cb3 b 114 117
-FUNC 2cc0 20 0 errno()
+FUNC 2cc0 20 0 _errno()
 2cc0 4 279 117
 2cc4 5 280 117
 2cc9 5 281 117
 2cce 9 282 117
 2cd7 4 284 117
 2cdb 5 287 117
-FUNC 2ce0 4d 0 get_errno_from_oserr(unsigned long)
+FUNC 2ce0 4d 0 _get_errno_from_oserr(unsigned long)
 2ce0 10 123 117
 2cf0 5 124 117
 2cf5 e 123 117
@@ -1054,7 +1054,7 @@ FUNC 2ce0 4d 0 get_errno_from_oserr(unsigned long)
 2d23 1 139 117
 2d24 8 125 117
 2d2c 1 139 117
-FUNC 2d30 f2 0 call_reportfault(int, unsigned long, unsigned long)
+FUNC 2d30 f2 0 _call_reportfault(int, unsigned long, unsigned long)
 2d30 36 148 261
 2d66 5 150 261
 2d6b 5 151 261
@@ -1071,21 +1071,21 @@ FUNC 2d30 f2 0 call_reportfault(int, unsigned long, unsigned long)
 2de6 d 205 261
 2df3 7 206 261
 2dfa 28 208 261
-FUNC 2e24 8 0 initp_misc_invarg(void*)
+FUNC 2e24 8 0 _initp_misc_invarg(void*)
 2e24 7 40 261
 2e2b 1 41 261
-FUNC 2e2c 65 0 invalid_parameter(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
+FUNC 2e2c 65 0 _invalid_parameter(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
 2e2c 17 71 261
 2e43 16 78 261
 2e59 11 81 261
 2e6a 14 86 261
 2e7e 3 81 261
 2e81 10 85 261
-FUNC 2e94 1e 0 invalid_parameter_noinfo()
+FUNC 2e94 1e 0 _invalid_parameter_noinfo()
 2e94 4 95 261
 2e98 15 96 261
 2ead 5 97 261
-FUNC 2eb4 3b 0 invoke_watson(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
+FUNC 2eb4 3b 0 _invoke_watson(wchar_t const*, wchar_t const*, wchar_t const*, unsigned int, unsigned long long)
 2eb4 4 121 261
 2eb8 e 131 261
 2ec6 7 132 261
@@ -1161,7 +1161,7 @@ FUNC 2f70 a8 0 strlen()
 3011 1 124 237
 3012 5 126 237
 3017 1 127 237
-FUNC 3018 44 0 lock(int)
+FUNC 3018 44 0 _lock(int)
 3018 a 325 273
 3022 14 330 273
 3036 9 332 273
@@ -1169,7 +1169,7 @@ FUNC 3018 44 0 lock(int)
 3047 4 340 273
 304b a 341 273
 3055 7 340 273
-FUNC 305c 87 0 mtdeletelocks()
+FUNC 305c 87 0 _mtdeletelocks()
 305c 14 183 273
 3070 e 189 273
 307e e 191 273
@@ -1182,7 +1182,7 @@ FUNC 305c 87 0 mtdeletelocks()
 30bf 6 216 273
 30c5 9 210 273
 30ce 15 219 273
-FUNC 30e4 bd 0 mtinitlocknum(int)
+FUNC 30e4 bd 0 _mtinitlocknum(int)
 30e4 13 254 273
 30f7 a 264 273
 3101 5 266 273
@@ -1203,7 +1203,7 @@ FUNC 30e4 bd 0 mtinitlocknum(int)
 3181 d 293 273
 318e 2 296 273
 3190 11 297 273
-FUNC 31a4 61 0 mtinitlocks()
+FUNC 31a4 61 0 _mtinitlocks()
 31a4 f 137 273
 31b3 c 139 273
 31bf 6 145 273
@@ -1211,7 +1211,7 @@ FUNC 31a4 61 0 mtinitlocks()
 31cf 1a 147 273
 31e9 9 144 273
 31f2 13 153 273
-FUNC 3208 18 0 unlock(int)
+FUNC 3208 18 0 _unlock(int)
 3208 18 367 273
 FUNC 3220 b6 0 malloc(unsigned long long)
 3220 12 84 128
@@ -1228,7 +1228,7 @@ FUNC 3220 b6 0 malloc(unsigned long long)
 32b9 b 115 128
 32c4 2 116 128
 32c6 10 125 128
-FUNC 32f0 24 0 local_unwind()
+FUNC 32f0 24 0 _local_unwind()
 32f0 7 49 38
 32f7 3 58 38
 32fa 3 59 38
@@ -1237,15 +1237,15 @@ FUNC 32f0 24 0 local_unwind()
 3307 5 67 38
 330c 7 68 38
 3313 1 69 38
-FUNC 3320 18 0 NLG_Notify()
+FUNC 3320 18 0 _NLG_Notify()
 3320 5 105 38
 3325 5 106 38
 332a 5 107 38
 332f 7 108 38
 3336 2 109 38
-FUNC 3340 1 0 _NLG_Dispatch2()
+FUNC 3340 1 0 __NLG_Dispatch2()
 3340 1 114 38
-FUNC 3350 1 0 _NLG_Return2()
+FUNC 3350 1 0 __NLG_Return2()
 3350 1 138 38
 FUNC 3354 1f 0 terminate()
 3354 4 66 319
@@ -1254,11 +1254,11 @@ FUNC 3354 1f 0 terminate()
 3369 2 81 319
 336b 2 82 319
 336d 6 96 319
-FUNC 3374 1d 0 initp_eh_hooks(void*)
+FUNC 3374 1d 0 _initp_eh_hooks(void*)
 3374 4 51 319
 3378 14 52 319
 338c 5 53 319
-FUNC 3394 6d 0 _crtCaptureCurrentContext(_CONTEXT*)
+FUNC 3394 6d 0 __crtCaptureCurrentContext(_CONTEXT*)
 3394 d 327 192
 33a1 6 335 192
 33a7 7 337 192
@@ -1266,7 +1266,7 @@ FUNC 3394 6d 0 _crtCaptureCurrentContext(_CONTEXT*)
 33bf 5 340 192
 33c4 32 348 192
 33f6 b 350 192
-FUNC 3404 71 0 _crtCapturePreviousContext(_CONTEXT*)
+FUNC 3404 71 0 __crtCapturePreviousContext(_CONTEXT*)
 3404 b 279 192
 340f 6 287 192
 3415 7 289 192
@@ -1275,23 +1275,23 @@ FUNC 3404 71 0 _crtCapturePreviousContext(_CONTEXT*)
 342f 5 296 192
 3434 39 304 192
 346d 8 309 192
-FUNC 3478 1a 0 _crtFlsAlloc(void (*)(void*))
+FUNC 3478 1a 0 __crtFlsAlloc(void (*)(void*))
 3478 10 386 192
 3488 3 388 192
 348b 7 392 192
-FUNC 3494 1a 0 _crtFlsFree(unsigned long)
+FUNC 3494 1a 0 __crtFlsFree(unsigned long)
 3494 10 403 192
 34a4 3 405 192
 34a7 7 409 192
-FUNC 34b0 1a 0 _crtFlsGetValue(unsigned long)
+FUNC 34b0 1a 0 __crtFlsGetValue(unsigned long)
 34b0 10 420 192
 34c0 3 422 192
 34c3 7 426 192
-FUNC 34cc 1a 0 _crtFlsSetValue(unsigned long, void*)
+FUNC 34cc 1a 0 __crtFlsSetValue(unsigned long, void*)
 34cc 10 438 192
 34dc 3 440 192
 34df 7 444 192
-FUNC 34e8 2b 0 _crtInitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsigned long, unsigned long)
+FUNC 34e8 2b 0 __crtInitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsigned long, unsigned long)
 34e8 4 457 192
 34ec 10 459 192
 34fc 4 467 192
@@ -1299,13 +1299,13 @@ FUNC 34e8 2b 0 _crtInitializeCriticalSectionEx(_RTL_CRITICAL_SECTION*, unsigned 
 3503 6 465 192
 3509 5 466 192
 350e 5 467 192
-FUNC 3514 4c 0 _crtIsPackagedApp()
+FUNC 3514 4c 0 __crtIsPackagedApp()
 3514 6 126 192
 351a c 133 192
 3526 2d 135 192
 3553 7 138 192
 355a 6 140 192
-FUNC 3560 3fa 0 _crtLoadWinApiPointers()
+FUNC 3560 3fa 0 __crtLoadWinApiPointers()
 3560 6 749 192
 3566 d 750 192
 3573 13 752 192
@@ -1342,22 +1342,22 @@ FUNC 3560 3fa 0 _crtLoadWinApiPointers()
 390a 25 783 192
 392f 25 784 192
 3954 6 785 192
-FUNC 395c 7 0 _crtSetUnhandledExceptionFilter(long (*)(_EXCEPTION_POINTERS*))
+FUNC 395c 7 0 __crtSetUnhandledExceptionFilter(long (*)(_EXCEPTION_POINTERS*))
 395c 7 198 192
-FUNC 3964 7 0 _crtSleep(unsigned long)
+FUNC 3964 7 0 __crtSleep(unsigned long)
 3964 7 739 192
-FUNC 396c 1f 0 _crtTerminateProcess(unsigned int)
+FUNC 396c 1f 0 __crtTerminateProcess(unsigned int)
 396c 8 221 192
 3974 b 224 192
 397f 5 225 192
 3984 7 224 192
-FUNC 398c 20 0 _crtUnhandledException(_EXCEPTION_POINTERS*)
+FUNC 398c 20 0 __crtUnhandledException(_EXCEPTION_POINTERS*)
 398c 9 253 192
 3995 8 255 192
 399d 3 258 192
 39a0 5 259 192
 39a5 7 258 192
-FUNC 39ac 7f 0 calloc_crt(unsigned long long, unsigned long long)
+FUNC 39ac 7f 0 _calloc_crt(unsigned long long, unsigned long long)
 39ac 19 55 124
 39c5 c 56 124
 39d1 11 62 124
@@ -1365,7 +1365,7 @@ FUNC 39ac 7f 0 calloc_crt(unsigned long long, unsigned long long)
 39ef 19 64 124
 3a08 5 65 124
 3a0d 1e 69 124
-FUNC 3a2c 7a 0 malloc_crt(unsigned long long)
+FUNC 3a2c 7a 0 _malloc_crt(unsigned long long)
 3a2c 19 40 124
 3a45 f 41 124
 3a54 b 45 124
@@ -1373,7 +1373,7 @@ FUNC 3a2c 7a 0 malloc_crt(unsigned long long)
 3a68 1b 47 124
 3a83 5 48 124
 3a88 1e 52 124
-FUNC 3aa8 81 0 realloc_crt(void*, unsigned long long)
+FUNC 3aa8 81 0 _realloc_crt(void*, unsigned long long)
 3aa8 19 72 124
 3ac1 c 73 124
 3acd e 77 124
@@ -1381,7 +1381,7 @@ FUNC 3aa8 81 0 realloc_crt(void*, unsigned long long)
 3aed 19 79 124
 3b06 5 80 124
 3b0b 1e 84 124
-FUNC 3b2c 8c 0 _addlocaleref(threadlocaleinfostruct*)
+FUNC 3b2c 8c 0 __addlocaleref(threadlocaleinfostruct*)
 3b2c 3 39 182
 3b2f c 41 182
 3b3b 3 42 182
@@ -1399,7 +1399,7 @@ FUNC 3b2c 8c 0 _addlocaleref(threadlocaleinfostruct*)
 3ba0 9 53 182
 3ba9 e 63 182
 3bb7 1 64 182
-FUNC 3bb8 196 0 _freetlocinfo(threadlocaleinfostruct*)
+FUNC 3bb8 196 0 __freetlocinfo(threadlocaleinfostruct*)
 3bb8 14 129 182
 3bcc 2c 137 182
 3bf8 11 140 182
@@ -1428,7 +1428,7 @@ FUNC 3bb8 196 0 _freetlocinfo(threadlocaleinfostruct*)
 3d32 3 202 182
 3d35 14 203 182
 3d49 5 202 182
-FUNC 3d50 a4 0 _removelocaleref(threadlocaleinfostruct*)
+FUNC 3d50 a4 0 __removelocaleref(threadlocaleinfostruct*)
 3d50 9 77 182
 3d59 8 79 182
 3d61 c 81 182
@@ -1448,7 +1448,7 @@ FUNC 3d50 a4 0 _removelocaleref(threadlocaleinfostruct*)
 3de1 f 103 182
 3df0 3 106 182
 3df3 1 107 182
-FUNC 3df4 75 0 _updatetlocinfo()
+FUNC 3df4 75 0 __updatetlocinfo()
 3df4 6 282 182
 3dfa 8 284 182
 3e02 18 286 182
@@ -1460,7 +1460,7 @@ FUNC 3df4 75 0 _updatetlocinfo()
 3e58 8 303 182
 3e60 3 306 182
 3e63 6 307 182
-FUNC 3e6c 62 0 updatetlocinfoEx_nolock(threadlocaleinfostruct**, threadlocaleinfostruct*)
+FUNC 3e6c 62 0 _updatetlocinfoEx_nolock(threadlocaleinfostruct**, threadlocaleinfostruct*)
 3e6c d 217 182
 3e79 a 220 182
 3e83 3 223 182
@@ -1474,7 +1474,7 @@ FUNC 3e6c 62 0 updatetlocinfoEx_nolock(threadlocaleinfostruct**, threadlocaleinf
 3ebc 5 254 182
 3ec1 2 221 182
 3ec3 b 255 182
-FUNC 3ed0 28 0 _initmbctable()
+FUNC 3ed0 28 0 __initmbctable()
 3ed0 4 854 257
 3ed4 9 864 257
 3edd a 865 257
@@ -1556,7 +1556,7 @@ FUNC 40b0 1e1 0 setSBUpLow(threadmbcinfostruct*)
 425d 7 484 257
 4264 9 472 257
 426d 24 486 257
-FUNC 4294 ba 0 _updatetmbcinfo()
+FUNC 4294 ba 0 __updatetmbcinfo()
 4294 a 507 257
 429e 8 510 257
 42a6 18 511 257
@@ -1572,7 +1572,7 @@ FUNC 4294 ba 0 _updatetmbcinfo()
 4338 8 550 257
 4340 3 553 257
 4343 b 554 257
-FUNC 4350 244 0 setmbcp(int)
+FUNC 4350 244 0 _setmbcp(int)
 4350 1b 585 257
 436b 4 586 257
 436f 8 590 257
@@ -1615,7 +1615,7 @@ FUNC 4350 244 0 setmbcp(int)
 4571 5 684 257
 4576 3 693 257
 4579 1b 694 257
-FUNC 4594 2ae 0 setmbcp_nolock(int, threadmbcinfostruct*)
+FUNC 4594 2ae 0 _setmbcp_nolock(int, threadmbcinfostruct*)
 4594 28 697 257
 45bc 5 704 257
 45c1 8 707 257
@@ -1663,14 +1663,14 @@ FUNC 4594 2ae 0 setmbcp_nolock(int, threadmbcinfostruct*)
 4812 8 747 257
 481a 2 748 257
 481c 26 813 257
-FUNC 4850 44 0 FindPESection(unsigned char*, unsigned long long)
+FUNC 4850 44 0 _FindPESection(unsigned char*, unsigned long long)
 4850 4 93 185
 4854 1f 102 185
 4873 12 105 185
 4885 c 102 185
 4891 2 117 185
 4893 1 118 185
-FUNC 48a0 4d 0 IsNonwritableInCurrentImage(unsigned char*)
+FUNC 48a0 4d 0 _IsNonwritableInCurrentImage(unsigned char*)
 48a0 d 143 185
 48ad 13 158 185
 48c0 3 168 185
@@ -1679,7 +1679,7 @@ FUNC 48a0 4d 0 IsNonwritableInCurrentImage(unsigned char*)
 48d3 d 179 185
 48e0 2 187 185
 48e2 b 189 185
-FUNC 48f0 2e 0 ValidateImageBase(unsigned char*)
+FUNC 48f0 2e 0 _ValidateImageBase(unsigned char*)
 48f0 3 38 185
 48f3 a 44 185
 48fd 2 46 185
@@ -1688,7 +1688,7 @@ FUNC 48f0 2e 0 ValidateImageBase(unsigned char*)
 4907 a 52 185
 4911 c 56 185
 491d 1 62 185
-FUNC 4920 43 0 _onexitinit()
+FUNC 4920 43 0 __onexitinit()
 4920 6 201 183
 4926 d 204 183
 4933 1a 205 183
@@ -1697,7 +1697,7 @@ FUNC 4920 43 0 _onexitinit()
 4957 4 214 183
 495b 2 216 183
 495d 6 217 183
-FUNC 4964 10a 0 onexit(int (*)())
+FUNC 4964 10a 0 _onexit(int (*)())
 4964 1c 81 183
 4980 6 84 183
 4986 c6 87 183
@@ -1708,27 +1708,27 @@ FUNC 4a70 17 0 atexit(void (*)())
 4a70 4 161 183
 4a74 e 162 183
 4a82 5 163 183
-FUNC 4a88 39 0 initp_misc_cfltcvt_tab(<NoType>)
+FUNC 4a88 39 0 _initp_misc_cfltcvt_tab(<NoType>)
 4a88 a 54 204
 4a92 9 56 204
 4a9b 1b 58 204
 4ab6 b 60 204
-FUNC 4ac4 33 0 callnewh(unsigned long long)
+FUNC 4ac4 33 0 _callnewh(unsigned long long)
 4ac4 9 131 230
 4acd d 133 230
 4ada e 135 230
 4ae8 7 138 230
 4aef 2 136 230
 4af1 6 139 230
-FUNC 4af8 8 0 initp_heap_handler(void*)
+FUNC 4af8 8 0 _initp_heap_handler(void*)
 4af8 7 32 230
 4aff 1 33 230
-FUNC 4b00 8 0 initp_misc_purevirt(void*)
+FUNC 4b00 8 0 _initp_misc_purevirt(void*)
 4b00 7 180 176
 4b07 1 181 176
-FUNC 4b08 e 0 _get_sigabrt()
+FUNC 4b08 e 0 __get_sigabrt()
 4b08 e 671 187
-FUNC 4b18 1d 0 initp_misc_winsig(void*)
+FUNC 4b18 1d 0 _initp_misc_winsig(void*)
 4b18 7 58 187
 4b1f 7 59 187
 4b26 7 60 187
@@ -1783,10 +1783,10 @@ FUNC 4b38 233 0 raise(int)
 4d44 a 601 187
 4d4e 5 604 187
 4d53 18 605 187
-FUNC 4d6c 8 0 initp_misc_rand_s(void*)
+FUNC 4d6c 8 0 _initp_misc_rand_s(void*)
 4d6c 7 53 197
 4d73 1 54 197
-FUNC 4d74 98 0 _initstdio()
+FUNC 4d74 98 0 __initstdio()
 4d74 a 109 206
 4d7e 11 118 206
 4d8f 7 119 206
@@ -1799,7 +1799,7 @@ FUNC 4d74 98 0 _initstdio()
 4df6 9 141 206
 4dff 2 144 206
 4e01 b 145 206
-FUNC 4e0c 30 0 _endstdio()
+FUNC 4e0c 30 0 __endstdio()
 4e0c 4 173 206
 4e10 5 175 206
 4e15 9 178 206
@@ -1807,7 +1807,7 @@ FUNC 4e0c 30 0 _endstdio()
 4e23 c 180 206
 4e2f 8 181 206
 4e37 5 182 206
-FUNC 4e3c 65 0 lock_file(_iobuf*)
+FUNC 4e3c 65 0 _lock_file(_iobuf*)
 4e3c 9 203 206
 4e45 18 208 206
 4e5d 29 213 206
@@ -1816,7 +1816,7 @@ FUNC 4e3c 65 0 lock_file(_iobuf*)
 4e91 4 223 206
 4e95 5 224 206
 4e9a 7 223 206
-FUNC 4ea4 31 0 lock_file2(int, void*)
+FUNC 4ea4 31 0 _lock_file2(int, void*)
 4ea4 9 246 206
 4ead 5 251 206
 4eb2 8 256 206
@@ -1825,12 +1825,12 @@ FUNC 4ea4 31 0 lock_file2(int, void*)
 4ec5 4 266 206
 4ec9 5 267 206
 4ece 7 266 206
-FUNC 4ed8 4e 0 unlock_file(_iobuf*)
+FUNC 4ed8 4e 0 _unlock_file(_iobuf*)
 4ed8 18 293 206
 4ef0 5 299 206
 4ef5 26 300 206
 4f1b b 308 206
-FUNC 4f28 1d 0 unlock_file2(int, void*)
+FUNC 4f28 1d 0 _unlock_file2(int, void*)
 4f28 5 336 206
 4f2d 5 342 206
 4f32 8 343 206
@@ -1840,7 +1840,7 @@ FUNC 4f48 79 0 x_ismbbtype_l(localeinfo_struct*, unsigned int, int, int)
 4f59 13 224 256
 4f6c 45 232 256
 4fb1 10 233 256
-FUNC 4fc4 12 0 ismbblead(unsigned int)
+FUNC 4fc4 12 0 _ismbblead(unsigned int)
 4fc4 12 182 256
 FUNC 4fd8 85 0 wcscat_s(unsigned short*, unsigned long long, wchar_t const*)
 4fd8 6 13 221
@@ -1899,7 +1899,7 @@ FUNC 50e8 cc 0 wcsncpy_s(unsigned short*, unsigned long long, wchar_t const*, un
 519c 6 59 219
 51a2 3 61 219
 51a5 f 62 219
-FUNC 51b4 273 0 _crtMessageBoxW(wchar_t const*, wchar_t const*, unsigned int)
+FUNC 51b4 273 0 __crtMessageBoxW(wchar_t const*, wchar_t const*, unsigned int)
 51b4 21 91 203
 51d5 e 99 203
 51e3 5 106 203
@@ -1945,12 +1945,12 @@ FUNC 51b4 273 0 _crtMessageBoxW(wchar_t const*, wchar_t const*, unsigned int)
 53f9 10 250 203
 5409 2 255 203
 540b 1c 258 203
-FUNC 5428 1d 0 _GSHandlerCheck(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
+FUNC 5428 1d 0 __GSHandlerCheck(_EXCEPTION_RECORD*, void*, _CONTEXT*, _DISPATCHER_CONTEXT*)
 5428 4 75 36
 542c f 84 36
 543b 5 91 36
 5440 5 92 36
-FUNC 5448 63 0 _GSHandlerCheckCommon(void*, _DISPATCHER_CONTEXT*, _GS_HANDLER_DATA*)
+FUNC 5448 63 0 __GSHandlerCheckCommon(void*, _DISPATCHER_CONTEXT*, _GS_HANDLER_DATA*)
 5448 6 126 36
 544e d 140 36
 545b 9 149 36
@@ -1963,7 +1963,7 @@ FUNC 5448 63 0 _GSHandlerCheckCommon(void*, _DISPATCHER_CONTEXT*, _GS_HANDLER_DA
 549e 3 185 36
 54a1 5 186 36
 54a6 5 185 36
-FUNC 54c0 1f 0 _security_check_cookie()
+FUNC 54c0 1f 0 __security_check_cookie()
 54c0 7 47 1
 54c7 2 48 1
 54c9 4 49 1
@@ -1972,7 +1972,7 @@ FUNC 54c0 1f 0 _security_check_cookie()
 54d5 1 53 1
 54d6 4 61 1
 54da 5 65 1
-FUNC 54e0 8 0 _crt_debugger_hook(int)
+FUNC 54e0 8 0 __crt_debugger_hook(int)
 54e0 7 60 155
 54e7 1 61 155
 FUNC 5500 22a 0 memset()
@@ -2135,7 +2135,7 @@ FUNC 5784 d3 0 realloc(void*, unsigned long long)
 5839 2 112 131
 583b 17 103 131
 5852 5 105 131
-FUNC 5858 9a 0 calloc_impl(unsigned long long, unsigned long long, int*)
+FUNC 5858 9a 0 _calloc_impl(unsigned long long, unsigned long long, int*)
 5858 10 21 119
 5868 5 26 119
 586d 1d 28 119
@@ -2152,7 +2152,7 @@ FUNC 5858 9a 0 calloc_impl(unsigned long long, unsigned long long, int*)
 58dc 5 52 119
 58e1 6 53 119
 58e7 b 69 119
-FUNC 58f4 10a 0 _free_lconv_mon(lconv*)
+FUNC 58f4 10a 0 __free_lconv_mon(lconv*)
 58f4 e 271 177
 5902 3 270 177
 5905 d 274 177
@@ -2182,7 +2182,7 @@ FUNC 58f4 10a 0 _free_lconv_mon(lconv*)
 59e3 10 310 177
 59f3 5 311 177
 59f8 6 312 177
-FUNC 5a00 6c 0 _free_lconv_num(lconv*)
+FUNC 5a00 6c 0 __free_lconv_num(lconv*)
 5a00 a 218 178
 5a0a 3 217 178
 5a0d c 221 178
@@ -2196,7 +2196,7 @@ FUNC 5a00 6c 0 _free_lconv_num(lconv*)
 5a54 d 233 178
 5a61 5 234 178
 5a66 6 235 178
-FUNC 5a6c 3fa 0 _free_lc_time(__lc_time_data*)
+FUNC 5a6c 3fa 0 __free_lc_time(__lc_time_data*)
 5a6c e 231 180
 5a7a 3 230 180
 5a7d 9 234 180
@@ -2318,7 +2318,7 @@ FUNC 5e68 2ec 0 __crtLCMapStringA_stat(localeinfo_struct*, wchar_t const*, unsig
 611b 11 242 259
 612c 2 244 259
 612e 26 245 259
-FUNC 6154 96 0 _crtLCMapStringA(localeinfo_struct*, wchar_t const*, unsigned long, char const*, int, char*, int, int, int)
+FUNC 6154 96 0 __crtLCMapStringA(localeinfo_struct*, wchar_t const*, unsigned long, char const*, int, char*, int, int, int)
 6154 12 258 259
 6166 13 259 259
 6179 5f 271 259
@@ -2337,19 +2337,19 @@ FUNC 61ec 176 0 __crtGetStringTypeA_stat(localeinfo_struct*, unsigned long, char
 6329 11 115 260
 633a 2 117 260
 633c 26 118 260
-FUNC 6364 7c 0 _crtGetStringTypeA(localeinfo_struct*, unsigned long, char const*, int, unsigned short*, int, int)
+FUNC 6364 7c 0 __crtGetStringTypeA(localeinfo_struct*, unsigned long, char const*, int, unsigned short*, int, int)
 6364 11 129 260
 6375 13 130 260
 6388 48 140 260
 63d0 10 141 260
-FUNC 63e0 39 0 msize(void*)
+FUNC 63e0 39 0 _msize(void*)
 63e0 4 39 130
 63e4 19 43 130
 63fd 5 50 130
 6402 c 46 130
 640e 4 50 130
 6412 7 46 130
-FUNC 641c a 0 fptrap()
+FUNC 641c a 0 _fptrap()
 641c a 47 275
 FUNC 6428 8a 0 GetTableIndexFromLocaleName(wchar_t const*)
 6428 1c 52 190
@@ -2366,7 +2366,7 @@ FUNC 6428 8a 0 GetTableIndexFromLocaleName(wchar_t const*)
 6487 5 71 190
 648c b 63 190
 6497 1b 72 190
-FUNC 64b4 32 0 _crtDownlevelLocaleNameToLCID(wchar_t const*)
+FUNC 64b4 32 0 __crtDownlevelLocaleNameToLCID(wchar_t const*)
 64b4 4 107 190
 64b8 5 110 190
 64bd 5 113 190
@@ -2374,13 +2374,13 @@ FUNC 64b4 32 0 _crtDownlevelLocaleNameToLCID(wchar_t const*)
 64d0 f 118 190
 64df 2 116 190
 64e1 5 119 190
-FUNC 64e8 8f 0 _crtLCMapStringEx(wchar_t const*, unsigned long, wchar_t const*, int, unsigned short*, int)
+FUNC 64e8 8f 0 __crtLCMapStringEx(wchar_t const*, unsigned long, wchar_t const*, int, unsigned short*, int)
 64e8 10 325 190
 64f8 18 327 190
 6510 2a 329 190
 653a 2d 333 190
 6567 10 334 190
-FUNC 6578 55 0 _wcsnicmp_ascii(wchar_t const*, wchar_t const*, unsigned long long)
+FUNC 6578 55 0 __wcsnicmp_ascii(wchar_t const*, wchar_t const*, unsigned long long)
 6578 9 30 190
 6581 5 32 190
 6586 3 40 190
@@ -2754,19 +2754,19 @@ FUNC 65e0 565 0 memcpy()
 6b3e 3 779 234
 6b41 3 780 234
 6b44 1 781 234
-FUNC 6b48 26 0 fileno(_iobuf*)
+FUNC 6b48 26 0 _fileno(_iobuf*)
 6b48 4 40 205
 6b4c 1a 41 205
 6b66 3 42 205
 6b69 5 43 205
-FUNC 6b70 5f 0 isatty(int)
+FUNC 6b70 5f 0 _isatty(int)
 6b70 4 37 139
 6b74 12 39 139
 6b86 c 40 139
 6b92 26 43 139
 6bb8 12 40 139
 6bca 5 44 139
-FUNC 6bd0 4c 0 fflush_nolock(_iobuf*)
+FUNC 6bd0 4c 0 _fflush_nolock(_iobuf*)
 6bd0 9 97 211
 6bd9 5 101 211
 6bde 5 116 211
@@ -2777,7 +2777,7 @@ FUNC 6bd0 4c 0 fflush_nolock(_iobuf*)
 6bff 15 112 211
 6c14 2 115 211
 6c16 6 116 211
-FUNC 6c1c 79 0 flush(_iobuf*)
+FUNC 6c1c 79 0 _flush(_iobuf*)
 6c1c f 142 211
 6c2b 20 152 211
 6c4b 17 154 211
@@ -2790,7 +2790,7 @@ FUNC 6c1c 79 0 flush(_iobuf*)
 6c7c 4 168 211
 6c80 2 170 211
 6c82 13 171 211
-FUNC 6c98 a 0 flushall()
+FUNC 6c98 a 0 _flushall()
 6c98 a 194 211
 FUNC 6ca4 e6 0 flsall(int)
 6ca4 1c 228 211
@@ -2812,7 +2812,7 @@ FUNC 6ca4 e6 0 flsall(int)
 6d5d a 283 211
 6d67 9 286 211
 6d70 1a 290 211
-FUNC 6d8c a8 0 fcloseall()
+FUNC 6d8c a8 0 _fcloseall()
 6d8c f 43 209
 6d9b 2 44 209
 6d9d 9 47 209
@@ -2828,7 +2828,7 @@ FUNC 6d8c a8 0 fcloseall()
 6e18 a 70 209
 6e22 2 73 209
 6e24 10 74 209
-FUNC 6e34 49 0 _raise_securityfailure(_EXCEPTION_POINTERS*)
+FUNC 6e34 49 0 __raise_securityfailure(_EXCEPTION_POINTERS*)
 6e34 9 64 160
 6e3d 6 66 160
 6e43 10 67 160
@@ -2838,7 +2838,7 @@ FUNC 6e34 49 0 _raise_securityfailure(_EXCEPTION_POINTERS*)
 6e6e 5 85 160
 6e73 5 86 160
 6e78 5 85 160
-FUNC 6e80 d1 0 _report_gsfailure(unsigned long long)
+FUNC 6e80 d1 0 __report_gsfailure(unsigned long long)
 6e80 9 129 160
 6e89 e 149 160
 6e97 7 151 160
@@ -2855,7 +2855,7 @@ FUNC 6e80 d1 0 _report_gsfailure(unsigned long long)
 6f2b 15 229 160
 6f40 c 236 160
 6f4c 5 241 160
-FUNC 6f54 1a4 0 _isa_available_init(<NoType>)
+FUNC 6f54 1a4 0 __isa_available_init(<NoType>)
 6f54 14 63 213
 6f68 1f 75 213
 6f87 23 81 213
@@ -2878,14 +2878,14 @@ FUNC 6f54 1a4 0 _isa_available_init(<NoType>)
 70cd a 140 213
 70d7 a 141 213
 70e1 17 147 213
-FUNC 70f8 47 0 locterm()
+FUNC 70f8 47 0 _locterm()
 70f8 6 186 196
 70fe 10 187 196
 710e b 188 196
 7119 16 191 196
 712f a 195 196
 7139 6 198 196
-FUNC 7150 4e 0 _chkstk()
+FUNC 7150 4e 0 __chkstk()
 7150 4 71 277
 7154 4 83 277
 7158 5 84 277
@@ -2905,7 +2905,7 @@ FUNC 7150 4e 0 _chkstk()
 7194 5 113 277
 7199 4 114 277
 719d 1 115 277
-FUNC 71a0 d7 0 commit(int)
+FUNC 71a0 d7 0 _commit(int)
 71a0 14 39 137
 71b4 15 43 137
 71c9 10 44 137
@@ -2924,7 +2924,7 @@ FUNC 71a0 d7 0 commit(int)
 7252 4 75 137
 7256 13 44 137
 7269 e 76 137
-FUNC 7278 e1 0 write(int, void const*, unsigned int)
+FUNC 7278 e1 0 _write(int, void const*, unsigned int)
 7278 1e 61 144
 7296 1d 65 144
 72b3 c 66 144
@@ -2940,7 +2940,7 @@ FUNC 7278 e1 0 write(int, void const*, unsigned int)
 7328 4 85 144
 732c 1b 66 144
 7347 12 86 144
-FUNC 735c 7f1 0 write_nolock(int, void const*, unsigned int)
+FUNC 735c 7f1 0 _write_nolock(int, void const*, unsigned int)
 735c 36 94 144
 7392 11 95 144
 73a3 3 96 144
@@ -3064,7 +3064,7 @@ FUNC 735c 7f1 0 write_nolock(int, void const*, unsigned int)
 7b1a 5 501 144
 7b1f 4 506 144
 7b23 2a 507 144
-FUNC 7b50 7a 0 fclose_nolock(_iobuf*)
+FUNC 7b50 7a 0 _fclose_nolock(_iobuf*)
 7b50 a 85 210
 7b5a 6 87 210
 7b60 19 89 210
@@ -3091,7 +3091,7 @@ FUNC 7bcc 66 0 fclose(_iobuf*)
 7c1d 8 59 210
 7c25 2 63 210
 7c27 b 64 210
-FUNC 7c34 db 0 isctype_l(int, int, localeinfo_struct*)
+FUNC 7c34 db 0 _isctype_l(int, int, localeinfo_struct*)
 7c34 16 114 244
 7c4a c 118 244
 7c56 a 121 244
@@ -3109,7 +3109,7 @@ FUNC 7c34 db 0 isctype_l(int, int, localeinfo_struct*)
 7cd2 14 145 244
 7ce6 18 148 244
 7cfe 11 149 244
-FUNC 7d10 cf 0 _crt_atoflt_l(_CRT_FLOAT*, char const*, localeinfo_struct*, char**)
+FUNC 7d10 cf 0 __crt_atoflt_l(_CRT_FLOAT*, char const*, localeinfo_struct*, char**)
 7d10 20 125 242
 7d30 10 132 242
 7d40 30 139 242
@@ -3124,7 +3124,7 @@ FUNC 7d10 cf 0 _crt_atoflt_l(_CRT_FLOAT*, char const*, localeinfo_struct*, char*
 7dad 5 152 242
 7db2 15 155 242
 7dc7 18 156 242
-FUNC 7de0 c7 0 atodbl_l(_CRT_DOUBLE*, char*, localeinfo_struct*)
+FUNC 7de0 c7 0 _atodbl_l(_CRT_DOUBLE*, char*, localeinfo_struct*)
 7de0 22 40 242
 7e02 d 47 242
 7e0f 2e 55 242
@@ -3137,11 +3137,11 @@ FUNC 7de0 c7 0 atodbl_l(_CRT_DOUBLE*, char*, localeinfo_struct*)
 7e6f 5 65 242
 7e74 15 68 242
 7e89 1e 69 242
-FUNC 7ea8 8 0 atoflt_l(_CRT_FLOAT*, char const*, localeinfo_struct*)
+FUNC 7ea8 8 0 _atoflt_l(_CRT_FLOAT*, char const*, localeinfo_struct*)
 7ea8 8 167 242
-FUNC 7eb0 5 0 fpmath(int)
+FUNC 7eb0 5 0 _fpmath(int)
 7eb0 5 64 291
-FUNC 7eb8 86 0 cfltcvt_init(<NoType>)
+FUNC 7eb8 86 0 _cfltcvt_init(<NoType>)
 7eb8 15 84 291
 7ecd 15 85 291
 7ee2 7 86 291
@@ -3219,7 +3219,7 @@ FUNC 7f50 c7 0 memcmp()
 8011 2 177 233
 8013 3 178 233
 8016 1 179 233
-FUNC 8018 98 0 _lock_fhandle(int)
+FUNC 8018 98 0 __lock_fhandle(int)
 8018 15 436 142
 802d 1c 437 142
 8049 7 443 142
@@ -3231,7 +3231,7 @@ FUNC 8018 98 0 _lock_fhandle(int)
 8084 11 458 142
 8095 5 461 142
 809a 16 462 142
-FUNC 80b0 aa 0 free_osfhnd(int)
+FUNC 80b0 aa 0 _free_osfhnd(int)
 80b0 10 257 142
 80c0 36 260 142
 80f6 9 263 142
@@ -3247,7 +3247,7 @@ FUNC 80b0 aa 0 free_osfhnd(int)
 813e 8 281 142
 8146 3 282 142
 8149 11 284 142
-FUNC 815c 74 0 get_osfhandle(int)
+FUNC 815c 74 0 _get_osfhandle(int)
 815c 4 307 142
 8160 1a 308 142
 817a c 309 142
@@ -3255,9 +3255,9 @@ FUNC 815c 74 0 get_osfhandle(int)
 81a9 6 312 142
 81af 1c 309 142
 81cb 5 313 142
-FUNC 81d0 2a 0 unlock_fhandle(int)
+FUNC 81d0 2a 0 _unlock_fhandle(int)
 81d0 2a 484 142
-FUNC 81fc 43 0 isleadbyte_l(int, localeinfo_struct*)
+FUNC 81fc 43 0 _isleadbyte_l(int, localeinfo_struct*)
 81fc 8 55 239
 8204 a 56 239
 820e 2b 57 239
@@ -3266,7 +3266,7 @@ FUNC 8240 45 0 isleadbyte(int)
 8240 8 63 239
 8248 37 64 239
 827f 6 65 239
-FUNC 8288 93 0 lseeki64_nolock(int, long long, int)
+FUNC 8288 93 0 _lseeki64_nolock(int, long long, int)
 8288 18 106 140
 82a0 d 116 140
 82ad b 118 140
@@ -3277,7 +3277,7 @@ FUNC 8288 93 0 lseeki64_nolock(int, long long, int)
 82e5 21 132 140
 8306 5 133 140
 830b 10 134 140
-FUNC 831c 151 0 mbtowc_l(wchar_t*, char const*, unsigned long long, localeinfo_struct*)
+FUNC 831c 151 0 _mbtowc_l(wchar_t*, char const*, unsigned long long, localeinfo_struct*)
 831c 19 55 245
 8335 16 56 245
 834b 5 61 245
@@ -3299,7 +3299,7 @@ FUNC 831c 151 0 mbtowc_l(wchar_t*, char const*, unsigned long long, localeinfo_s
 8453 1a 113 245
 FUNC 8470 8 0 mbtowc(wchar_t*, char const*, unsigned long long)
 8470 8 124 245
-FUNC 8478 59 0 putwch_nolock(wchar_t)
+FUNC 8478 59 0 _putwch_nolock(wchar_t)
 8478 9 84 149
 8481 d 87 149
 848e c 88 149
@@ -3308,7 +3308,7 @@ FUNC 8478 59 0 putwch_nolock(wchar_t)
 84a7 20 99 149
 84c7 5 104 149
 84cc 5 105 149
-FUNC 84d4 c3 0 close(int)
+FUNC 84d4 c3 0 _close(int)
 84d4 14 41 134
 84e8 1d 45 134
 8505 c 46 134
@@ -3323,7 +3323,7 @@ FUNC 84d4 c3 0 close(int)
 856a 4 64 134
 856e 1b 46 134
 8589 e 65 134
-FUNC 8598 ba 0 close_nolock(int)
+FUNC 8598 ba 0 _close_nolock(int)
 8598 d 71 134
 85a5 5c 92 134
 8601 a 98 134
@@ -3335,7 +3335,7 @@ FUNC 8598 ba 0 close_nolock(int)
 8640 5 107 134
 8645 2 110 134
 8647 b 111 134
-FUNC 8654 37 0 freebuf(_iobuf*)
+FUNC 8654 37 0 _freebuf(_iobuf*)
 8654 6 45 207
 865a f 48 207
 8669 9 50 207
@@ -3343,19 +3343,19 @@ FUNC 8654 37 0 freebuf(_iobuf*)
 8679 9 53 207
 8682 3 54 207
 8685 6 56 207
-FUNC 8690 5b6 0 ld12tod(_LDBL12*, _CRT_DOUBLE*)
+FUNC 8690 5b6 0 _ld12tod(_LDBL12*, _CRT_DOUBLE*)
 8690 2d 598 290
 86bd 33 599 290
 86f0 4 598 290
 86f4 528 599 290
 8c1c 2a 600 290
-FUNC 8c48 5b6 0 ld12tof(_LDBL12*, _CRT_FLOAT*)
+FUNC 8c48 5b6 0 _ld12tof(_LDBL12*, _CRT_FLOAT*)
 8c48 2d 618 290
 8c75 33 619 290
 8ca8 4 618 290
 8cac 528 619 290
 91d4 2a 620 290
-FUNC 9200 861 0 _strgtold12_l(_LDBL12*, char const**, char const*, int, int, int, int, localeinfo_struct*)
+FUNC 9200 861 0 __strgtold12_l(_LDBL12*, char const**, char const*, int, int, int, int, localeinfo_struct*)
 9200 2a 80 284
 922a 51 126 284
 927b 22 129 284
@@ -3493,11 +3493,11 @@ FUNC 9200 861 0 _strgtold12_l(_LDBL12*, char const**, char const*, int, int, int
 9a23 9 455 284
 9a2c e 457 284
 9a3a 27 458 284
-FUNC 9a64 24 0 cfltcvt(double*, char*, unsigned long long, int, int, int)
+FUNC 9a64 24 0 _cfltcvt(double*, char*, unsigned long long, int, int, int)
 9a64 4 913 278
 9a68 1b 914 278
 9a83 5 915 278
-FUNC 9a88 7e 0 cfltcvt_l(double*, char*, unsigned long long, int, int, int, localeinfo_struct*)
+FUNC 9a88 7e 0 _cfltcvt_l(double*, char*, unsigned long long, int, int, int, localeinfo_struct*)
 9a88 13 897 278
 9a9b 6 902 278
 9aa1 1a 903 278
@@ -3506,7 +3506,7 @@ FUNC 9a88 7e 0 cfltcvt_l(double*, char*, unsigned long long, int, int, int, loca
 9ae3 2 906 278
 9ae5 1c 901 278
 9b01 5 910 278
-FUNC 9b08 3b0 0 cftoa_l(double*, char*, unsigned long long, int, int, localeinfo_struct*)
+FUNC 9b08 3b0 0 _cftoa_l(double*, char*, unsigned long long, int, int, localeinfo_struct*)
 9b08 1f 415 278
 9b27 2a 426 278
 9b51 9 428 278
@@ -3624,7 +3624,7 @@ a056 f 340 278
 a065 15 344 278
 a07a 21 345 278
 a09b 16 293 278
-FUNC a0b4 f7 0 cftoe_l(double*, char*, unsigned long long, int, int, localeinfo_struct*)
+FUNC a0b4 f7 0 _cftoe_l(double*, char*, unsigned long long, int, int, localeinfo_struct*)
 a0b4 1b 354 278
 a0cf 23 362 278
 a0f2 18 366 278
@@ -3663,7 +3663,7 @@ a2ad 1e 701 278
 a2cb 10 702 278
 a2db 15 706 278
 a2f0 1d 707 278
-FUNC a310 d1 0 cftof_l(double*, char*, unsigned long long, int, localeinfo_struct*)
+FUNC a310 d1 0 _cftof_l(double*, char*, unsigned long long, int, localeinfo_struct*)
 a310 18 736 278
 a328 23 744 278
 a34b 15 748 278
@@ -3674,7 +3674,7 @@ a3a1 3 758 278
 a3a4 2 759 278
 a3a6 25 762 278
 a3cb 16 765 278
-FUNC a3e4 134 0 cftog_l(double*, char*, unsigned long long, int, int, localeinfo_struct*)
+FUNC a3e4 134 0 _cftog_l(double*, char*, unsigned long long, int, int, localeinfo_struct*)
 a3e4 1d 795 278
 a401 23 810 278
 a424 18 813 278
@@ -3693,9 +3693,9 @@ a4a1 3 846 278
 a4a4 27 849 278
 a4cb 32 840 278
 a4fd 1b 851 278
-FUNC a518 7 0 cropzeros(char*)
+FUNC a518 7 0 _cropzeros(char*)
 a518 7 140 278
-FUNC a520 96 0 cropzeros_l(char*, localeinfo_struct*)
+FUNC a520 96 0 _cropzeros_l(char*, localeinfo_struct*)
 a520 9 144 278
 a529 a 145 278
 a533 1b 148 278
@@ -3710,9 +3710,9 @@ a57c 10 160 278
 a58c 3 161 278
 a58f e 163 278
 a59d 19 165 278
-FUNC a5b8 8 0 fassign(int, char*, char*)
+FUNC a5b8 8 0 _fassign(int, char*, char*)
 a5b8 8 215 278
-FUNC a5c0 40 0 fassign_l(int, char*, char*, localeinfo_struct*)
+FUNC a5c0 40 0 _fassign_l(int, char*, char*, localeinfo_struct*)
 a5c0 c 175 278
 a5cc 14 203 278
 a5e0 8 204 278
@@ -3720,9 +3720,9 @@ a5e8 2 205 278
 a5ea a 206 278
 a5f4 6 207 278
 a5fa 6 211 278
-FUNC a600 7 0 forcdecpt(char*)
+FUNC a600 7 0 _forcdecpt(char*)
 a600 7 74 278
-FUNC a608 7f 0 forcdecpt_l(char*, localeinfo_struct*)
+FUNC a608 7f 0 _forcdecpt_l(char*, localeinfo_struct*)
 a608 9 78 278
 a611 a 79 278
 a61b d 83 278
@@ -3736,18 +3736,18 @@ a662 2 106 278
 a664 2 107 278
 a666 9 108 278
 a66f 18 109 278
-FUNC a688 12 0 positive(double*)
+FUNC a688 12 0 _positive(double*)
 a688 11 170 278
 a699 1 171 278
-FUNC a69c 20 0 _termconout()
+FUNC a69c 20 0 __termconout()
 a69c 15 83 146
 a6b1 6 85 146
 a6b7 5 87 146
-FUNC a6bc 3b 0 _initconout()
+FUNC a6bc 3b 0 __initconout()
 a6bc 4 53 146
 a6c0 32 60 146
 a6f2 5 61 146
-FUNC a6f8 222 0 _mtold12(char*, unsigned int, _LDBL12*)
+FUNC a6f8 222 0 __mtold12(char*, unsigned int, _LDBL12*)
 a6f8 18 34 288
 a710 4 38 288
 a714 5 39 288
@@ -3809,7 +3809,7 @@ a922 c 140 238
 a92e 10 142 238
 a93e 52 146 238
 a990 6 148 238
-FUNC a998 152 0 tolower_l(int, localeinfo_struct*)
+FUNC a998 152 0 _tolower_l(int, localeinfo_struct*)
 a998 15 70 250
 a9ad 9 74 250
 a9b6 8 77 250
@@ -3872,7 +3872,7 @@ ac3b 6 207 214
 ac41 9 209 214
 ac4a 4 213 214
 ac4e 2 214 214
-FUNC ac50 cb 0 fptostr(char*, unsigned long long, int, _strflt*)
+FUNC ac50 cb 0 _fptostr(char*, unsigned long long, int, _strflt*)
 ac50 d 50 58
 ac5d 4 52 58
 ac61 20 55 58
@@ -3893,7 +3893,7 @@ acf5 2 101 58
 acf7 17 105 58
 ad0e 2 108 58
 ad10 b 109 58
-FUNC ad1c cd 0 _dtold(_LDOUBLE*, double*)
+FUNC ad1c cd 0 __dtold(_LDOUBLE*, double*)
 ad1c 5 51 294
 ad21 8 58 294
 ad29 1b 60 294
@@ -3917,7 +3917,7 @@ adc2 6 93 294
 adc8 12 94 294
 adda 4 97 294
 adde b 99 294
-FUNC adec b7 0 fltout2(_CRT_DOUBLE, _strflt*, char*, unsigned long long)
+FUNC adec b7 0 _fltout2(_CRT_DOUBLE, _strflt*, char*, unsigned long long)
 adec 26 21 294
 ae12 13 25 294
 ae25 26 26 294


### PR DESCRIPTION
When we have a procedure symbol, and then later find a public symbol
at the same address, we try to get the parameter size from the public
symbol's name. But we didn't only got the parameter size, we also
overwrote the function name with the undecorated function name.
This overwriting is not necessary:

 - If the function has a non-zero TypeIndex, we will use the TypeFormatter
   to add parameters, and we want to add those to the original function
   name, not to the undecorated name from the PUBLIC.
 - If the function has a zero TypeIndex, we will call FuncName::get_unknown
   again, and it will get undecorated at that point.

Storing the undecorated name here meant that some functions lost their
leading underscores.