### PR TITLE
Update to clap v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,17 +41,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,25 +144,23 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "0acbd8d28a0a60d7108d7ae850af6ba34cf2d1257fc646980e5f97ce14275966"
 dependencies = [
- "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -392,6 +379,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -619,6 +627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,10 +751,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e394faa0efb47f9f227f1cd89978f854542b318a6f64fa695489c9c993056656"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itoa"
@@ -783,6 +822,12 @@ name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
 name = "lock_api"
@@ -926,7 +971,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1178,6 +1223,20 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustix"
+version = "0.36.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustls"
@@ -1502,12 +1561,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ http = ["reqwest", "futures", "tokio"]
 anyhow = "1.0"
 bitflags = "1.3"
 cab = "0.4"
-clap = { version = "3", optional = true, features = ["cargo"] }
+clap = { version = "4", optional = true, features = ["cargo"] }
 crossbeam = "0.8.2"
 dirs = "4.0"
 futures = { version = "0.3", optional = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,39 +26,33 @@ fn cli() -> Command {
             .help("Files to dump (.dll, .exe, .pdb, .pd_, .so, .dbg)")
             .required(true)
             .num_args(1..)
-            .action(ArgAction::Set)
     )
     .arg(
         Arg::new("output")
             .help("Output file or - for stdout")
             .short('o')
             .long("output")
-            .action(ArgAction::Set),
     )
     .arg(
         Arg::new("store")
             .help("Store output file as FILENAME.pdb/DEBUG_ID/FILENAME.sym in the given directory")
             .short('s')
             .long("store")
-            .action(ArgAction::Set),
     )
     .arg(
         Arg::new("debug_id")
             .help("Get the pdb file passed as argument from the cache or from symbol server using the debug id")
             .long("debug-id")
-            .action(ArgAction::Set),
     )
     .arg(
         Arg::new("code_id")
             .help("Get the dll/exe file passed as argument from the cache or from symbol server using the code id")
             .long("code-id")
-            .action(ArgAction::Set),
     )
     .arg(
         Arg::new("symbol-server")
             .help("Symbol Server configuration\n(e.g. \"SRV*c:\\symcache\\*https://symbols.mozilla.org/\")\nIt can be in file $HOME/.dump_syms/config too.")
             .long("symbol-server")
-            .action(ArgAction::Set),
     )
     .arg(
         Arg::new("check_cfi")
@@ -71,7 +65,6 @@ fn cli() -> Command {
             .help("Set the level of verbosity (off, error (default), warn, info, debug, trace)")
             .long("verbose")
             .default_value("error")
-            .action(ArgAction::Set),
     )
     .arg(
         Arg::new("arch")
@@ -79,7 +72,6 @@ fn cli() -> Command {
             .short('a')
             .long("arch")
             .default_value(common::get_compile_time_arch())
-            .action(ArgAction::Set),
     )
     .arg(
         Arg::new("type")
@@ -87,7 +79,6 @@ fn cli() -> Command {
             .short('t')
             .long("type")
             .default_value("")
-            .action(ArgAction::Set),
     ).arg(
         Arg::new("list_arch")
             .help("List the architectures present in the fat binaries")
@@ -100,19 +91,18 @@ fn cli() -> Command {
             .short('j')
             .value_name("NUMBER")
             .default_value("")
-            .action(ArgAction::Set),
     )
     .arg(
         Arg::new("mapping_var")
             .help("A pair var=value such as rev=123abcd")
             .long("mapping-var")
-            .action(ArgAction::Append),
+            .action(ArgAction::Append)
     )
     .arg(
         Arg::new("mapping_src")
             .help("Regex to match a path with capturing groups")
             .long("mapping-src")
-            .action(ArgAction::Append),
+            .action(ArgAction::Append)
     )
     .arg(
         Arg::new("mapping_dest")
@@ -120,19 +110,18 @@ fn cli() -> Command {
 For example with --mapping-var="rev=123abc" --mapping-src="/foo/bar/(.*)" --mapping-dest="https://my.source.org/{rev}/{digest}/{1}" a path like "/foo/bar/myfile.cpp" will be transformed into "https://my.source.org/123abc/sha512_of_myfile.cpp/myfile.cpp"
 "#)
             .long("mapping-dest")
-            .action(ArgAction::Append),
+            .action(ArgAction::Append)
     )
     .arg(
         Arg::new("mapping_file")
             .help("A json file containing mapping")
             .long("mapping-file")
-            .action(ArgAction::Set),
     )
     .arg(
         Arg::new("inlines")
             .help("Whether to emit INLINE and INLINE_ORIGIN directives")
             .long("inlines")
-            .action(ArgAction::SetTrue),
+            .action(ArgAction::SetTrue)
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn cli() -> Command {
             .long("code-id")
     )
     .arg(
-        Arg::new("symbol-server")
+        Arg::new("symbol_server")
             .help("Symbol Server configuration\n(e.g. \"SRV*c:\\symcache\\*https://symbols.mozilla.org/\")\nIt can be in file $HOME/.dump_syms/config too.")
             .long("symbol-server")
     )
@@ -172,7 +172,7 @@ fn main() {
     let output = matches.get_one::<String>("output").map(String::as_str);
     let filenames = to_vec(matches.get_many::<String>("filenames").unwrap());
     let symbol_server = matches
-        .get_one::<String>("symbol-server")
+        .get_one::<String>("symbol_server")
         .map(String::as_str);
     let store = matches.get_one::<String>("store").map(String::as_str);
     let debug_id = matches.get_one::<String>("debug_id").map(String::as_str);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use clap::ArgAction;
-use clap::{crate_authors, crate_version, App, Arg};
+use clap::{crate_authors, crate_version, Arg, Command};
 use log::error;
 use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
 use std::ops::Deref;
@@ -16,147 +16,144 @@ use action::Action;
 use dump_syms::common;
 use dump_syms::dumper;
 
-fn cli() -> App<'static> {
-    App::new("dump_syms")
+fn cli() -> Command<'static> {
+    Command::new("dump_syms")
     .version(crate_version!())
     .author(crate_authors!("\n"))
     .about("Dump debug symbols to breakpad symbols")
     .arg(
-        Arg::with_name("filenames")
+        Arg::new("filenames")
             .help("Files to dump (.dll, .exe, .pdb, .pd_, .so, .dbg)")
             .required(true)
-            .multiple(true)
+            .multiple_values(true)
             .takes_value(true)
-            .action(ArgAction::StoreValue)
+            .action(ArgAction::Set)
     )
     .arg(
-        Arg::with_name("output")
+        Arg::new("output")
             .help("Output file or - for stdout")
             .short('o')
             .long("output")
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Set),
     )
     .arg(
-        Arg::with_name("store")
+        Arg::new("store")
             .help("Store output file as FILENAME.pdb/DEBUG_ID/FILENAME.sym in the given directory")
             .short('s')
             .long("store")
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Set),
     )
     .arg(
-        Arg::with_name("debug_id")
+        Arg::new("debug_id")
             .help("Get the pdb file passed as argument from the cache or from symbol server using the debug id")
             .long("debug-id")
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Set),
     )
     .arg(
-        Arg::with_name("code_id")
+        Arg::new("code_id")
             .help("Get the dll/exe file passed as argument from the cache or from symbol server using the code id")
             .long("code-id")
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Set),
     )
     .arg(
-        Arg::with_name("symbol-server")
+        Arg::new("symbol-server")
             .help("Symbol Server configuration\n(e.g. \"SRV*c:\\symcache\\*https://symbols.mozilla.org/\")\nIt can be in file $HOME/.dump_syms/config too.")
             .long("symbol-server")
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Set),
     )
     .arg(
-        Arg::with_name("check_cfi")
+        Arg::new("check_cfi")
             .help("Fail if there are no CFI data")
             .long("check-cfi")
-            .action(ArgAction::StoreValue)
+            .action(ArgAction::SetTrue)
     )
     .arg(
-        Arg::with_name("verbose")
+        Arg::new("verbose")
             .help("Set the level of verbosity (off, error (default), warn, info, debug, trace)")
             .long("verbose")
             .default_value("error")
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Set),
     )
     .arg(
-        Arg::with_name("arch")
+        Arg::new("arch")
             .help("Set the architecture to select in fat binaries")
             .short('a')
             .long("arch")
             .default_value(common::get_compile_time_arch())
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Set),
     )
     .arg(
-        Arg::with_name("type")
+        Arg::new("type")
             .help("Ignored, listed for compatibility only")
             .short('t')
             .long("type")
             .default_value("")
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Set),
     ).arg(
-        Arg::with_name("list_arch")
+        Arg::new("list_arch")
             .help("List the architectures present in the fat binaries")
             .long("list-arch")
-            .action(ArgAction::StoreValue)
+            .action(ArgAction::SetTrue)
     )
     .arg(
-        Arg::with_name("num_jobs")
+        Arg::new("num_jobs")
             .help("Number of jobs")
             .short('j')
             .value_name("NUMBER")
             .default_value("")
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Set),
     )
     .arg(
-        Arg::with_name("mapping_var")
+        Arg::new("mapping_var")
             .help("A pair var=value such as rev=123abcd")
             .long("mapping-var")
-            .multiple(true)
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Append),
     )
     .arg(
-        Arg::with_name("mapping_src")
+        Arg::new("mapping_src")
             .help("Regex to match a path with capturing groups")
             .long("mapping-src")
-            .multiple(true)
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Append),
     )
     .arg(
-        Arg::with_name("mapping_dest")
+        Arg::new("mapping_dest")
             .help(r#"A replacement string using groups, variables (set with --mapping-var), special variable like DIGEST or digest.
 For example with --mapping-var="rev=123abc" --mapping-src="/foo/bar/(.*)" --mapping-dest="https://my.source.org/{rev}/{digest}/{1}" a path like "/foo/bar/myfile.cpp" will be transformed into "https://my.source.org/123abc/sha512_of_myfile.cpp/myfile.cpp"
 "#)
             .long("mapping-dest")
-            .multiple(true)
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Append),
     )
     .arg(
-        Arg::with_name("mapping_file")
+        Arg::new("mapping_file")
             .help("A json file containing mapping")
             .long("mapping-file")
             .takes_value(true)
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::Set),
     )
     .arg(
-        Arg::with_name("inlines")
+        Arg::new("inlines")
             .help("Whether to emit INLINE and INLINE_ORIGIN directives")
             .long("inlines")
-            .action(ArgAction::StoreValue),
+            .action(ArgAction::SetTrue),
     )
 }
 
 fn main() {
     let matches = cli().get_matches();
 
-    let verbosity = match matches.value_of("verbose").unwrap() {
+    let verbosity = match matches.get_one::<String>("verbose").unwrap().as_str() {
         "off" => LevelFilter::Off,
         "warn" => LevelFilter::Warn,
         "info" => LevelFilter::Info,
@@ -197,32 +194,34 @@ fn main() {
         error!("A panic occurred at {}:{}: {}", filename, line, cause);
     }));
 
-    let output = matches.value_of("output");
-    let filenames: Vec<_> = matches.values_of("filenames").unwrap().collect();
-    let symbol_server = matches.value_of("symbol-server");
-    let store = matches.value_of("store");
-    let debug_id = matches.value_of("debug_id");
-    let code_id = matches.value_of("code_id");
-    let arch = matches.value_of("arch").unwrap();
-    let check_cfi = matches.is_present("check_cfi");
-    let emit_inlines = matches.is_present("inlines");
-    let mapping_var = matches
-        .values_of("mapping_var")
-        .map(|v| v.collect::<Vec<_>>());
-    let mapping_src = matches
-        .values_of("mapping_src")
-        .map(|v| v.collect::<Vec<_>>());
-    let mapping_dest = matches
-        .values_of("mapping_dest")
-        .map(|v| v.collect::<Vec<_>>());
-    let mapping_file = matches.value_of("mapping_file");
-    let num_jobs = if let Ok(num_jobs) = matches.value_of("num_jobs").unwrap().parse::<usize>() {
+    let output = matches.get_one::<String>("output").map(String::as_str);
+    let filenames = to_vec(matches.get_many::<String>("filenames").unwrap());
+    let symbol_server = matches
+        .get_one::<String>("symbol-server")
+        .map(String::as_str);
+    let store = matches.get_one::<String>("store").map(String::as_str);
+    let debug_id = matches.get_one::<String>("debug_id").map(String::as_str);
+    let code_id = matches.get_one::<String>("code_id").map(String::as_str);
+    let arch = matches.get_one::<String>("arch").unwrap().as_str();
+    let check_cfi = matches.get_flag("check_cfi");
+    let emit_inlines = matches.get_flag("inlines");
+    let mapping_var = matches.get_many("mapping_var").map(to_vec);
+    let mapping_src = matches.get_many("mapping_src").map(to_vec);
+    let mapping_dest = matches.get_many("mapping_dest").map(to_vec);
+    let mapping_file = matches
+        .get_one::<String>("mapping_file")
+        .map(String::as_str);
+    let num_jobs = if let Ok(num_jobs) = matches
+        .get_one::<String>("num_jobs")
+        .unwrap()
+        .parse::<usize>()
+    {
         num_jobs
     } else {
         num_cpus::get()
     };
 
-    let action = if matches.is_present("list_arch") {
+    let action = if matches.get_flag("list_arch") {
         Action::ListArch
     } else {
         let output = match (output, store) {
@@ -255,6 +254,10 @@ fn main() {
         eprintln!("{}", e);
         std::process::exit(1);
     }
+}
+
+fn to_vec(values: clap::parser::ValuesRef<String>) -> Vec<&str> {
+    values.map(String::as_str).collect()
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use action::Action;
 use dump_syms::common;
 use dump_syms::dumper;
 
-fn cli() -> Command<'static> {
+fn cli() -> Command {
     Command::new("dump_syms")
     .version(crate_version!())
     .author(crate_authors!("\n"))
@@ -25,8 +25,7 @@ fn cli() -> Command<'static> {
         Arg::new("filenames")
             .help("Files to dump (.dll, .exe, .pdb, .pd_, .so, .dbg)")
             .required(true)
-            .multiple_values(true)
-            .takes_value(true)
+            .num_args(1..)
             .action(ArgAction::Set)
     )
     .arg(
@@ -34,7 +33,6 @@ fn cli() -> Command<'static> {
             .help("Output file or - for stdout")
             .short('o')
             .long("output")
-            .takes_value(true)
             .action(ArgAction::Set),
     )
     .arg(
@@ -42,28 +40,24 @@ fn cli() -> Command<'static> {
             .help("Store output file as FILENAME.pdb/DEBUG_ID/FILENAME.sym in the given directory")
             .short('s')
             .long("store")
-            .takes_value(true)
             .action(ArgAction::Set),
     )
     .arg(
         Arg::new("debug_id")
             .help("Get the pdb file passed as argument from the cache or from symbol server using the debug id")
             .long("debug-id")
-            .takes_value(true)
             .action(ArgAction::Set),
     )
     .arg(
         Arg::new("code_id")
             .help("Get the dll/exe file passed as argument from the cache or from symbol server using the code id")
             .long("code-id")
-            .takes_value(true)
             .action(ArgAction::Set),
     )
     .arg(
         Arg::new("symbol-server")
             .help("Symbol Server configuration\n(e.g. \"SRV*c:\\symcache\\*https://symbols.mozilla.org/\")\nIt can be in file $HOME/.dump_syms/config too.")
             .long("symbol-server")
-            .takes_value(true)
             .action(ArgAction::Set),
     )
     .arg(
@@ -77,7 +71,6 @@ fn cli() -> Command<'static> {
             .help("Set the level of verbosity (off, error (default), warn, info, debug, trace)")
             .long("verbose")
             .default_value("error")
-            .takes_value(true)
             .action(ArgAction::Set),
     )
     .arg(
@@ -86,7 +79,6 @@ fn cli() -> Command<'static> {
             .short('a')
             .long("arch")
             .default_value(common::get_compile_time_arch())
-            .takes_value(true)
             .action(ArgAction::Set),
     )
     .arg(
@@ -95,7 +87,6 @@ fn cli() -> Command<'static> {
             .short('t')
             .long("type")
             .default_value("")
-            .takes_value(true)
             .action(ArgAction::Set),
     ).arg(
         Arg::new("list_arch")
@@ -109,21 +100,18 @@ fn cli() -> Command<'static> {
             .short('j')
             .value_name("NUMBER")
             .default_value("")
-            .takes_value(true)
             .action(ArgAction::Set),
     )
     .arg(
         Arg::new("mapping_var")
             .help("A pair var=value such as rev=123abcd")
             .long("mapping-var")
-            .takes_value(true)
             .action(ArgAction::Append),
     )
     .arg(
         Arg::new("mapping_src")
             .help("Regex to match a path with capturing groups")
             .long("mapping-src")
-            .takes_value(true)
             .action(ArgAction::Append),
     )
     .arg(
@@ -132,14 +120,12 @@ fn cli() -> Command<'static> {
 For example with --mapping-var="rev=123abc" --mapping-src="/foo/bar/(.*)" --mapping-dest="https://my.source.org/{rev}/{digest}/{1}" a path like "/foo/bar/myfile.cpp" will be transformed into "https://my.source.org/123abc/sha512_of_myfile.cpp/myfile.cpp"
 "#)
             .long("mapping-dest")
-            .takes_value(true)
             .action(ArgAction::Append),
     )
     .arg(
         Arg::new("mapping_file")
             .help("A json file containing mapping")
             .long("mapping-file")
-            .takes_value(true)
             .action(ArgAction::Set),
     )
     .arg(


### PR DESCRIPTION
This updates clap to version 4.

I followed [this migration guide](https://github.com/clap-rs/clap/blob/3262016c26587e97c18187dffc60978a3b1547ae/CHANGELOG.md#migrating).