### PR TITLE
Never emit symbols that are entirely made of whitespace

### DIFF
--- a/src/object_info.rs
+++ b/src/object_info.rs
@@ -65,7 +65,7 @@ impl Display for ObjectInfo {
         }
 
         for (n, function_name) in self.inline_origins.iter().enumerate() {
-            let function_name = if function_name.is_empty() {
+            let function_name = if function_name.trim().is_empty() {
                 "<name omitted>"
             } else {
                 function_name


### PR DESCRIPTION
This fixes #543