### PR TITLE
Add more sensible way for constructing dumper::Config

### DIFF
--- a/src/dumper.rs
+++ b/src/dumper.rs
@@ -89,6 +89,30 @@ pub struct Config<'a> {
     pub mapping_file: Option<&'a str>,
 }
 
+impl Config<'_> {
+    /// Create a [`Config`] using the given [`Output`], with all other
+    /// fields set to reasonable defaults.
+    ///
+    /// The architecture will be set to the architecture for which
+    /// compilation is happening, the number of jobs will be set to one.
+    pub fn with_output(output: Output) -> Self {
+        Self {
+            output,
+            symbol_server: None,
+            debug_id: None,
+            code_id: None,
+            arch: common::get_compile_time_arch(),
+            num_jobs: 1,
+            check_cfi: true,
+            emit_inlines: true,
+            mapping_var: None,
+            mapping_src: None,
+            mapping_dest: None,
+            mapping_file: None,
+        }
+    }
+}
+
 fn get_pdb_object_info(
     buf: &[u8],
     path: &Path,


### PR DESCRIPTION
It is rather cumbersome to create a dumper::Config object, owing to the many fields that conceptually have sensible defaults but have to be named explicitly nevertheless.
This change introduces a new constructor that instantiates an instance given only an Output object as input -- all other fields are set to sensible defaults. This is also a good first step towards making the type less prone to semver violations caused by additions, because it more easily enables making it non-exhaustive (which really should be done, but isn't as part of this change, because it would be a semver breaking change in and of itself).