### PR TITLE
Fix tokio feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 simplelog = { version = "0.12", optional = true, features = ["local-offset"] }
 symbolic = { version = "12", features = ["demangle", "cfi"] }
-tokio = { version = "1.23", optional = true }
+tokio = { version = "1.23", optional = true, features = ["rt-multi-thread"] }
 url = "2.2"
 uuid = "1"
 
@@ -69,6 +69,11 @@ ci = ["github"]
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+]
 # Publish jobs to run in CI
 pr-run-mode = "upload"


### PR DESCRIPTION
As stated in #677, a crate in the dependency graph was previously toggling on the multi-threaded feature, but the most recent version does not, which breaks compilation under `cargo install` unless the additional `--locked` argument is set.

Resolves: #677