### PR TITLE
Remove hashbrown dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ crossbeam = "0.8.2"
 dirs = "4.0"
 futures = { version = "0.3", optional = true }
 goblin = "0.6" # Keep in sync with symbolic-debuginfo
-hashbrown = { version = "0.12", features = ["serde"] }
 log = "0.4"
 lzma-rs = "0.2.0"
 num_cpus = "1.13"

--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -4,8 +4,8 @@
 // copied, modified, or distributed except according to those terms.
 
 use crossbeam::channel::{bounded, Receiver, Sender};
-use hashbrown::HashMap;
 use log::{error, info};
+use std::collections::HashMap;
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -3,11 +3,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use hashbrown::{HashMap, HashSet};
 use log::warn;
 use regex::Regex;
 use serde::Deserialize;
 use sha2::{Digest, Sha512};
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Mutex;
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -3,8 +3,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use hashbrown::{hash_map, HashMap};
 use log::error;
+use std::collections::{hash_map, HashMap};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;


### PR DESCRIPTION
The std HashMap uses hashbrown these days, so I think this won't make anything slower. But I haven't tested it.